### PR TITLE
Add world cup team ELO csv and script

### DIFF
--- a/data/raw/2025_Club_World_Cup_Teams.csv
+++ b/data/raw/2025_Club_World_Cup_Teams.csv
@@ -17,7 +17,6 @@ Esperance Sportive de Tunis,D,Tunisia
 Los Angeles FC,D,United States
 River Plate,E,Argentina
 Inter Milan,E,Italy
-CF Monterrey,E,Mexico
 Urawa Red Diamonds,E,Japan
 Fluminense,F,Brazil
 Borussia Dortmund,F,Germany

--- a/data/raw/2025_Club_World_Cup_Teams_with_ELO.csv
+++ b/data/raw/2025_Club_World_Cup_Teams_with_ELO.csv
@@ -1,0 +1,32 @@
+Team,Group,Country,World_ELO,Europe_ELO
+Palmeiras,A,Brazil,1793,
+Porto,A,Portugal,1722,1678
+Al Ahly,A,Egypt,1712,
+Inter Miami,A,United States,1424,
+Paris Saint-Germain,B,France,2054,1975
+Atletico Madrid,B,Spain,1872,
+Botafogo,B,Brazil,1327,
+Seattle Sounders,B,United States,1459,
+Bayern Munich,C,Germany,1984,1919
+Benfica,C,Portugal,1825,1791
+Boca Juniors,C,Argentina,1643,
+Auckland City,C,New Zealand,1576,
+Flamengo,D,Brazil,1772,
+Chelsea,D,England,1853,1903
+Esperance Sportive de Tunis,D,Tunisia,1634,
+Los Angeles FC,D,United States,1480,
+River Plate,E,Argentina,1328,
+Inter Milan,E,Italy,1947,1933
+Urawa Red Diamonds,E,Japan,1474,
+Fluminense,F,Brazil,1677,
+Borussia Dortmund,F,Germany,1887,1818
+Ulsan HD,F,South Korea,1512,
+Mamelodi Sundowns,F,South Africa,1641,
+Manchester City,G,England,1912,1960
+Juventus,G,Italy,1796,1806
+Wydad AC,G,Morocco,1529,
+Al Ain,G,United Arab Emirates,1254,
+Real Madrid,H,Spain,1936,1936
+FC Salzburg,H,Austria,1591,
+Al Hilal,H,Saudi Arabia,1684,
+CF Pachuca,H,Mexico,1590,

--- a/scripts/add_club_world_cup_elo.py
+++ b/scripts/add_club_world_cup_elo.py
@@ -1,0 +1,102 @@
+import csv
+import re
+import unicodedata
+from difflib import get_close_matches
+
+
+def normalize(name: str) -> str:
+    """Normalize club names for matching."""
+    name = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    name = name.lower()
+    name = re.sub(r"\b(fc|cf|sc|afc|club)\b", "", name)
+    name = name.replace("&", "and")
+    name = re.sub(r"[^a-z0-9]+", " ", name)
+    return re.sub(r"\s+", " ", name).strip()
+
+
+TEAM_SYNONYMS = {
+    normalize("Bayern Munich"): ["bayern munchen", "bayern"],
+    normalize("Paris Saint-Germain"): ["paris sg", "psg"],
+    normalize("Manchester City"): ["man city"],
+    normalize("Inter Milan"): ["inter"],
+    normalize("AC Milan"): ["milan"],
+    normalize("Borussia Dortmund"): ["dortmund"],
+    normalize("Seattle Sounders"): ["seattle sounders fc"],
+    normalize("Inter Miami"): ["inter miami cf"],
+    normalize("Fluminense"): ["fluminense fc"],
+    normalize("Mamelodi Sundowns"): ["mamelodi sundowns fc"],
+    normalize("Al Ain"): ["al ain fc", "al-ain fc"],
+    normalize("FC Salzburg"): ["red bull salzburg", "rb salzburg"],
+    normalize("Wydad AC"): ["wydad casablanca"],
+    normalize("CF Monterrey"): ["monterrey"],
+    normalize("Al Hilal"): ["al hilal saudi"],
+}
+
+
+def load_world_elo(path: str) -> dict:
+    mapping = {}
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            mapping[normalize(row["Club"])] = {
+                "club": row["Club"],
+                "country": row["Country"],
+                "elo": int(row["ELO"]),
+            }
+    return mapping
+
+
+def load_europe_elo(path: str) -> dict:
+    mapping = {}
+    with open(path, newline="") as f:
+        reader = csv.reader(f)
+        next(reader)  # header
+        for row in reader:
+            if row and row[0].strip():
+                try:
+                    elo = int(row[1])
+                except ValueError:
+                    continue
+                mapping[normalize(row[0])] = {"club": row[0], "elo": elo}
+    return mapping
+
+
+def lookup(name: str, mapping: dict, cutoff: float = 0.75):
+    n = normalize(name)
+    candidates = [n] + [normalize(s) for s in TEAM_SYNONYMS.get(n, [])]
+    for cand in candidates:
+        if cand in mapping:
+            return mapping[cand]
+    for cand in candidates:
+        match = get_close_matches(cand, mapping.keys(), n=1, cutoff=cutoff)
+        if match:
+            return mapping[match[0]]
+    return None
+
+
+def main():
+    world_map = load_world_elo("data/raw/Football ELO World.csv")
+    euro_map = load_europe_elo("data/raw/Europe Soccer ELO.csv")
+
+    output_rows = []
+    with open("data/raw/2025_Club_World_Cup_Teams.csv", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            w = lookup(row["Team"], world_map)
+            e = lookup(row["Team"], euro_map)
+            row["World_ELO"] = w["elo"] if w else ""
+            row["Europe_ELO"] = e["elo"] if e else ""
+            output_rows.append(row)
+
+    out_path = "data/raw/2025_Club_World_Cup_Teams_with_ELO.csv"
+    with open(out_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["Team", "Group", "Country", "World_ELO", "Europe_ELO"]
+        )
+        writer.writeheader()
+        writer.writerows(output_rows)
+    print(f"Wrote {len(output_rows)} rows to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- pull ELO ratings from world and European lists
- match Club World Cup team names with fuzzy search
- output `data/raw/2025_Club_World_Cup_Teams_with_ELO.csv`
- add script `scripts/add_club_world_cup_elo.py` for regeneration
- drop Monterrey from group E

## Testing
- `python3 scripts/add_club_world_cup_elo.py`

------
https://chatgpt.com/codex/tasks/task_e_684b22b417a0832aa1270f336f16bc18