### PR TITLE
Add football ELO download script

### DIFF
--- a/scripts/download_football_elo.py
+++ b/scripts/download_football_elo.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import requests
+from pathlib import Path
+
+URL = "https://footballdatabase.com/ranking/world/1"
+OUTPUT = Path("outputs/Football ELO World.csv")
+
+
+def download_football_elo(url: str = URL, output: Path = OUTPUT) -> None:
+    """Download the world football ELO rankings and save as CSV."""
+    response = requests.get(url)
+    response.raise_for_status()
+    tables = pd.read_html(response.text)
+    if not tables:
+        raise ValueError("No tables found on the page")
+    df = tables[0]
+    output.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output, index=False)
+    print(f"Saved {len(df)} rows to {output}")
+
+
+if __name__ == "__main__":
+    download_football_elo()


### PR DESCRIPTION
## Summary
- add a Python script to download world football ELO rankings from footballdatabase.com

## Testing
- `python3 scripts/download_football_elo.py` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_684b0affbf2c832a876f30bda08f0ba4