### PR TITLE
Add pre-round 2 market-adjusted strokes

### DIFF
--- a/outputs/Adjusted Round Score Pre R2.csv
+++ b/outputs/Adjusted Round Score Pre R2.csv
@@ -1,0 +1,157 @@
+PLAYER NAME,BASELINE STROKES,ADJUSTED STROKES
+"Ahlawat, Veer",72.0,72.0
+"Aiken, Thomas",71.694,71.694
+"Akesson, Bjorn",72.51,72.51
+"Amat, Bastien",72.754,72.754
+"Armitage, Marcus",71.088,71.063
+"Ayora, Angel",70.745,70.809
+"Bairstow, Sam",70.52,70.577
+"Baldwin, Matthew",71.998,71.998
+"Bekirian, Jean",72.683,72.683
+"Besseling, Wil",71.903,71.903
+"Bjerregaard, Lucas",72.371,72.371
+"Boneta, Albert",71.935,71.935
+"Bradbury, Dan",71.473,71.473
+"Brown, Daniel",71.178,71.214
+"Brown, Hamish",72.149,72.149
+"Brun, Julien",72.607,72.607
+"Bryant, Davis",71.691,71.691
+"Cabrera Bello, Rafa",71.984,71.984
+"Campillo, Jorge",71.053,71.042
+"Canter, Laurie",70.437,70.435
+"Cantero Gutierrez, Ivan",71.545,71.545
+"Catlin, John",70.976,71.002
+"Chacarra, Eugenio",70.426,70.511
+"Clements, Todd",70.968,71.063
+"Cockerill, Aaron",71.18,71.18
+"Colsaerts, Nicolas",71.899,71.899
+"Coussaud, Ugo",71.0,71.036
+"Crocker, Sean",70.9,71.034
+"Dantorp, Jens",71.656,71.656
+"De Bruyn, Jannik",72.085,72.085
+"De Leo, Gregorio",71.72,71.72
+"De Vries, Wouter",73.22,73.22
+"Dean, Joe",71.136,71.238
+"Del Rey, Alejandro",71.188,71.158
+"Ding, Wenyi",70.627,70.516
+"Donaldson, Jamie",72.883,72.883
+"Driessen, Bjorn",74.751,74.751
+"Elvira Mijares, Ignacio",71.408,71.408
+"Elvira, Manuel",71.548,71.548
+"Erickson, Dan",72.135,72.135
+"Fdez-Castano, Gonzalo",73.689,73.689
+"Ferguson, Ewen",70.286,70.377
+"Fisher, Ross",72.378,72.378
+"Fitzpatrick, Alex",70.857,70.886
+"Follet-Smith, Benjamin",72.753,72.753
+"Forrest, Grant",71.454,71.387
+"Forsstrom, Simon",71.627,71.627
+"Frances, Alexander George",72.63,72.63
+"Frittelli, Dylan",71.459,71.458
+"Gale, Daniel",72.228,72.228
+"Garcia-Heredia, Alfredo",72.283,72.283
+"Germishuys, Deon",72.037,72.037
+"Girrbach, Joel",71.895,71.895
+"Gouveia, Ricardo",71.489,71.353
+"Green, Gavin",71.587,71.581
+"Guerrier, Julien",70.807,70.797
+"Gumberg, Jordan",71.722,71.722
+"Halvorsen, Andreas",71.471,71.471
+"Harding, Justin",72.544,72.544
+"Hebert, Benjamin",71.68,71.68
+"Hidalgo, Angel",71.537,71.595
+"Hill, Calum",71.203,71.243
+"Hillier, Daniel",70.761,70.807
+"Huizing, Daan",72.283,72.283
+"Jamieson, Scott",71.134,71.104
+"Jarvis, Casey",71.202,71.202
+"Jin, Zihao",72.241,72.241
+"Johnston, Ryggs",71.916,71.916
+"Katsuragawa, Yuto",71.153,71.118
+"Kieffer, Maximilian",71.245,71.282
+"Kim, Minkyu",71.824,71.824
+"Kimsey, Nathan",71.136,71.044
+"Kinhult, Marcus",71.122,71.131
+"Kleen, Algot",72.029,72.029
+"Knappe, Alexander",72.9,72.9
+"Ko, Jeong Weon",72.19,72.19
+"Kobori, Kazuma",71.137,71.329
+"Kouwenaar, Koen",75.022,75.022
+"Lafeber, Guus",74.777,74.777
+"Lagergren, Joakim",71.848,71.848
+"Laporta, Francesco",70.445,70.338
+"Larrazabal, Pablo",71.346,71.408
+"Lawrence, Thriston",71.06,71.088
+"Lemke, Niklas",71.175,71.239
+"Li, Haotong",70.182,70.227
+"Lindberg, Mikael",72.147,72.147
+"Lindell, Oliver",70.913,70.861
+"List, Danny",72.63,72.63
+"Lombard, Zander",72.514,72.514
+"Luiten, Joost",70.056,69.951
+"Mansell, Richard",70.716,70.676
+"Merritt, Troy",71.23,71.217
+"Micheluzzi, David",71.726,71.679
+"Migliozzi, Guido",70.951,71.007
+"Molinari, Francesco",71.333,71.376
+"Moscatel, Joel",72.092,72.092
+"Naidoo, Dylan",72.253,72.253
+"Nakajima, Keita",70.181,70.166
+"Neergaard-Petersen, Rasmus",69.779,69.85
+"Nienaber, Wilco",71.454,71.473
+"Olesen, Jacob Skov",71.089,70.895
+"Otaegui, Adrian",71.033,71.08
+"Parry, John",70.717,70.805
+"Paul, Yannik",71.274,71.281
+"Pavan, Andrea",70.647,70.711
+"Pineau, Pierre",72.653,72.653
+"Porsius, Davey",74.118,74.118
+"Pulkkanen, Tapio",71.889,71.889
+"Purcell, Conor",71.445,71.445
+"Ramsay, Richie",71.447,71.265
+"Ravetto, David",71.269,71.216
+"Reitan, Kristoffer",70.529,70.435
+"Reuter, Benjamin",73.533,73.533
+"Robinson-Thompson, Brandon",71.021,71.209
+"Ruiter, Nevill",74.312,74.312
+"Schaper, Jayden",70.461,70.434
+"Schmidt, Ben",71.348,71.348
+"Schneider, Marcel",70.569,70.596
+"Schott, Freddy",71.639,71.639
+"Schwab, Matthias",72.911,72.911
+"Scrivener, Jason",71.205,70.978
+"Senior, Jack",71.757,71.757
+"Sharma, Shubhankar",71.669,71.669
+"Shaun, Corey",72.376,72.376
+"Shinkwin, Callum",71.299,71.299
+"Siem, Marcel",71.129,71.143
+"Soderberg, Sebastian",70.852,70.836
+"Sordet, Clement",71.877,71.877
+"Southgate, Matthew",71.253,71.253
+"Sterne, Richard",72.35,72.35
+"Stone, Brandon",70.466,70.436
+"Strydom, Ockie",73.068,73.068
+"Sullivan, Andy",70.837,70.803
+"Syme, Connor",71.51,71.452
+"Tarren, Callum",71.562,71.542
+"Tetak, TadeÃ¡Å¡",72.43,72.43
+"Trainer, Martin",73.788,73.788
+"Vaillant, Tom",71.156,71.143
+"Van Der Vight, Lars",72.525,72.525
+"Van Driel, Darius",71.259,71.253
+"Van Meijel, Lars",71.995,71.995
+"Van Veen, Vince",72.736,72.736
+"Van Velzen, Ryan",72.083,72.083
+"Veerman, Johannes",70.857,70.836
+"Verdonk, Aydan",74.925,74.925
+"Von Dellingshausen, Nicolai",71.125,71.089
+"Walker, Jimmy",72.674,72.674
+"Whitnell, Dale",72.27,72.27
+"Wiesberger, Bernd",71.151,71.055
+"Williams, Robin",71.427,71.427
+"Wilson, Andrew",71.549,71.616
+"Winther, Jeff",71.286,71.304
+"Woltering, Scott",74.147,74.147
+"Wood, Chris",72.72,72.72
+"Wu, Brandon",71.406,71.512
+"Zanotti, Fabrizio",70.864,70.899

--- a/outputs/PreR1_vs_PreR2_Strokes_Diff.csv
+++ b/outputs/PreR1_vs_PreR2_Strokes_Diff.csv
@@ -1,0 +1,157 @@
+PLAYER NAME,PRE R1 STROKES,PRE R2 STROKES,DIFFERENCE
+"Ahlawat, Veer",72.0,72.0,0.0
+"Aiken, Thomas",71.694,71.694,0.0
+"Akesson, Bjorn",72.51,72.51,0.0
+"Amat, Bastien",72.754,72.754,0.0
+"Armitage, Marcus",70.999,71.063,0.064
+"Ayora, Angel",70.809,70.809,0.0
+"Bairstow, Sam",70.523,70.577,0.054
+"Baldwin, Matthew",71.998,71.998,0.0
+"Bekirian, Jean",72.683,72.683,0.0
+"Besseling, Wil",71.903,71.903,0.0
+"Bjerregaard, Lucas",72.371,72.371,0.0
+"Boneta, Albert",71.935,71.935,0.0
+"Bradbury, Dan",71.473,71.473,0.0
+"Brown, Daniel",71.214,71.214,0.0
+"Brown, Hamish",72.149,72.149,0.0
+"Brun, Julien",72.607,72.607,0.0
+"Bryant, Davis",71.691,71.691,0.0
+"Cabrera Bello, Rafa",71.984,71.984,0.0
+"Campillo, Jorge",71.042,71.042,0.0
+"Canter, Laurie",70.435,70.435,0.0
+"Cantero Gutierrez, Ivan",71.545,71.545,0.0
+"Catlin, John",70.996,71.002,0.006
+"Chacarra, Eugenio",70.511,70.511,0.0
+"Clements, Todd",71.063,71.063,0.0
+"Cockerill, Aaron",71.18,71.18,0.0
+"Colsaerts, Nicolas",71.899,71.899,0.0
+"Coussaud, Ugo",71.036,71.036,0.0
+"Crocker, Sean",70.965,71.034,0.069
+"Dantorp, Jens",71.656,71.656,0.0
+"De Bruyn, Jannik",72.085,72.085,0.0
+"De Leo, Gregorio",71.72,71.72,0.0
+"De Vries, Wouter",73.22,73.22,0.0
+"Dean, Joe",71.238,71.238,0.0
+"Del Rey, Alejandro",71.158,71.158,0.0
+"Ding, Wenyi",70.578,70.516,-0.062
+"Donaldson, Jamie",72.883,72.883,0.0
+"Driessen, Bjorn",74.751,74.751,0.0
+"Elvira Mijares, Ignacio",71.408,71.408,0.0
+"Elvira, Manuel",71.548,71.548,0.0
+"Erickson, Dan",72.135,72.135,0.0
+"Fdez-Castano, Gonzalo",73.689,73.689,0.0
+"Ferguson, Ewen",70.351,70.377,0.026
+"Fisher, Ross",72.378,72.378,0.0
+"Fitzpatrick, Alex",70.879,70.886,0.007
+"Follet-Smith, Benjamin",72.753,72.753,0.0
+"Forrest, Grant",71.387,71.387,0.0
+"Forsstrom, Simon",71.627,71.627,0.0
+"Frances, Alexander George",72.63,72.63,0.0
+"Frittelli, Dylan",71.44,71.458,0.018
+"Gale, Daniel",72.228,72.228,0.0
+"Garcia-Heredia, Alfredo",72.283,72.283,0.0
+"Germishuys, Deon",72.037,72.037,0.0
+"Girrbach, Joel",71.895,71.895,0.0
+"Gouveia, Ricardo",71.489,71.353,-0.136
+"Green, Gavin",71.581,71.581,0.0
+"Guerrier, Julien",70.765,70.797,0.032
+"Gumberg, Jordan",71.722,71.722,0.0
+"Halvorsen, Andreas",71.471,71.471,0.0
+"Harding, Justin",72.544,72.544,0.0
+"Hebert, Benjamin",71.68,71.68,0.0
+"Hidalgo, Angel",71.537,71.595,0.058
+"Hill, Calum",71.249,71.243,-0.006
+"Hillier, Daniel",70.807,70.807,0.0
+"Huizing, Daan",72.283,72.283,0.0
+"Jamieson, Scott",71.104,71.104,0.0
+"Jarvis, Casey",71.202,71.202,0.0
+"Jin, Zihao",72.241,72.241,0.0
+"Johnston, Ryggs",71.916,71.916,0.0
+"Katsuragawa, Yuto",71.147,71.118,-0.029
+"Kieffer, Maximilian",71.245,71.282,0.037
+"Kim, Minkyu",71.824,71.824,0.0
+"Kimsey, Nathan",71.125,71.044,-0.081
+"Kinhult, Marcus",71.131,71.131,0.0
+"Kleen, Algot",72.029,72.029,0.0
+"Knappe, Alexander",72.9,72.9,0.0
+"Ko, Jeong Weon",72.19,72.19,0.0
+"Kobori, Kazuma",71.084,71.329,0.245
+"Kouwenaar, Koen",75.022,75.022,0.0
+"Lafeber, Guus",74.777,74.777,0.0
+"Lagergren, Joakim",71.848,71.848,0.0
+"Laporta, Francesco",70.358,70.338,-0.02
+"Larrazabal, Pablo",71.408,71.408,0.0
+"Lawrence, Thriston",71.088,71.088,0.0
+"Lemke, Niklas",71.239,71.239,0.0
+"Li, Haotong",70.227,70.227,0.0
+"Lindberg, Mikael",72.147,72.147,0.0
+"Lindell, Oliver",70.965,70.861,-0.104
+"List, Danny",72.63,72.63,0.0
+"Lombard, Zander",72.514,72.514,0.0
+"Luiten, Joost",70.059,69.951,-0.108
+"Mansell, Richard",70.755,70.676,-0.079
+"Merritt, Troy",71.217,71.217,0.0
+"Micheluzzi, David",71.679,71.679,0.0
+"Migliozzi, Guido",70.93,71.007,0.077
+"Molinari, Francesco",71.376,71.376,0.0
+"Moscatel, Joel",72.092,72.092,0.0
+"Naidoo, Dylan",72.253,72.253,0.0
+"Nakajima, Keita",70.166,70.166,0.0
+"Neergaard-Petersen, Rasmus",69.738,69.85,0.112
+"Nienaber, Wilco",71.473,71.473,0.0
+"Olesen, Jacob Skov",71.02,70.895,-0.125
+"Otaegui, Adrian",70.999,71.08,0.081
+"Parry, John",70.772,70.805,0.033
+"Paul, Yannik",71.247,71.281,0.034
+"Pavan, Andrea",70.647,70.711,0.064
+"Pineau, Pierre",72.653,72.653,0.0
+"Porsius, Davey",74.118,74.118,0.0
+"Pulkkanen, Tapio",71.889,71.889,0.0
+"Purcell, Conor",71.445,71.445,0.0
+"Ramsay, Richie",71.447,71.265,-0.182
+"Ravetto, David",71.357,71.216,-0.141
+"Reitan, Kristoffer",70.433,70.435,0.002
+"Reuter, Benjamin",73.533,73.533,0.0
+"Robinson-Thompson, Brandon",71.053,71.209,0.156
+"Ruiter, Nevill",74.312,74.312,0.0
+"Schaper, Jayden",70.414,70.434,0.02
+"Schmidt, Ben",71.348,71.348,0.0
+"Schneider, Marcel",70.596,70.596,0.0
+"Schott, Freddy",71.639,71.639,0.0
+"Schwab, Matthias",72.911,72.911,0.0
+"Scrivener, Jason",71.074,70.978,-0.096
+"Senior, Jack",71.757,71.757,0.0
+"Sharma, Shubhankar",71.669,71.669,0.0
+"Shaun, Corey",72.376,72.376,0.0
+"Shinkwin, Callum",71.299,71.299,0.0
+"Siem, Marcel",71.143,71.143,0.0
+"Soderberg, Sebastian",70.793,70.836,0.043
+"Sordet, Clement",71.877,71.877,0.0
+"Southgate, Matthew",71.253,71.253,0.0
+"Sterne, Richard",72.35,72.35,0.0
+"Stone, Brandon",70.408,70.436,0.028
+"Strydom, Ockie",73.068,73.068,0.0
+"Sullivan, Andy",70.834,70.803,-0.031
+"Syme, Connor",71.51,71.452,-0.058
+"Tarren, Callum",71.542,71.542,0.0
+"Tetak, TadeÃ¡Å¡",72.43,72.43,0.0
+"Trainer, Martin",73.788,73.788,0.0
+"Vaillant, Tom",71.143,71.143,0.0
+"Van Der Vight, Lars",72.525,72.525,0.0
+"Van Driel, Darius",71.253,71.253,0.0
+"Van Meijel, Lars",71.995,71.995,0.0
+"Van Veen, Vince",72.736,72.736,0.0
+"Van Velzen, Ryan",72.083,72.083,0.0
+"Veerman, Johannes",70.836,70.836,0.0
+"Verdonk, Aydan",74.925,74.925,0.0
+"Von Dellingshausen, Nicolai",71.089,71.089,0.0
+"Walker, Jimmy",72.674,72.674,0.0
+"Whitnell, Dale",72.27,72.27,0.0
+"Wiesberger, Bernd",71.119,71.055,-0.064
+"Williams, Robin",71.427,71.427,0.0
+"Wilson, Andrew",71.616,71.616,0.0
+"Winther, Jeff",71.122,71.304,0.182
+"Woltering, Scott",74.147,74.147,0.0
+"Wood, Chris",72.72,72.72,0.0
+"Wu, Brandon",71.408,71.512,0.104
+"Zanotti, Fabrizio",70.918,70.899,-0.019


### PR DESCRIPTION
## Summary
- run market-maker adjustment with KLM Open round 2 matchup odds
- generate `Adjusted Round Score Pre R2.csv`
- compute differences between pre-tournament and pre-round-2 projections

## Testing
- `python3 scripts/adjust_projections.py --strokes 'outputs/Adjusted KLM Open DG Thursday Strokes 20250604.csv' --matchups 'data/raw/KLM Open r2 match up 20250606.csv' --output 'outputs/Adjusted Round Score Pre R2.csv'`


------
https://chatgpt.com/codex/tasks/task_e_68430e2f2074832aa9f7220701889a53