### PR TITLE
Add deduplication and robust mapping for SP+ updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,19 @@ python3 scripts/fetch_college_football_games.py --api_key YOUR_KEY --output ncaa
 ```
 
 The script saves the JSON response so you can analyze the lines offline.
+
+## Updating SP+ Ratings with Market Odds
+
+`scripts/update_sp_plus_from_odds.py` adjusts Bill Connelly's SP+ team ratings to
+better reflect the betting market. Provide the latest SP+ CSV dump, a games JSON
+file from the Odds API, and an output path:
+
+```bash
+python3 scripts/update_sp_plus_from_odds.py \
+  --sp_csv data/raw/SP+20250615.csv \
+  --odds_json data/raw/college_football_games_2025-06-16.json \
+  --output outputs/Updated_SP_Plus.csv
+```
+
+The resulting CSV lists each team with its previous SP+ value, the market-adj
+usted rating, and the change in points.

--- a/outputs/Updated_SP_Plus.csv
+++ b/outputs/Updated_SP_Plus.csv
@@ -1,0 +1,137 @@
+Team,Previous_SP,Updated_SP,Change
+Air Force,-7.3,-7.3,0.0
+Akron,-19.3,-19.8,-0.5
+Alabama,27.9,26.2,-1.7
+App. St.,-8.8,-8.8,0.0
+Arizona,0.7,0.2,-0.5
+Arizona St.,12.2,12.2,0.0
+Arkansas,7.0,7.0,0.0
+Arkansas St.,-9.9,-9.9,0.0
+Army,-0.6,-0.6,0.0
+Auburn,11.8,11.7,-0.1
+BYU,11.5,11.5,0.0
+Ball St.,-21.2,-21.4,-0.2
+Baylor,7.5,7.6,0.1
+Boise St.,9.2,13.9,4.7
+Boston Coll.,0.3,0.3,0.0
+Bowling Green,-13.7,-13.7,0.0
+Buffalo,-7.1,-7.2,-0.1
+CMU,-14.8,-14.4,0.4
+California,-0.3,-0.6,-0.3
+Charlotte,-19.4,-19.4,0.0
+Cincinnati,-0.3,0.9,1.2
+Clemson,23.3,22.9,-0.4
+Coastal Caro.,-7.3,-8.8,-1.5
+Colorado,2.6,2.8,0.2
+Colorado St.,-8.3,-8.0,0.3
+Delaware,-13.0,-13.0,0.0
+Duke,4.9,4.9,0.0
+ECU,-6.6,-6.6,0.0
+EMU,-14.2,-15.0,-0.8
+FAU,-14.4,-14.0,0.4
+FIU,-18.0,-18.0,0.0
+Florida,17.3,12.6,-4.7
+Florida St.,7.2,8.9,1.7
+Fresno St.,-6.2,-6.2,0.0
+Ga. Southern,-4.0,-4.3,-0.3
+Ga. Tech,4.7,4.5,-0.2
+Georgia,26.9,23.4,-3.5
+Georgia St.,-14.3,-11.6,2.7
+Hawaii,-11.5,-10.7,0.8
+Houston,0.9,0.9,0.0
+Illinois,14.3,14.3,0.0
+Indiana,12.2,10.9,-1.3
+Iowa,11.4,11.4,0.0
+Iowa St.,11.0,10.8,-0.2
+J'ville St.,-10.4,-10.7,-0.3
+JMU,3.0,3.0,0.0
+Kansas,3.0,3.3,0.3
+Kansas St.,15.6,15.8,0.2
+Kennesaw St.,-18.9,-18.9,0.0
+Kent St.,-24.9,-24.9,0.0
+Kentucky,4.7,5.0,0.3
+LSU,22.1,22.5,0.4
+La. Tech,-11.9,-11.9,0.0
+Liberty,-1.1,-1.1,0.0
+Louisiana,-3.1,-3.7,-0.6
+Louisville,12.1,12.1,0.0
+Marshall,-9.4,-5.9,3.5
+Maryland,-1.1,-1.5,-0.4
+Memphis,2.1,2.1,0.0
+Miami,18.8,19.4,0.6
+Miami-OH,-7.6,-7.2,0.4
+Michigan,21.5,17.4,-4.1
+Michigan St.,-0.2,-0.3,-0.1
+Middle Tenn.,-16.4,-16.4,0.0
+Minnesota,6.0,6.1,0.1
+Miss. St.,-1.4,-1.8,-0.4
+Missouri,12.5,12.5,0.0
+Missouri St.,-17.6,-16.2,1.4
+N. Carolina,2.0,3.4,1.4
+N. Texas,-7.2,-7.2,0.0
+NC St.,4.8,9.6,4.8
+NIU,-11.0,-11.0,0.0
+Navy,-1.0,-1.0,0.0
+Nebraska,8.9,8.7,-0.2
+Nevada,-16.3,-11.4,4.9
+New Mexico,-18.4,-14.0,4.4
+New Mexico St.,-16.0,-16.0,0.0
+Northwestern,-6.1,-4.6,1.5
+Notre Dame,24.9,24.3,-0.6
+ODU,-10.2,-8.9,1.3
+Ohio,-4.4,-4.0,0.4
+Ohio St.,29.5,27.4,-2.1
+Oklahoma,16.5,16.5,0.0
+Oklahoma St.,0.9,0.9,0.0
+Ole Miss,19.8,17.1,-2.7
+Oregon,24.7,24.7,0.0
+Oregon St.,-2.4,-2.1,0.3
+Penn St.,27.7,22.8,-4.9
+Pittsburgh,3.4,3.4,0.0
+Purdue,-10.0,-9.8,0.2
+Rice,-15.8,-15.2,0.6
+Rutgers,4.7,4.3,-0.4
+S. Alabama,-3.4,-3.4,0.0
+S. Carolina,16.1,9.5,-6.6
+SDSU,-10.1,-10.1,0.0
+SJSU,-5.2,-5.6,-0.4
+SMU,13.1,13.1,0.0
+Sam Houston,-11.1,-12.6,-1.5
+So. Miss,-17.7,-17.3,0.4
+Stanford,-6.2,-6.5,-0.3
+Syracuse,1.6,2.5,0.9
+TCU,11.1,9.7,-1.4
+Temple,-16.4,-17.6,-1.2
+Tennessee,18.4,17.5,-0.9
+Texas,26.4,27.2,0.8
+Texas A&M,17.2,16.5,-0.7
+Texas St.,-7.2,-6.4,0.8
+Texas Tech,11.8,11.8,0.0
+Toledo,-1.4,-1.7,-0.3
+Troy,-6.0,-6.0,0.0
+Tulane,3.3,1.8,-1.5
+Tulsa,-15.6,-15.6,0.0
+UAB,-13.8,-13.8,0.0
+UCF,0.4,0.7,0.3
+UCLA,2.9,3.4,0.5
+UConn,-5.4,-5.4,0.0
+UL-Monroe,-14.6,-14.6,0.0
+UMass,-23.9,-22.7,1.2
+UNLV,-3.3,-1.9,1.4
+USC,11.0,9.6,-1.4
+USF,-3.5,-3.5,0.0
+UTEP,-16.1,-15.9,0.2
+UTSA,0.0,0.7,0.7
+Utah,11.0,10.5,-0.5
+Utah St.,-14.8,-15.0,-0.2
+Va. Tech,4.3,4.3,0.0
+Vanderbilt,1.7,1.7,0.0
+Virginia,-4.3,-1.0,3.3
+W. Virginia,1.0,1.0,0.0
+WKU,-5.8,-5.7,0.1
+WMU,-14.8,-14.7,0.1
+Wake Forest,-4.6,-4.6,0.0
+Wash. St.,-4.8,-4.8,0.0
+Washington,6.4,6.1,-0.3
+Wisconsin,7.2,6.8,-0.4
+Wyoming,-10.8,-10.3,0.5

--- a/scripts/update_sp_plus_from_odds.py
+++ b/scripts/update_sp_plus_from_odds.py
@@ -1,0 +1,190 @@
+import argparse
+import csv
+import json
+from statistics import NormalDist
+import re
+import unicodedata
+from difflib import get_close_matches
+from pathlib import Path
+
+HFA = 2.5
+SIGMA = 14.0  # spread-result error standard deviation
+
+# Manual mapping from odds team names to SP+ team names.
+# Keys are normalised forms with the mascot removed ("Army Black Knights" → "army black").
+TEAM_SYNONYMS = {
+    "appalachian state": "App. St.",
+    "army black": "Army",
+    "marshall thundering": "Marshall",
+    "mississippi state": "Miss. St.",
+    "old dominion": "ODU",
+    "penn state nittany": "Penn St.",
+    "san jose state": "SJSU",
+    "southern mississippi golden": "So. Miss",
+    "tcu horned": "TCU",
+    "central michigan": "CMU",
+    "eastern michigan": "EMU",
+    "western michigan": "WMU",
+    "florida atlantic": "FAU",
+    "georgia tech yellow": "Ga. Tech",
+    "hawaii rainbow": "Hawaii",
+    "jacksonville state": "J'ville St.",
+    "notre dame fighting": "Notre Dame",
+    "rutgers scarlet": "Rutgers",
+    "alabama crimson": "Alabama",
+    "duke blue": "Duke",
+    "illinois fighting": "Illinois",
+    "tulane green": "Tulane",
+    "western kentucky": "WKU",
+}
+
+
+def normalize(name: str) -> str:
+    """Return ASCII lowercase alphanumeric representation."""
+    name = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    name = name.lower().replace("&", "and")
+    name = re.sub(r"[^a-z0-9 ]+", "", name)
+    return re.sub(r"\s+", " ", name).strip()
+
+
+def load_sp_plus(path: str) -> dict:
+    """Return mapping of team name to SP+ rating."""
+    ratings = {}
+    with open(path) as f:
+        lines = [ln for ln in f.read().splitlines() if ln.strip()]
+    for line in lines[2:]:
+        parts = line.split(",")
+        m = re.match(r"\d+\.\s*(.+)", parts[0])
+        if not m:
+            continue
+        team = m.group(1)
+        try:
+            rating = float(parts[1])
+        except ValueError:
+            continue
+        ratings[team] = rating
+    return ratings
+
+
+def build_lookup(ratings: dict) -> dict:
+    """Return mapping of normalised name to SP+ team name."""
+    lookup = {}
+    for team in ratings:
+        key = normalize(team.replace("St.", "State"))
+        lookup[key] = team
+    return lookup
+
+
+def map_team(name: str, lookup: dict) -> str | None:
+    base = " ".join(name.split()[:-1])
+    key = normalize(base)
+    if key in TEAM_SYNONYMS:
+        return TEAM_SYNONYMS[key]
+    if key in lookup:
+        return lookup[key]
+    match = get_close_matches(key, lookup.keys(), n=1, cutoff=0.6)
+    if match:
+        return lookup[match[0]]
+    return None
+
+
+def american_to_prob(odds: int) -> float:
+    """Convert American odds to implied probability."""
+    if odds > 0:
+        return 100 / (odds + 100)
+    return -odds / (-odds + 100)
+
+
+def consensus_home_prob(event: dict) -> float | None:
+    probs = []
+    home = event["home_team"]
+    away = event["away_team"]
+    for bm in event.get("bookmakers", []):
+        for market in bm.get("markets", []):
+            if market.get("key") != "h2h":
+                continue
+            prices = {o["name"]: o.get("price") for o in market.get("outcomes", [])}
+            if home in prices and away in prices:
+                h = american_to_prob(int(prices[home]))
+                a = american_to_prob(int(prices[away]))
+                total = h + a
+                probs.append(h / total)
+            break
+    if not probs:
+        return None
+    return sum(probs) / len(probs)
+
+
+def prob_to_margin(prob: float) -> float:
+    """Convert win probability to point margin using normal assumption."""
+    prob = min(max(prob, 1e-6), 1 - 1e-6)
+    z = NormalDist().inv_cdf(prob)
+    return SIGMA * z
+
+
+def _aggregate_event_probs(events: list, lookup: dict) -> list[tuple[str, str, float]]:
+    """Return list of unique (home, away, home_prob) tuples averaged over duplicates."""
+    pairs: dict[tuple[str, str], list[float]] = {}
+    for ev in events:
+        home = map_team(ev["home_team"], lookup)
+        away = map_team(ev["away_team"], lookup)
+        if not home or not away:
+            continue
+        prob = consensus_home_prob(ev)
+        if prob is None:
+            continue
+        key = (home, away)
+        pairs.setdefault(key, []).append(prob)
+    out = []
+    for (home, away), probs in pairs.items():
+        out.append((home, away, sum(probs) / len(probs)))
+    return out
+
+
+def update_ratings(sp: dict, events: list, lookup: dict) -> dict:
+    new = sp.copy()
+    for home, away, home_prob in _aggregate_event_probs(events, lookup):
+        market_margin = prob_to_margin(home_prob)
+        rating_market = market_margin - HFA
+        h_old = new[home]
+        a_old = new[away]
+        diff_old = h_old - a_old
+        diff_new = 0.5 * diff_old + 0.5 * rating_market
+        avg = (h_old + a_old) / 2
+        new[home] = round(avg + diff_new / 2, 1)
+        new[away] = round(avg - diff_new / 2, 1)
+    return new
+
+
+def write_ratings(new: dict, old: dict, path: str) -> None:
+    rows = []
+    for team in sorted(new):
+        updated = new[team]
+        previous = old.get(team, float("nan"))
+        change = round(updated - previous, 1) if isinstance(previous, float) else ""
+        rows.append({"Team": team, "Previous_SP": previous, "Updated_SP": updated, "Change": change})
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["Team", "Previous_SP", "Updated_SP", "Change"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update SP+ ratings using market odds")
+    parser.add_argument("--sp_csv", default="data/raw/SP+20250615.csv", help="CSV file with SP+ ratings")
+    parser.add_argument("--odds_json", default="data/raw/college_football_games_2025-06-16.json", help="JSON file with game odds")
+    parser.add_argument("--output", default="outputs/Updated_SP_Plus.csv", help="Output CSV path")
+    args = parser.parse_args()
+
+    sp = load_sp_plus(args.sp_csv)
+    lookup = build_lookup(sp)
+    with open(args.odds_json) as f:
+        events = json.load(f)
+    updated = update_ratings(sp, events, lookup)
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    write_ratings(updated, sp, args.output)
+    print(f"Wrote updated ratings for {len(updated)} teams to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refine team name mapping for `update_sp_plus_from_odds.py`
- deduplicate game odds before updating ratings
- document script usage
- refresh generated ratings

## Testing
- `python3 scripts/update_sp_plus_from_odds.py --output outputs/Updated_SP_Plus.csv`


------
https://chatgpt.com/codex/tasks/task_e_68519ec9e574832a81795f5cf38de9c6