### PR TITLE
Add adjusted KLM Open strokes

### DIFF
--- a/outputs/Adjusted KLM Open DG Thursday Strokes 20250604.csv
+++ b/outputs/Adjusted KLM Open DG Thursday Strokes 20250604.csv
@@ -1,0 +1,157 @@
+PLAYER NAME,BASELINE STROKES,ADJUSTED STROKES
+"Ahlawat, Veer",72.0,72.0
+"Aiken, Thomas",71.694,71.694
+"Akesson, Bjorn",72.51,72.51
+"Amat, Bastien",72.754,72.754
+"Armitage, Marcus",71.088,70.999
+"Ayora, Angel",70.745,70.809
+"Bairstow, Sam",70.52,70.523
+"Baldwin, Matthew",71.998,71.998
+"Bekirian, Jean",72.683,72.683
+"Besseling, Wil",71.903,71.903
+"Bjerregaard, Lucas",72.371,72.371
+"Boneta, Albert",71.935,71.935
+"Bradbury, Dan",71.473,71.473
+"Brown, Daniel",71.178,71.214
+"Brown, Hamish",72.149,72.149
+"Brun, Julien",72.607,72.607
+"Bryant, Davis",71.691,71.691
+"Cabrera Bello, Rafa",71.984,71.984
+"Campillo, Jorge",71.053,71.042
+"Canter, Laurie",70.437,70.435
+"Cantero Gutierrez, Ivan",71.545,71.545
+"Catlin, John",70.976,70.996
+"Chacarra, Eugenio",70.426,70.511
+"Clements, Todd",70.968,71.063
+"Cockerill, Aaron",71.18,71.18
+"Colsaerts, Nicolas",71.899,71.899
+"Coussaud, Ugo",71.0,71.036
+"Crocker, Sean",70.9,70.965
+"Dantorp, Jens",71.656,71.656
+"De Bruyn, Jannik",72.085,72.085
+"De Leo, Gregorio",71.72,71.72
+"De Vries, Wouter",73.22,73.22
+"Dean, Joe",71.136,71.238
+"Del Rey, Alejandro",71.188,71.158
+"Ding, Wenyi",70.627,70.578
+"Donaldson, Jamie",72.883,72.883
+"Driessen, Bjorn",74.751,74.751
+"Elvira Mijares, Ignacio",71.408,71.408
+"Elvira, Manuel",71.548,71.548
+"Erickson, Dan",72.135,72.135
+"Fdez-Castano, Gonzalo",73.689,73.689
+"Ferguson, Ewen",70.286,70.351
+"Fisher, Ross",72.378,72.378
+"Fitzpatrick, Alex",70.857,70.879
+"Follet-Smith, Benjamin",72.753,72.753
+"Forrest, Grant",71.454,71.387
+"Forsstrom, Simon",71.627,71.627
+"Frances, Alexander George",72.63,72.63
+"Frittelli, Dylan",71.459,71.44
+"Gale, Daniel",72.228,72.228
+"Garcia-Heredia, Alfredo",72.283,72.283
+"Germishuys, Deon",72.037,72.037
+"Girrbach, Joel",71.895,71.895
+"Gouveia, Ricardo",71.489,71.489
+"Green, Gavin",71.587,71.581
+"Guerrier, Julien",70.807,70.765
+"Gumberg, Jordan",71.722,71.722
+"Halvorsen, Andreas",71.471,71.471
+"Harding, Justin",72.544,72.544
+"Hebert, Benjamin",71.68,71.68
+"Hidalgo, Angel",71.537,71.537
+"Hill, Calum",71.203,71.249
+"Hillier, Daniel",70.761,70.807
+"Huizing, Daan",72.283,72.283
+"Jamieson, Scott",71.134,71.104
+"Jarvis, Casey",71.202,71.202
+"Jin, Zihao",72.241,72.241
+"Johnston, Ryggs",71.916,71.916
+"Katsuragawa, Yuto",71.153,71.147
+"Kieffer, Maximilian",71.245,71.245
+"Kim, Minkyu",71.824,71.824
+"Kimsey, Nathan",71.136,71.125
+"Kinhult, Marcus",71.122,71.131
+"Kleen, Algot",72.029,72.029
+"Knappe, Alexander",72.9,72.9
+"Ko, Jeong Weon",72.19,72.19
+"Kobori, Kazuma",71.137,71.084
+"Kouwenaar, Koen",75.022,75.022
+"Lafeber, Guus",74.777,74.777
+"Lagergren, Joakim",71.848,71.848
+"Laporta, Francesco",70.445,70.358
+"Larrazabal, Pablo",71.346,71.408
+"Lawrence, Thriston",71.06,71.088
+"Lemke, Niklas",71.175,71.239
+"Li, Haotong",70.182,70.227
+"Lindberg, Mikael",72.147,72.147
+"Lindell, Oliver",70.913,70.965
+"List, Danny",72.63,72.63
+"Lombard, Zander",72.514,72.514
+"Luiten, Joost",70.056,70.059
+"Mansell, Richard",70.716,70.755
+"Merritt, Troy",71.23,71.217
+"Micheluzzi, David",71.726,71.679
+"Migliozzi, Guido",70.951,70.93
+"Molinari, Francesco",71.333,71.376
+"Moscatel, Joel",72.092,72.092
+"Naidoo, Dylan",72.253,72.253
+"Nakajima, Keita",70.181,70.166
+"Neergaard-Petersen, Rasmus",69.779,69.738
+"Nienaber, Wilco",71.454,71.473
+"Olesen, Jacob Skov",71.089,71.02
+"Otaegui, Adrian",71.033,70.999
+"Parry, John",70.717,70.772
+"Paul, Yannik",71.274,71.247
+"Pavan, Andrea",70.647,70.647
+"Pineau, Pierre",72.653,72.653
+"Porsius, Davey",74.118,74.118
+"Pulkkanen, Tapio",71.889,71.889
+"Purcell, Conor",71.445,71.445
+"Ramsay, Richie",71.447,71.447
+"Ravetto, David",71.269,71.357
+"Reitan, Kristoffer",70.529,70.433
+"Reuter, Benjamin",73.533,73.533
+"Robinson-Thompson, Brandon",71.021,71.053
+"Ruiter, Nevill",74.312,74.312
+"Schaper, Jayden",70.461,70.414
+"Schmidt, Ben",71.348,71.348
+"Schneider, Marcel",70.569,70.596
+"Schott, Freddy",71.639,71.639
+"Schwab, Matthias",72.911,72.911
+"Scrivener, Jason",71.205,71.074
+"Senior, Jack",71.757,71.757
+"Sharma, Shubhankar",71.669,71.669
+"Shaun, Corey",72.376,72.376
+"Shinkwin, Callum",71.299,71.299
+"Siem, Marcel",71.129,71.143
+"Soderberg, Sebastian",70.852,70.793
+"Sordet, Clement",71.877,71.877
+"Southgate, Matthew",71.253,71.253
+"Sterne, Richard",72.35,72.35
+"Stone, Brandon",70.466,70.408
+"Strydom, Ockie",73.068,73.068
+"Sullivan, Andy",70.837,70.834
+"Syme, Connor",71.51,71.51
+"Tarren, Callum",71.562,71.542
+"Tetak, TadeÃ¡Å¡",72.43,72.43
+"Trainer, Martin",73.788,73.788
+"Vaillant, Tom",71.156,71.143
+"Van Der Vight, Lars",72.525,72.525
+"Van Driel, Darius",71.259,71.253
+"Van Meijel, Lars",71.995,71.995
+"Van Veen, Vince",72.736,72.736
+"Van Velzen, Ryan",72.083,72.083
+"Veerman, Johannes",70.857,70.836
+"Verdonk, Aydan",74.925,74.925
+"Von Dellingshausen, Nicolai",71.125,71.089
+"Walker, Jimmy",72.674,72.674
+"Whitnell, Dale",72.27,72.27
+"Wiesberger, Bernd",71.151,71.119
+"Williams, Robin",71.427,71.427
+"Wilson, Andrew",71.549,71.616
+"Winther, Jeff",71.286,71.122
+"Woltering, Scott",74.147,74.147
+"Wood, Chris",72.72,72.72
+"Wu, Brandon",71.406,71.408
+"Zanotti, Fabrizio",70.864,70.918

--- a/scripts/adjust_projections.py
+++ b/scripts/adjust_projections.py
@@ -51,27 +51,37 @@ def phi_inv(p):
 def load_strokes(path, use_adjusted=True, course=None):
     """Load strokes from a CSV. Optionally filter by course name."""
     data = {}
-    with open(path) as f:
+    with open(path, encoding="utf-8-sig") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            if course and row.get('COURSE NAME') and course not in row['COURSE NAME']:
+            # normalize header names for easier matching
+            row = {k.strip().upper().replace("_", " "): v for k, v in row.items()}
+
+            if course and row.get("COURSE NAME") and course not in row["COURSE NAME"]:
                 continue
-            if use_adjusted and 'ADJUSTED STROKES' in row:
-                val = row['ADJUSTED STROKES']
-            elif 'BASELINE STROKES' in row:
-                val = row['BASELINE STROKES']
+
+            if use_adjusted and "ADJUSTED STROKES" in row:
+                val = row["ADJUSTED STROKES"]
+            elif "BASELINE STROKES" in row:
+                val = row["BASELINE STROKES"]
             else:
-                val = row.get('STROKES PREDICTION')
-            if val is None or val == '':
+                val = row.get("STROKES PREDICTION")
+
+            if val is None or val == "":
                 continue
-            data[row['PLAYER NAME'].strip()] = float(val)
+
+            name = row.get("PLAYER NAME")
+            if not name:
+                continue
+            data[name.strip()] = float(val)
     return data
 
 def parse_matchups(path, strokes):
     pairs = []
-    with open(path) as f:
+    with open(path, encoding="utf-8-sig") as f:
         reader = csv.DictReader(f)
         for row in reader:
+            row = {k.strip().lower(): v for k, v in row.items()}
             p1 = row['name_p1'].strip()
             p2 = row['name_p2'].strip()
             probs = []


### PR DESCRIPTION
## Summary
- make adjust_projections more resilient to header formats
- compute adjusted DG Thursday strokes for the 2025 KLM Open

## Testing
- `python3 -m py_compile scripts/adjust_projections.py scripts/fair_odds.py scripts/scrape_live_scores.py`
- `python3 scripts/adjust_projections.py --strokes 'data/raw/KLM Open DG Thursday Strokes 20250604.csv' --matchups 'data/raw/KLM Open 72 Hole Matchups 20250604.csv' --matchups 'data/raw/KLM Open r1 Matchups 20250604.csv' --output 'outputs/Adjusted KLM Open DG Thursday Strokes 20250604.csv'`

------
https://chatgpt.com/codex/tasks/task_e_68409d81eedc832abda93b533bae5e91