### PR TITLE
Compute positive EV bets for LIV Virginia

### DIFF
--- a/outputs/liv_virginia_positive_ev.csv
+++ b/outputs/liv_virginia_positive_ev.csv
@@ -1,0 +1,24 @@
+market,player,book,odds,ev
+win,"Na, Kevin",fanduel,+21000,0.688
+top_5,"Steele, Brendan",bovada,+2200,0.679
+top_5,"Na, Kevin",bet365,+2600,0.647
+win,"Steele, Brendan",caesars,+15000,0.51
+top_5,"Stenson, Henrik",bet365,+3700,0.406
+top_10,"Na, Kevin",bet365,+825,0.3782
+win,"Kozuma, Jinichiro",caesars,+15000,0.359
+top_10,"Steele, Brendan",bovada,+700,0.344
+top_10,"Stenson, Henrik",bet365,+1100,0.212
+top_5,"Kozuma, Jinichiro",bet365,+1600,0.207
+win,"Stenson, Henrik",bet365,+30000,0.204
+win,"DeChambeau, Bryson",bet365,+450,0.199
+top_5,"Kokrak, Jason",draftkings,+1400,0.185
+top_10,"Kokrak, Jason",betonline,+550,0.17
+top_10,"Kozuma, Jinichiro",draftkings,+600,0.169
+top_5,"Kaymer, Martin",betway,+8000,0.134
+win,"Kokrak, Jason",draftkings,+10000,0.111
+win,"Herbert, Lucas",betcris,+2241,0.1003
+top_5,"DeChambeau, Bryson",unibet,+100,0.1
+top_10,"Howell III, Charles",draftkings,+450,0.078
+top_20,"Na, Kevin",bet365,+210,0.0757
+win,"Howell III, Charles",pinnacle,+8135,0.0705
+top_5,"Howell III, Charles",draftkings,+1100,0.068

--- a/scripts/compute_liv_virginia_ev.py
+++ b/scripts/compute_liv_virginia_ev.py
@@ -1,0 +1,94 @@
+import csv
+from pathlib import Path
+
+BOOKS = [
+    'bet365','fanduel','draftkings','betcris','caesars','betway','bovada','betonline','unibet','betmgm','betfair','pinnacle'
+]
+
+MARKET_FILES = {
+    'win': 'liv_virginia_win_american_ch.csv',
+    'top_5': 'liv_virginia_top5_american_ch.csv',
+    'top_10': 'liv_virginia_top10_american_ch.csv',
+    'top_20': 'liv_virginia_top20_american_ch.csv'
+}
+
+PRED_FILE = 'LIV Virginia Model Fairs 20250605.csv'
+
+def american_to_decimal(odds:str):
+    try:
+        o=int(odds)
+    except Exception:
+        return None
+    if o>0:
+        return 1+o/100
+    return 1+100/(-o)
+
+
+def load_predictions(path):
+    preds={}
+    with open(path) as f:
+        reader=csv.DictReader(f)
+        for row in reader:
+            # prediction file uses "first last" names
+            name=row['player_name'].strip().lower()
+            name=" ".join(p.title() for p in name.split())
+            preds[name]= {
+                'win': float(row['win']),
+                'top_5': float(row['top_5']),
+                'top_10': float(row['top_10']),
+                'top_20': float(row['top_20'])
+            }
+    return preds
+
+
+def best_ev_bets(preds, data_root, threshold=0.06):
+    bets=[]
+    for market,file in MARKET_FILES.items():
+        path=Path(data_root)/file
+        with open(path) as f:
+            reader=csv.DictReader(f)
+            for row in reader:
+                name=row['player_name'].strip()
+                # odds files use "Last, First" format
+                if ',' in name:
+                    last, first = [x.strip() for x in name.split(',',1)]
+                    norm = f"{first.title()} {last.title()}"
+                else:
+                    norm = " ".join(p.title() for p in name.split())
+                pred_key = norm
+                if pred_key not in preds:
+                    continue
+                prob=preds[pred_key][market]
+                best=None
+                for book in BOOKS:
+                    odds=row.get(f"{book}_odds")
+                    if not odds or odds in ('','null'):
+                        continue
+                    dec=american_to_decimal(odds)
+                    if dec is None:
+                        continue
+                    ev=prob*dec-1
+                    if ev>=threshold and (best is None or ev>best['ev']):
+                        best={'market':market,'player':name,'book':book,'odds':odds,'ev':ev}
+                if best:
+                    bets.append(best)
+    bets.sort(key=lambda x: x['ev'], reverse=True)
+    return bets
+
+
+def main():
+    preds=load_predictions(Path('data/raw')/PRED_FILE)
+    bets=best_ev_bets(preds,'data/raw')
+    out=Path('outputs/liv_virginia_positive_ev.csv')
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out,'w',newline='') as f:
+        writer=csv.DictWriter(f, fieldnames=['market','player','book','odds','ev'])
+        writer.writeheader()
+        for b in bets:
+            b2=b.copy(); b2['ev']=round(b2['ev'],4)
+            writer.writerow(b2)
+    for b in bets:
+        print(f"{b['market']}, {b['player']}, {b['book']}, {b['odds']}, {b['ev']:.4f}")
+
+if __name__=='__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `compute_liv_virginia_ev.py` to calculate expected value bets using model probabilities vs. sportsbook odds
- generate output list of +EV wagers for the LIV Virginia event

## Testing
- `python3 scripts/compute_liv_virginia_ev.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6841d341baac832aa3f85f2b3a38d8ae