### PR TITLE
Fix team name mismatches for ELO updates

### DIFF
--- a/outputs/Updated_Club_World_Cup_ELO.csv
+++ b/outputs/Updated_Club_World_Cup_ELO.csv
@@ -1,0 +1,32 @@
+Team,Previous_ELO,Updated_ELO,Change
+Al Ahly,1712.0,1673.14,-38.86
+Al Ain,1254.0,1485.63,231.63
+Al Hilal,1684.0,1657.57,-26.43
+Atletico Madrid,1872.0,1802.26,-69.74
+Auckland City,1576.0,1400.8,-175.2
+Bayern Munich,1932.0,1939.46,7.46
+Benfica,1798.0,1980.81,182.81
+Boca Juniors,1643.0,1627.93,-15.07
+Borussia Dortmund,1832.0,1841.9,9.9
+Botafogo,1327.0,1488.1,161.1
+CF Pachuca,1590.0,1620.8,30.8
+Chelsea,1893.0,1900.82,7.82
+Esperance Sportive de Tunis,1634.0,1525.03,-108.97
+FC Salzburg,1591.0,1620.51,29.51
+Flamengo,1772.0,1772.33,0.33
+Fluminense,1677.0,1691.01,14.01
+Inter Miami,1424.0,1485.09,61.09
+Inter Milan,1936.0,1769.09,-166.91
+Juventus,1804.0,1733.56,-70.44
+Los Angeles FC,1480.0,1580.82,100.82
+Mamelodi Sundowns,1641.0,1589.18,-51.82
+Manchester City,1950.0,1873.71,-76.29
+Palmeiras,1793.0,1831.86,38.86
+Paris Saint-Germain,1991.0,1829.9,-161.1
+Porto,1687.0,1625.91,-61.09
+Real Madrid,1936.0,1902.12,-33.88
+River Plate,1328.0,1482.89,154.89
+Seattle Sounders,1459.0,1528.74,69.74
+Ulsan HD,1512.0,1539.91,27.91
+Urawa Red Diamonds,1474.0,1486.02,12.02
+Wydad AC,1529.0,1444.1,-84.9

--- a/scripts/update_elo_from_odds.py
+++ b/scripts/update_elo_from_odds.py
@@ -1,0 +1,159 @@
+import argparse
+import json
+import csv
+import math
+from pathlib import Path
+
+# Map inconsistent team names from the odds feed to the names used in the
+# ELO CSV so ratings can be matched correctly.
+NAME_MAP = {
+    "Al Ahly FC": "Al Ahly",
+    "Al Ain FC": "Al Ain",
+    "Al-Hilal Saudi FC": "Al Hilal",
+    "Atlético Madrid": "Atletico Madrid",
+    "Auckland City FC": "Auckland City",
+    "Espérance Sportive de Tunis": "Esperance Sportive de Tunis",
+    "FC Porto": "Porto",
+    "Inter Miami CF": "Inter Miami",
+    "Mamelodi Sundowns F.C.": "Mamelodi Sundowns",
+    "Paris Saint Germain": "Paris Saint-Germain",
+    "Pachuca": "CF Pachuca",
+    "RB Salzburg": "FC Salzburg",
+    "Seattle Sounders FC": "Seattle Sounders",
+}
+
+
+def fix_name(name: str) -> str:
+    """Return canonical team name used in the ELO table."""
+    return NAME_MAP.get(name, name)
+
+
+def read_elos(path: str) -> dict:
+    """Return mapping of team name to ELO rating as float."""
+    elos = {}
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                elos[row["Team"]] = float(row["Adjusted_ELO"])
+            except (KeyError, ValueError):
+                continue
+    return elos
+
+
+def parse_events(path: str) -> list:
+    """Return list of events with averaged implied probabilities."""
+    with open(path) as f:
+        data = json.load(f)
+
+    events = []
+    for event in data:
+        # Normalise team names so they match those in the ELO ratings table
+        home = fix_name(event.get("home_team"))
+        away = fix_name(event.get("away_team"))
+        start = event.get("commence_time")
+        probs = []  # (home, draw, away)
+        for bm in event.get("bookmakers", []):
+            for market in bm.get("markets", []):
+                if market.get("key") != "h2h":
+                    continue
+                prices = {fix_name(o["name"]): o.get("price") for o in market.get("outcomes", [])}
+                if home in prices and away in prices and "Draw" in prices:
+                    h = 1 / prices[home]
+                    a = 1 / prices[away]
+                    d = 1 / prices["Draw"]
+                    total = h + a + d
+                    probs.append((h / total, d / total, a / total))
+                break
+        if not probs:
+            continue
+        home_p = sum(p[0] for p in probs) / len(probs)
+        draw_p = sum(p[1] for p in probs) / len(probs)
+        away_p = sum(p[2] for p in probs) / len(probs)
+        events.append(
+            {
+                "home": home,
+                "away": away,
+                "start": start,
+                "home_prob": home_p,
+                "draw_prob": draw_p,
+                "away_prob": away_p,
+            }
+        )
+    events.sort(key=lambda e: e["start"])
+    return events
+
+
+def update_elos(elos: dict, events: list) -> dict:
+    """Return a new dict of updated ELOs after applying events."""
+    new_elos = elos.copy()
+    for ev in events:
+        home, away = ev["home"], ev["away"]
+        if home not in new_elos or away not in new_elos:
+            continue
+        h_elo, a_elo = new_elos[home], new_elos[away]
+        avg = (h_elo + a_elo) / 2
+        diff_old = h_elo - a_elo
+        score_home = ev["home_prob"] + 0.5 * ev["draw_prob"]
+        diff_market = 400 * math.log10(score_home / (1 - score_home))
+        diff_new = 0.5 * diff_old + 0.5 * diff_market
+        new_elos[home] = round(avg + diff_new / 2, 2)
+        new_elos[away] = round(avg - diff_new / 2, 2)
+    return new_elos
+
+
+def write_elos(new_elos: dict, old_elos: dict, path: str) -> None:
+    """Write updated ELOs alongside the previous values and change."""
+    rows = []
+    for team in sorted(new_elos):
+        updated = new_elos[team]
+        previous = old_elos.get(team, float("nan"))
+        change = round(updated - previous, 2) if isinstance(previous, float) else ""
+        rows.append(
+            {
+                "Team": team,
+                "Previous_ELO": previous,
+                "Updated_ELO": updated,
+                "Change": change,
+            }
+        )
+
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["Team", "Previous_ELO", "Updated_ELO", "Change"]
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Update Club World Cup ELO ratings using market odds"
+    )
+    parser.add_argument(
+        "--elo_csv",
+        default="data/raw/2025_Club_World_Cup_Teams_with_ELO.csv",
+        help="CSV file with team ELO ratings",
+    )
+    parser.add_argument(
+        "--odds_json",
+        default="data/raw/club_world_cup_odds2020616.json",
+        help="JSON file with Club World Cup odds",
+    )
+    parser.add_argument(
+        "--output",
+        default="outputs/Updated_Club_World_Cup_ELO.csv",
+        help="Output CSV with updated ELO ratings",
+    )
+    args = parser.parse_args()
+
+    base_elos = read_elos(args.elo_csv)
+    events = parse_events(args.odds_json)
+    updated = update_elos(base_elos, events)
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    write_elos(updated, base_elos, args.output)
+    print(f"Wrote updated ELO ratings for {len(updated)} teams to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- handle alternative team names when parsing betting odds
- regenerate market-based Club World Cup ELO ratings with names normalized

## Testing
- `python3 scripts/update_elo_from_odds.py`

------
https://chatgpt.com/codex/tasks/task_e_68503b247734832a91476fd20963b6a2