### PR TITLE
Add Adjusted ELO for Club World Cup teams

### DIFF
--- a/data/raw/2025_Club_World_Cup_Teams_with_ELO.csv
+++ b/data/raw/2025_Club_World_Cup_Teams_with_ELO.csv
@@ -1,32 +1,32 @@
-Team,Group,Country,World_ELO,Europe_ELO
-Palmeiras,A,Brazil,1793,
-Porto,A,Portugal,1722,1678
-Al Ahly,A,Egypt,1712,
-Inter Miami,A,United States,1424,
-Paris Saint-Germain,B,France,2054,1975
-Atletico Madrid,B,Spain,1872,
-Botafogo,B,Brazil,1327,
-Seattle Sounders,B,United States,1459,
-Bayern Munich,C,Germany,1984,1919
-Benfica,C,Portugal,1825,1791
-Boca Juniors,C,Argentina,1643,
-Auckland City,C,New Zealand,1576,
-Flamengo,D,Brazil,1772,
-Chelsea,D,England,1853,1903
-Esperance Sportive de Tunis,D,Tunisia,1634,
-Los Angeles FC,D,United States,1480,
-River Plate,E,Argentina,1328,
-Inter Milan,E,Italy,1947,1933
-Urawa Red Diamonds,E,Japan,1474,
-Fluminense,F,Brazil,1677,
-Borussia Dortmund,F,Germany,1887,1818
-Ulsan HD,F,South Korea,1512,
-Mamelodi Sundowns,F,South Africa,1641,
-Manchester City,G,England,1912,1960
-Juventus,G,Italy,1796,1806
-Wydad AC,G,Morocco,1529,
-Al Ain,G,United Arab Emirates,1254,
-Real Madrid,H,Spain,1936,1936
-FC Salzburg,H,Austria,1591,
-Al Hilal,H,Saudi Arabia,1684,
-CF Pachuca,H,Mexico,1590,
+Team,Group,Country,World_ELO,Europe_ELO,Adjusted_ELO
+Palmeiras,A,Brazil,1793,,1793
+Porto,A,Portugal,1722,1678,1687
+Al Ahly,A,Egypt,1712,,1712
+Inter Miami,A,United States,1424,,1424
+Paris Saint-Germain,B,France,2054,1975,1991
+Atletico Madrid,B,Spain,1872,,1872
+Botafogo,B,Brazil,1327,,1327
+Seattle Sounders,B,United States,1459,,1459
+Bayern Munich,C,Germany,1984,1919,1932
+Benfica,C,Portugal,1825,1791,1798
+Boca Juniors,C,Argentina,1643,,1643
+Auckland City,C,New Zealand,1576,,1576
+Flamengo,D,Brazil,1772,,1772
+Chelsea,D,England,1853,1903,1893
+Esperance Sportive de Tunis,D,Tunisia,1634,,1634
+Los Angeles FC,D,United States,1480,,1480
+River Plate,E,Argentina,1328,,1328
+Inter Milan,E,Italy,1947,1933,1936
+Urawa Red Diamonds,E,Japan,1474,,1474
+Fluminense,F,Brazil,1677,,1677
+Borussia Dortmund,F,Germany,1887,1818,1832
+Ulsan HD,F,South Korea,1512,,1512
+Mamelodi Sundowns,F,South Africa,1641,,1641
+Manchester City,G,England,1912,1960,1950
+Juventus,G,Italy,1796,1806,1804
+Wydad AC,G,Morocco,1529,,1529
+Al Ain,G,United Arab Emirates,1254,,1254
+Real Madrid,H,Spain,1936,1936,1936
+FC Salzburg,H,Austria,1591,,1591
+Al Hilal,H,Saudi Arabia,1684,,1684
+CF Pachuca,H,Mexico,1590,,1590

--- a/scripts/add_club_world_cup_elo.py
+++ b/scripts/add_club_world_cup_elo.py
@@ -86,12 +86,28 @@ def main():
             e = lookup(row["Team"], euro_map)
             row["World_ELO"] = w["elo"] if w else ""
             row["Europe_ELO"] = e["elo"] if e else ""
+
+            if row["World_ELO"] and row["Europe_ELO"]:
+                world = float(row["World_ELO"])
+                euro = float(row["Europe_ELO"])
+                row["Adjusted_ELO"] = round(0.8 * euro + 0.2 * world)
+            else:
+                row["Adjusted_ELO"] = row["World_ELO"]
+
             output_rows.append(row)
 
     out_path = "data/raw/2025_Club_World_Cup_Teams_with_ELO.csv"
     with open(out_path, "w", newline="") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["Team", "Group", "Country", "World_ELO", "Europe_ELO"]
+            f,
+            fieldnames=[
+                "Team",
+                "Group",
+                "Country",
+                "World_ELO",
+                "Europe_ELO",
+                "Adjusted_ELO",
+            ],
         )
         writer.writeheader()
         writer.writerows(output_rows)


### PR DESCRIPTION
## Summary
- compute an Adjusted ELO that weights Europe ELO at 80% and World ELO at 20% when both are available
- regenerate the Club World Cup team ELO data with this new column

## Testing
- `python3 scripts/add_club_world_cup_elo.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2575fb80832a97b6bcf2530a6c0d