### PR TITLE
Add DK scoring projection for KLM Open

### DIFF
--- a/outputs/dk_projection_klm.csv
+++ b/outputs/dk_projection_klm.csv
@@ -1,0 +1,156 @@
+player,expected_points
+Rasmus Neergaard-Petersen,76.4
+Joost Luiten,70.96
+Keita Nakajima,69.53
+Haotong Li,68.52
+Ewen Ferguson,66.22
+Francesco Laporta,66.02
+Laurie Canter,65.21
+Brandon Stone,65.19
+Jayden Schaper,65.07
+Kristoffer Reitan,65.04
+Eugenio Chacarra,64.51
+Sam Bairstow,63.69
+Wenyi Ding,62.69
+Marcel Schneider,62.62
+Andrea Pavan,61.25
+Richard Mansell,60.18
+Angel Ayora,60.06
+Julien Guerrier,59.97
+Daniel Hillier,59.86
+John Parry,59.71
+Johannes Veerman,59.7
+Sebastian Soderberg,59.43
+Andy Sullivan,58.91
+Alex Fitzpatrick,58.02
+Guido Migliozzi,57.52
+Fabrizio Zanotti,57.47
+Sean Crocker,56.98
+John Catlin,56.55
+Marcus Armitage,56.51
+Adrian Otaegui,56.5
+Oliver Lindell,56.4
+Jacob Skov Olesen,56.2
+Jorge Campillo,56.19
+Thriston Lawrence,55.93
+Ugo Coussaud,55.87
+Brandon Robinson-Thompson,55.85
+Nicolai Von Dellingshausen,55.81
+Todd Clements,55.52
+Jason Scrivener,55.29
+Marcel Siem,55.12
+Kazuma Kobori,55.06
+Scott Jamieson,54.9
+Marcus Kinhult,54.9
+Nathan Kimsey,54.79
+Jeff Winther,54.72
+Bernd Wiesberger,54.69
+Tom Vaillant,54.45
+Alejandro Del Rey,54.43
+Aaron Cockerill,54.39
+Yuto Katsuragawa,54.39
+Daniel Brown,53.93
+Niklas Lemke,53.81
+Casey Jarvis,53.7
+Troy Merritt,53.68
+Joe Dean,53.44
+Darius Van Driel,53.35
+Maximilian Kieffer,53.15
+Matthew Southgate,53.04
+Calum Hill,52.97
+Yannik Paul,52.97
+Ben Schmidt,52.31
+Callum Shinkwin,52.23
+Francesco Molinari,51.76
+David Ravetto,51.39
+Conor Purcell,51.15
+Grant Forrest,51.07
+Pablo Larrazabal,51.05
+Dylan Frittelli,50.68
+Brandon Wu,50.59
+Robin Williams,50.53
+Ignacio Elvira Mijares,50.39
+Richie Ramsay,50.3
+Wilco Nienaber,50.13
+Andreas Halvorsen,50.11
+Dan Bradbury,50.0
+Ricardo Gouveia,49.79
+Connor Syme,49.54
+Manuel Elvira,49.31
+Angel Hidalgo,49.07
+Ivan Cantero Gutierrez,48.99
+Callum Tarren,48.99
+Gavin Green,48.34
+Andrew Wilson,48.18
+Simon Forsstrom,48.04
+Freddy Schott,47.92
+Jens Dantorp,47.91
+Davis Bryant,47.88
+Benjamin Hebert,47.75
+David Micheluzzi,47.6
+Thomas Aiken,47.31
+Shubhankar Sharma,47.3
+Jordan Gumberg,47.02
+Gregorio De Leo,46.86
+Jack Senior,46.37
+Clement Sordet,45.49
+Minkyu Kim,45.25
+Joakim Lagergren,45.09
+Tapio Pulkkanen,44.94
+Wil Besseling,44.85
+Joel Girrbach,44.83
+Nicolas Colsaerts,44.68
+Ryggs Johnston,44.65
+Algot Kleen,44.08
+Albert Boneta,43.97
+Veer Ahlawat,43.62
+Matthew Baldwin,43.6
+Lars Van Meijel,43.52
+Rafa Cabrera Bello,43.49
+Deon Germishuys,42.9
+Joel Moscatel,42.47
+Jannik De Bruyn,42.46
+Ryan Van Velzen,42.34
+Hamish Brown,42.18
+Mikael Lindberg,41.95
+Dan Erickson,41.8
+Jeong Weon Ko,41.45
+Daniel Gale,40.95
+Zihao Jin,40.91
+Dylan Naidoo,40.73
+Dale Whitnell,40.72
+Daan Huizing,40.39
+Alfredo Garcia-Heredia,40.32
+Corey Shaun,39.7
+Richard Sterne,39.66
+Ross Fisher,39.63
+Lucas Bjerregaard,39.44
+Zander Lombard,38.53
+Bjorn Akesson,38.2
+Lars Van Der Vight,38.14
+Justin Harding,37.56
+Pierre Pineau,37.17
+Jimmy Walker,37.17
+Danny List,37.02
+Alexander George Frances,37.0
+Julien Brun,36.77
+Jean Bekirian,36.55
+Chris Wood,36.41
+Bastien Amat,36.37
+Vince Van Veen,36.07
+Benjamin Follet-Smith,35.92
+Alexander Knappe,34.73
+Jamie Donaldson,34.58
+Matthias Schwab,34.41
+Ockie Strydom,33.08
+Wouter De Vries,32.3
+Benjamin Reuter,29.76
+Gonzalo Fdez-Castano,28.7
+Martin Trainer,27.78
+Davey Porsius,26.11
+Scott Woltering,25.72
+Nevill Ruiter,24.91
+Bjorn Driessen,22.69
+Guus Lafeber,22.63
+Aydan Verdonk,22.01
+Koen Kouwenaar,21.54

--- a/scripts/project_dk_scoring.py
+++ b/scripts/project_dk_scoring.py
@@ -1,0 +1,114 @@
+import csv
+import argparse
+
+# DraftKings scoring constants
+DK_HOLE_POINTS = {
+    'eagle_or_better': 8,  # treat double eagle the same as eagle for expectation
+    'birdie': 3,
+    'par': 0.5,
+    'bogey': -0.5,
+    'double_or_worse': -1,
+}
+
+# Average finish points for groups (approximate)
+FINISH_PTS = {
+    'win': 30,
+    '2_5': 17,   # average of positions 2-5
+    '6_10': 9.2, # average of positions 6-10
+    '11_20': 5.5, # average of positions 11-20
+}
+
+
+def normalize_name(name: str) -> str:
+    name = name.strip().replace('"', '')
+    if ',' in name:
+        last, first = [n.strip() for n in name.split(',', 1)]
+        return f"{first} {last}".title()
+    return name.title()
+
+def load_hole_points(path):
+    totals = {}
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            player = normalize_name(row['player'])
+            e = float(row['p_eagle_or_better'])
+            b = float(row['p_birdie'])
+            p = float(row['p_par'])
+            bo = float(row['p_bogey'])
+            d = float(row['p_double_or_worse'])
+            pts = (
+                e * DK_HOLE_POINTS['eagle_or_better'] +
+                b * DK_HOLE_POINTS['birdie'] +
+                p * DK_HOLE_POINTS['par'] +
+                bo * DK_HOLE_POINTS['bogey'] +
+                d * DK_HOLE_POINTS['double_or_worse']
+            )
+            totals[player] = totals.get(player, 0.0) + pts
+    return totals
+
+def load_sim(path):
+    data = {}
+    with open(path, newline='', encoding='utf-8-sig') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = normalize_name(row['player_name'])
+            data[name] = {
+                'make_cut': float(row['make_cut']),
+                'top_20': float(row['top_20']),
+                'top_10': float(row['top_10']),
+                'top_5': float(row['top_5']),
+                'win': float(row['win']),
+            }
+    return data
+
+
+def expected_finish_pts(info):
+    win = info['win']
+    top5 = info['top_5']
+    top10 = info['top_10']
+    top20 = info['top_20']
+
+    pts = 0.0
+    pts += FINISH_PTS['win'] * win
+    pts += FINISH_PTS['2_5'] * max(0.0, top5 - win)
+    pts += FINISH_PTS['6_10'] * max(0.0, top10 - top5)
+    pts += FINISH_PTS['11_20'] * max(0.0, top20 - top10)
+    return pts
+
+
+def project_dk(hole_points, sim_data):
+    results = []
+    for player, r1_pts in hole_points.items():
+        sim = sim_data.get(player)
+        if not sim:
+            continue
+        rounds = 2 + 2 * sim['make_cut']
+        finish = expected_finish_pts(sim)
+        total = r1_pts * rounds + finish
+        results.append({
+            'player': player,
+            'expected_points': round(total, 2),
+        })
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Project DraftKings scoring.')
+    parser.add_argument('--hole_probs', required=True, help='CSV with per-hole probabilities')
+    parser.add_argument('--simulation', required=True, help='CSV with simulation probabilities')
+    parser.add_argument('--output', required=True, help='Output CSV')
+    args = parser.parse_args()
+
+    hole_points = load_hole_points(args.hole_probs)
+    sim_data = load_sim(args.simulation)
+    results = project_dk(hole_points, sim_data)
+
+    with open(args.output, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['player', 'expected_points'])
+        writer.writeheader()
+        for row in sorted(results, key=lambda x: -x['expected_points']):
+            writer.writerow(row)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `project_dk_scoring.py` to estimate DraftKings fantasy points
- normalize player names between data sources
- generate DK point projections for the KLM Open

## Testing
- `python3 scripts/project_dk_scoring.py --hole_probs outputs/hole_probabilities.csv --simulation data/raw/KLM\ Open\ Simulation.csv --output outputs/dk_projection_klm.csv`

------
https://chatgpt.com/codex/tasks/task_e_6840a872049c832aa6edb1bb7a9357db