### PR TITLE
Add LIV support for stroke adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ python3 scripts/adjust_projections.py \
   --output "Adjusted Strokes Canadian Open 20250604.csv"
 ```
 
+For a LIV event (54 holes), include `--holes 54` and supply the LIV matchup files:
+
+```bash
+python3 scripts/adjust_projections.py \
+  --strokes "LIV Golf DG Thursday Strokes 20250605.csv" \
+  --matchups "LIV Virginia 54 Hole Matchup Odds 20250605.csv" \
+  --matchups "LIV VIrginia r1 matchup Odds 20250605.csv" \
+  --holes 54 \
+  --output "Adjusted Strokes LIV Virginia 20250605.csv"
+```
+
 The resulting CSV lists each player with the original and adjusted stroke projection.
 
 

--- a/outputs/Adjusted LIV Virginia DG Thursday Strokes 20250605.csv
+++ b/outputs/Adjusted LIV Virginia DG Thursday Strokes 20250605.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,BASELINE STROKES,ADJUSTED STROKES
+"Ancer, Abraham",70.704,70.668
+"Ballester Barrio, Jose Luis",71.339,71.339
+"Bland, Richard",70.731,70.848
+"Burmester, Dean",70.335,70.365
+"Campbell, Ben",71.777,71.777
+"Casey, Paul",70.698,70.691
+"DeChambeau, Bryson",68.329,68.113
+"Garcia, Sergio",70.376,70.275
+"Gooch, Talor",70.6,70.663
+"Grace, Branden",71.392,71.589
+"Hatton, Tyrrell",69.512,69.771
+"Herbert, Lucas",69.721,69.714
+"Horsfield, Sam",71.293,71.252
+"Howell III, Charles",70.875,70.762
+"Jang, Yubin",72.082,72.082
+"Johnson, Dustin",70.885,70.934
+"Jones, Matt",71.589,71.747
+"Kaymer, Martin",72.225,72.249
+"Kim, Anthony",73.684,73.684
+"Kjettrup, Frederik",72.951,72.951
+"Koepka, Brooks",70.398,70.412
+"Kokrak, Jason",71.226,70.841
+"Kozuma, Jinichiro",71.188,70.912
+"Lahiri, Anirban",71.068,71.101
+"Lee, Chieh-Po",71.756,71.756
+"Lee, Danny",72.623,73.067
+"Leishman, Marc",70.74,70.642
+"Masaveu, Luis",71.786,72.062
+"McDowell, Graeme",71.767,71.729
+"McKibbin, Tom",70.336,70.298
+"Meronk, Adrian",71.455,71.745
+"Mickelson, Phil",71.692,71.952
+"Munoz, Sebastian",70.042,70.001
+"Na, Kevin",71.381,71.066
+"Niemann, Joaquin",69.056,69.015
+"Ogletree, Andy",72.022,71.887
+"Oosthuizen, Louis",70.682,70.601
+"Ortiz, Carlos",69.998,70.003
+"Pereira, Mito",72.212,72.212
+"Pieters, Thomas",70.625,70.711
+"Poulter, Ian",71.842,72.03
+"Rahm, Jon",68.593,68.592
+"Reed, Patrick",69.956,69.906
+"Schwartzel, Charl",70.654,70.766
+"Smith, Cameron",70.315,70.371
+"Steele, Brendan",71.19,70.931
+"Stenson, Henrik",71.642,71.454
+"Surratt, Caleb",71.196,71.105
+"Tringale, Cameron",70.514,70.47
+"Uihlein, Peter",71.045,71.047
+"Varner III, Harold",70.954,70.962
+"Watson, Bubba",70.904,71.006
+"Westwood, Lee",72.307,72.283
+"Wolff, Matthew",71.402,71.361

--- a/scripts/adjust_projections.py
+++ b/scripts/adjust_projections.py
@@ -64,8 +64,10 @@ def load_strokes(path, use_adjusted=True, course=None):
                 val = row["ADJUSTED STROKES"]
             elif "BASELINE STROKES" in row:
                 val = row["BASELINE STROKES"]
-            else:
+            elif "STROKES PREDICTION" in row:
                 val = row.get("STROKES PREDICTION")
+            else:
+                val = row.get("STROKES")
 
             if val is None or val == "":
                 continue
@@ -76,7 +78,9 @@ def load_strokes(path, use_adjusted=True, course=None):
             data[name.strip()] = float(val)
     return data
 
-def parse_matchups(path, strokes):
+import math
+
+def parse_matchups(path, strokes, holes=72):
     pairs = []
     with open(path, encoding="utf-8-sig") as f:
         reader = csv.DictReader(f)
@@ -111,9 +115,11 @@ def parse_matchups(path, strokes):
             m = row.get('market', '').lower()
             if any(r in m for r in ('r1', 'r2', 'r3', 'r4')) or 'round' in m:
                 sigma_round = 2.5  # see pga_dispersion_model.md
-                sigma_diff = (2 ** 0.5) * sigma_round
+                sigma_diff = math.sqrt(2) * sigma_round
             else:
-                sigma_diff = 6.0
+                n_rounds = holes // 18
+                sigma_round = 2.5
+                sigma_diff = math.sqrt(n_rounds * 2) * sigma_round
             implied_diff = -sigma_diff * phi_inv(prob_p1)
             dg_diff = strokes[p1] - strokes[p2]
             pairs.append((p1,p2,dg_diff,implied_diff))
@@ -150,6 +156,8 @@ if __name__ == '__main__':
                         help='Output CSV path')
     parser.add_argument('--course', default=None,
                         help='If provided, filter strokes to rows containing this course name')
+    parser.add_argument('--holes', type=int, default=72,
+                        help='Number of holes for tournament matchups (default 72)')
     args = parser.parse_args()
 
     if not args.matchups:
@@ -159,7 +167,7 @@ if __name__ == '__main__':
     strokes = load_strokes(args.strokes, use_adjusted=True, course=args.course)
     pairs = []
     for mp in args.matchups:
-        pairs.extend(parse_matchups(mp, strokes))
+        pairs.extend(parse_matchups(mp, strokes, holes=args.holes))
     final = adjust_strokes(strokes, pairs)
 
     with open(args.output, 'w', newline='') as f:


### PR DESCRIPTION
## Summary
- update adjust_projections.py to work with 54-hole LIV events
- load generic `STROKES` column if no `STROKES PREDICTION`
- expose `--holes` option and compute variance per number of holes
- document usage for LIV tournaments
- generate adjusted LIV Virginia Thursday strokes output

## Testing
- `python3 scripts/adjust_projections.py --strokes 'data/raw/LIV Golf DG Thursday Strokes 20250605.csv' --matchups 'data/raw/LIV Virginia 54 Hole Matchup Odds 20250605.csv' --matchups 'data/raw/LIV VIrginia r1 matchup Odds 20250605.csv' --holes 54 --output 'outputs/Adjusted LIV Virginia DG Thursday Strokes 20250605.csv'`

------
https://chatgpt.com/codex/tasks/task_e_6841bca0b8fc832abbe150adca0110e4