### PR TITLE
Add full 2026 roster CSV

### DIFF
--- a/outputs/teamcrafters_cfb26_final_complete.csv
+++ b/outputs/teamcrafters_cfb26_final_complete.csv
@@ -1,0 +1,9697 @@
+team_id,team_name,player_name,position,overall_rating
+623,Air Force,Payton Zdroik,DT,88
+623,Air Force,Dylan Carson,FB,87
+623,Air Force,Samuel Floysand,RT,87
+623,Air Force,Jace Sutulovich,RG,87
+623,Air Force,Costen Cooley,C,86
+623,Air Force,Quin Smith,WR,86
+623,Air Force,Gabriel Averitt,C,85
+623,Air Force,Owen Allen,FB,84
+623,Air Force,Bruin Fleischmann,TE,84
+623,Air Force,Trevor Tate,LT,84
+623,Air Force,Alec Falk,LG,83
+623,Air Force,Zach Van Miller,DT,82
+623,Air Force,Jack Burnett,C,81
+623,Air Force,Kyle Chen,SS,80
+623,Air Force,Jackson Adams,LOLB,80
+623,Air Force,Parker Menefee,TE,79
+623,Air Force,Zach Juckel,MLB,79
+623,Air Force,Amari Wilkerson,WR,79
+623,Air Force,Kemper Hodges,FB,78
+623,Air Force,Greg Flinn,DT,78
+623,Air Force,Terrence Gist,FB,77
+623,Air Force,Evan Rau,CB,77
+623,Air Force,Brody Bujnoch,MLB,77
+623,Air Force,Nathan Elwood,RT,76
+623,Air Force,Chances Carter Hill,LOLB,76
+623,Air Force,Houston Hendrix,FS,75
+623,Air Force,Tre Roberson,WR,75
+623,Air Force,Jayden Oquendo,DT,75
+623,Air Force,Seth Mcfarland,ROLB,75
+623,Air Force,Tj Tarascio,LG,74
+623,Air Force,Blake Fletcher,ROLB,73
+623,Air Force,Gage Spencer,RT,73
+623,Air Force,Levi Brown,FS,72
+623,Air Force,Daryl Slaughter,QB,72
+623,Air Force,Dallas Daley,ROLB,72
+623,Air Force,Eric Hull,SS,72
+623,Air Force,Tommy Forney,LOLB,72
+623,Air Force,Lukia Rawls Jr,DT,71
+623,Air Force,Korey Johnson,CB,70
+623,Air Force,Josh Johnson,QB,70
+623,Air Force,Josh Verner,WR,70
+623,Air Force,Liam Szarka,QB,69
+623,Air Force,Luke Freer,P,68
+623,Air Force,Nick Beckwith,CB,68
+623,Air Force,Damion Clinton,WR,68
+623,Air Force,Roman Knox,WR,68
+623,Air Force,Justin Harrington,CB,67
+623,Air Force,Leslie Rowe,MLB,67
+623,Air Force,Kurt Chesney,TE,65
+623,Air Force,T J Carter,CB,64
+623,Air Force,Jaylin Reese,LOLB,63
+623,Air Force,Corey Conrad,TE,63
+623,Air Force,Christopher Tuck Walker,MLB,62
+623,Air Force,Matthew Donaldson,CB,62
+623,Air Force,Jonathan Hoffman,TE,62
+623,Air Force,Hasaan Mccormick,FS,62
+623,Air Force,Leon Mcneal,WR,62
+623,Air Force,Eric Harrison,WR,61
+623,Air Force,Reagan Tubbs,K,60
+623,Air Force,Isaac Hubert,LOLB,60
+623,Air Force,Max Collins Davis,RG,59
+623,Air Force,Mike Kitchen,CB,59
+623,Air Force,Shamir Booth,LT,59
+623,Air Force,Brandon Samuel,MLB,58
+623,Air Force,Brendan Caldwell,MLB,57
+623,Air Force,Nathan Davis,MLB,52
+623,Air Force,Kimani Holmes,CB,52
+623,Air Force,Alex Thompson,LG,52
+623,Air Force,Kerry Stockton,ROLB,44
+624,Akron,Daniel Sheldon,RT,88
+624,Akron,Delvin Morris,C,84
+624,Akron,Ben Finley,QB,83
+624,Akron,Jake Newell,TE,82
+624,Akron,Israel Polk,WR,82
+624,Akron,Kiawan Murphy,DT,82
+624,Akron,Dayne Shor,LT,82
+624,Akron,Justin Anderson,SS,81
+624,Akron,Keylen Davis,LG,81
+624,Akron,Ben Kamara,CB,79
+624,Akron,Darrell Johnson Jr,LT,78
+624,Akron,Conner Cravaack,TE,77
+624,Akron,Max Mobley,C,77
+624,Akron,Ryan Oliver,LT,77
+624,Akron,Alex Adams,WR,76
+624,Akron,Maasai King,RT,76
+624,Akron,Aman Greenwood,CB,76
+624,Akron,Colin Lyons,RG,76
+624,Akron,Melvin Spriggs,ROLB,76
+624,Akron,Khalil Witherspoon,TE,76
+624,Akron,Gage Summers,MLB,75
+624,Akron,Shammond Cooper,ROLB,75
+624,Akron,Alex Branch,CB,75
+624,Akron,Mehki Flowers,FS,74
+624,Akron,Jaiden Brown Demery,LG,74
+624,Akron,Devin Reeves,LOLB,74
+624,Akron,Paul Davis,WR,74
+624,Akron,Jonas Mann,RT,73
+624,Akron,Rich Benenge,MLB,73
+624,Akron,Gavin James,MLB,73
+624,Akron,Max Whisner,TE,72
+624,Akron,Johnny Brookhart,QB,72
+624,Akron,Derrick Hoover,FS,72
+624,Akron,Austin Wondolowski,LOLB,72
+624,Akron,Brandon Hills,WR,72
+624,Akron,Dj Stepney,FS,71
+624,Akron,Iesa Jarmon,CB,71
+624,Akron,Tim Grear Jr,WR,70
+624,Akron,Ronald Hull,DT,70
+624,Akron,Emmet Rhoades,TE,70
+624,Akron,Pat Pope,FB,70
+624,Akron,Amarie Archer,RG,69
+624,Akron,Malcom Dewalt Iv,CB,69
+624,Akron,Tyquan Wallace,FS,69
+624,Akron,Dimarco Johnson,FS,68
+624,Akron,Myles Walker,WR,68
+624,Akron,Markus Boswell,ROLB,68
+624,Akron,Cameron Monteiro,WR,67
+624,Akron,Cameron Peek,LT,67
+624,Akron,Rodrick Hunter,SS,66
+624,Akron,Bryan Corbett,MLB,66
+624,Akron,Jamie Lucas,CB,65
+624,Akron,Brayden Roggow,QB,65
+624,Akron,Jayvon Goodwin,WR,65
+624,Akron,Jason Hocker,LOLB,63
+624,Akron,Cam Davidson,MLB,62
+624,Akron,Daymon David,SS,62
+624,Akron,Kevin Newberry,DT,61
+624,Akron,Alan Develin,RT,60
+624,Akron,Cibastian Broughton,QB,57
+624,Akron,Aj George,LG,57
+624,Akron,Adam Samaha,K,56
+624,Akron,Matthew Schramm,K,56
+624,Akron,Jean Louis Iii,WR,56
+624,Akron,Kenneth Mcmanus Iv,C,55
+624,Akron,Tavares Fletcher,WR,54
+624,Akron,Nick Stopiak,LT,54
+624,Akron,Joseph Castle,P,53
+624,Akron,Kerry Whitney,LG,53
+624,Akron,Owen Wiley,K,52
+624,Akron,Cameron Layman,DT,52
+624,Akron,Elijah Davis,DT,45
+625,Alabama,Ryan Williams,WR,95
+625,Alabama,Kadyn Proctor,LT,94
+625,Alabama,Parker Brailsford,C,94
+625,Alabama,Jaeden Roberts,RG,92
+625,Alabama,Tim Keenan Iii,DT,92
+625,Alabama,Bray Hubbard,SS,91
+625,Alabama,Deontae Lawson,LOLB,91
+625,Alabama,Isaiah Horton,WR,88
+625,Alabama,Germie Bernard,WR,88
+625,Alabama,Domani Jackson,CB,87
+625,Alabama,Nikhai Hill Green,MLB,87
+625,Alabama,Jah Marien Latham,ROLB,87
+625,Alabama,Keon Sabb,FS,85
+625,Alabama,Cam Calhoun,CB,85
+625,Alabama,Geno Vandemark,RG,85
+625,Alabama,Justin Jefferson,MLB,84
+625,Alabama,Dashawn Jones,CB,84
+625,Alabama,Josh Cuevas,TE,84
+625,Alabama,Qua Russaw,ROLB,83
+625,Alabama,Bubba Rodgers,RT,82
+625,Alabama,Peter Knudson,TE,82
+625,Alabama,Kam Dewberry,LG,80
+625,Alabama,Danny Lewis Jr,TE,79
+625,Alabama,Arkel Anugwom,RT,79
+625,Alabama,Zabien Brown,CB,78
+625,Alabama,Ty Simpson,QB,78
+625,Alabama,Austin Mack,QB,77
+625,Alabama,Cole Adams,WR,77
+625,Alabama,Casey Poe,LT,76
+625,Alabama,Dre Kirkpatrick Jr,SS,76
+625,Alabama,Kameron Howard,FS,76
+625,Alabama,Brody Dalton,TE,76
+625,Alabama,Wilkin Formby,RT,74
+625,Alabama,Zavier Mincey,FS,74
+625,Alabama,Drew Brandt,TE,74
+625,Alabama,Baker Hickman,LT,73
+625,Alabama,David Bird,TE,73
+625,Alabama,Tayveon Bennett,LOLB,72
+625,Alabama,Jalen Hale,WR,71
+625,Alabama,Dijon Lee Jr,CB,71
+625,Alabama,Roq Montgomery,C,71
+625,Alabama,Yhonzae Pierre,ROLB,71
+625,Alabama,Michael Carroll,RG,70
+625,Alabama,Jarrelle White,CB,70
+625,Alabama,Jaylen Mbakwe,WR,70
+625,Alabama,Liam Mcchambers,SS,70
+625,Alabama,Blake Doud,K,69
+625,Alabama,Hakim Taylor,MLB,69
+625,Alabama,Duke Johnson Ii,MLB,69
+625,Alabama,Joseph Ionata,C,69
+625,Alabama,Terrell Perry,LG,68
+625,Alabama,Mac Smith,LG,68
+625,Alabama,Derek Meadows,WR,67
+625,Alabama,Jack Sammarco,TE,66
+625,Alabama,Rico Scott,WR,65
+625,Alabama,Jaquan Sullivan,RT,64
+625,Alabama,Cayden Jones,LOLB,64
+625,Alabama,Olaus Alinen,LG,62
+625,Alabama,Kaleb Edwards,TE,62
+625,Alabama,Conor Talty,K,62
+625,Alabama,Bubba Hampton,WR,61
+625,Alabama,Keelon Russell,QB,60
+625,Alabama,Red Morgan,FS,60
+625,Alabama,David Franks Wilson,LT,59
+625,Alabama,Qb Reese,LOLB,59
+625,Alabama,Reid Schuback,K,57
+625,Alabama,Alex Asparuhov,P,55
+625,Alabama,William Sanders,LG,54
+625,Alabama,Noah Carter,ROLB,53
+625,Alabama,Abdul Winn,ROLB,52
+625,Alabama,Jeremiah Beaman,DT,45
+625,Alabama,Isaia Faga,DT,43
+626,Appalachian State,Dalton Stroman,WR,85
+626,Appalachian State,William Fowles,WR,84
+626,Appalachian State,Trent Ramsey,LG,82
+626,Appalachian State,Billy Wiles,QB,82
+626,Appalachian State,James Herbert,LT,82
+626,Appalachian State,Ethan Johnson,CB,81
+626,Appalachian State,Griffin Scroggs,LG,81
+626,Appalachian State,Aj Swann,QB,81
+626,Appalachian State,Michael Marotta,C,81
+626,Appalachian State,David Larkins,TE,80
+626,Appalachian State,Myles Farmer,FS,80
+626,Appalachian State,Shamarr Jackson,RT,80
+626,Appalachian State,Davion Dozier,WR,79
+626,Appalachian State,Kyle Arnholt,MLB,79
+626,Appalachian State,Michael Hetzel,WR,79
+626,Appalachian State,Will Flowers,C,79
+626,Appalachian State,Dj Burks,SS,77
+626,Appalachian State,Emory Floyd,CB,77
+626,Appalachian State,Ja Den Mcburrows,CB,76
+626,Appalachian State,Thomas Davis,LOLB,76
+626,Appalachian State,Izayah Cummings,TE,76
+626,Appalachian State,Jaden Barnes,WR,76
+626,Appalachian State,Jared Gibble,TE,76
+626,Appalachian State,Phillip Pemberton,DT,75
+626,Appalachian State,Jordan Favors,SS,74
+626,Appalachian State,Dylan Hasz,CB,74
+626,Appalachian State,Jj Kohl,QB,74
+626,Appalachian State,Trenton Kinney,MLB,74
+626,Appalachian State,Danny Stevens,RG,74
+626,Appalachian State,Zyeir Gamble,FS,73
+626,Appalachian State,Brayshawn Littlejohn,ROLB,73
+626,Appalachian State,Chris Lawson Jr,WR,73
+626,Appalachian State,Colton Phares,ROLB,73
+626,Appalachian State,Kevin Morrison,FB,73
+626,Appalachian State,Jayden Ramsey,RG,72
+626,Appalachian State,Cristian Conyer,CB,72
+626,Appalachian State,Elijah Mc Cantos,CB,72
+626,Appalachian State,Kanen Hamlett,TE,72
+626,Appalachian State,Gabriel Simpkins,TE,72
+626,Appalachian State,Jackson Grier,WR,72
+626,Appalachian State,Bucci Farmer,DT,71
+626,Appalachian State,Rondarius Porter,DT,71
+626,Appalachian State,Luke Burgess,RT,70
+626,Appalachian State,Jayden Bethea,MLB,70
+626,Appalachian State,Cayden Sweatt,C,70
+626,Appalachian State,Jack Kelly,TE,70
+626,Appalachian State,Clayton Hughes,RG,69
+626,Appalachian State,Levi Dodson,ROLB,68
+626,Appalachian State,Kaden Ellis,DT,68
+626,Appalachian State,Noah Gillon,QB,67
+626,Appalachian State,Kayleb Williams,RG,67
+626,Appalachian State,Cameren Fleming,SS,66
+626,Appalachian State,Juan Berchal,CB,66
+626,Appalachian State,Tom Bean,K,65
+626,Appalachian State,Tyshawn Sanders,CB,65
+626,Appalachian State,Aj Mebane,LOLB,65
+626,Appalachian State,Dillon Galloway,TE,64
+626,Appalachian State,Kaleb Neal,FS,63
+626,Appalachian State,Patrick Loomis,C,62
+626,Appalachian State,Ja Torian Mack,SS,61
+626,Appalachian State,Matthew Wilson,QB,60
+626,Appalachian State,Aaron Talley,LOLB,60
+626,Appalachian State,Alex Sanchez,WR,60
+626,Appalachian State,Moritz Schmoranzer,LG,59
+626,Appalachian State,Lance Williams,LG,58
+626,Appalachian State,Jackson Moore,K,57
+626,Appalachian State,Mitchell Lake,P,56
+626,Appalachian State,D J Watkins Ellis,DT,56
+626,Appalachian State,Jaleel Freeman,ROLB,54
+626,Appalachian State,Ian Ratliff,P,46
+626,Appalachian State,Cash Mcvay,K,44
+627,Arizona,Noah Fifita,QB,87
+627,Arizona,Max Harris,MLB,87
+627,Arizona,Luke Wysong,WR,86
+627,Arizona,Dalton Johnson,SS,85
+627,Arizona,Kris Hutson,WR,85
+627,Arizona,Ayden Garnes,CB,85
+627,Arizona,Keyan Burnett,TE,84
+627,Arizona,Taye Brown,MLB,84
+627,Arizona,Chubba Ma Ae,LG,84
+627,Arizona,Jay Vion Cole,CB,83
+627,Arizona,Shancco Matautia,C,83
+627,Arizona,Treydan Stukes,CB,82
+627,Arizona,Michael Dansby,CB,82
+627,Arizona,Tiaoalii Savea,DT,81
+627,Arizona,Ka Ena Decambra,RG,81
+627,Arizona,Braedyn Locke,QB,80
+627,Arizona,Rhino Tapa Atoutai,LT,80
+627,Arizona,Michael Wooten,LT,79
+627,Arizona,Marquis Groves Killebrew,CB,78
+627,Arizona,Chris Hunter,WR,78
+627,Arizona,Ty Buchanan,RT,78
+627,Arizona,Chase Kennedy,ROLB,78
+627,Arizona,Sam Olson,TE,77
+627,Arizona,Riley Wilson,ROLB,77
+627,Arizona,David Crocker,LT,77
+627,Arizona,Jeremiah Patterson,WR,76
+627,Arizona,Alexander Doost,LG,76
+627,Arizona,Cameron Barmore,TE,76
+627,Arizona,Jshawn Frausto Ramos,CB,75
+627,Arizona,Johno Price,CB,75
+627,Arizona,Jarra Anderson,DT,75
+627,Arizona,Matthew Lado,RT,75
+627,Arizona,Genesis Smith,FS,74
+627,Arizona,Tre Spivey,WR,74
+627,Arizona,Isaac Perez,C,74
+627,Arizona,Devin Hyatt,WR,74
+627,Arizona,Leviticus Su A,MLB,74
+627,Arizona,Blake Gotcher,ROLB,74
+627,Arizona,Jack Luttrell,FS,72
+627,Arizona,Myron Robinson,ROLB,71
+627,Arizona,Jayln Harris,SS,71
+627,Arizona,Paul Clayton,P,71
+627,Arizona,Jake Klein,QB,70
+627,Arizona,Julian Savaiinaea,DT,70
+627,Arizona,Kellan Ford,TE,68
+627,Arizona,Carter Jones,MLB,68
+627,Arizona,Caleb Poole,FB,67
+627,Arizona,Dan Howard,C,67
+627,Arizona,Tommy Trout,QB,66
+627,Arizona,Isaiah Mizell,WR,66
+627,Arizona,Joe Sprinkle,FB,66
+627,Arizona,Gio Richardson,WR,65
+627,Arizona,Byron Hill,RT,65
+627,Arizona,Denzel White,LG,65
+627,Arizona,Rex Haynes,WR,65
+627,Arizona,Dajon Hinton,CB,64
+627,Arizona,Gavin Hunter,SS,64
+627,Arizona,Tyler Powell,TE,63
+627,Arizona,Frank Goodwin,RG,63
+627,Arizona,Oscar Burris,FS,63
+627,Arizona,Zach Rice,TE,62
+627,Arizona,Grayson Stovall,C,62
+627,Arizona,Leroy Palu,DT,62
+627,Arizona,Junior Sampson,RG,62
+627,Arizona,Jordan Brown,RG,62
+627,Arizona,Michael Salgado Medina,K,61
+627,Arizona,Terrance Parham,DT,60
+627,Arizona,Brandon Craddock,LOLB,59
+627,Arizona,Tristan Bounds,RT,58
+627,Arizona,Keona Peat,C,53
+627,Arizona,Tyler Mustain,LOLB,52
+627,Arizona,Sawyer Anderson,QB,50
+627,Arizona,Stacy Bey,LOLB,49
+627,Arizona,Josh Farris,K,49
+628,Arizona State,Jordyn Tyson,WR,94
+628,Arizona State,Ben Coleman,C,92
+628,Arizona State,Sam Leavitt,QB,91
+628,Arizona State,Xavion Alford,SS,91
+628,Arizona State,Jalen Moss,WR,89
+628,Arizona State,Max Iheanachor,RT,89
+628,Arizona State,Jimeto Obigbo,LG,89
+628,Arizona State,Chamon Metayer,TE,88
+628,Arizona State,Jordan Crook,ROLB,87
+628,Arizona State,Keyshaun Elliott,ROLB,86
+628,Arizona State,Jacob Rich Kongaika,DT,86
+628,Arizona State,Josh Atkins,LT,86
+628,Arizona State,C J Fite,DT,85
+628,Arizona State,Myles Rowser,FS,85
+628,Arizona State,Javan Robinson,CB,85
+628,Arizona State,Zyrus Fiaseu,MLB,85
+628,Arizona State,Tate Romney,ROLB,83
+628,Arizona State,Sean Na A,LG,83
+628,Arizona State,Ben Harrison,RG,83
+628,Arizona State,Malik Mcclain,WR,82
+628,Arizona State,Jeff Sims,QB,81
+628,Arizona State,Cameron Harpole,TE,81
+628,Arizona State,Keith Abney Ii,CB,80
+628,Arizona State,Nyland Green,CB,80
+628,Arizona State,Blazen Lono Wong,DT,80
+628,Arizona State,Khamari Anderson,TE,77
+628,Arizona State,Jalen Klemm,LT,77
+628,Arizona State,Adrian Wilson,FS,76
+628,Arizona State,My Keil Gardner,DT,76
+628,Arizona State,Noble Johnson,WR,76
+628,Arizona State,Zac Swanson,DT,75
+628,Arizona State,Kyndrich Breedlove,CB,75
+628,Arizona State,Martell Hughes,ROLB,75
+628,Arizona State,Rashad Mckenzie,DT,75
+628,Arizona State,Derek Eusebio,WR,73
+628,Arizona State,Krew Jackson,MLB,72
+628,Arizona State,Al Sieczkowski,LT,72
+628,Arizona State,Aj Ia,TE,72
+628,Arizona State,Tyler Wigglesworth,TE,72
+628,Arizona State,Nathan Matthews,C,71
+628,Arizona State,Plas Johnson,CB,69
+628,Arizona State,Jesus Gomez,K,68
+628,Arizona State,Tony Louis Nkuba,CB,68
+628,Arizona State,Isaiah Iosefa,LOLB,68
+628,Arizona State,Kyan Mcdonald,FS,68
+628,Arizona State,Jaren Hamilton,WR,66
+628,Arizona State,Rodney Bimage Jr,CB,66
+628,Arizona State,Michael Tollefson,QB,65
+628,Arizona State,Harry Hassmann,WR,65
+628,Arizona State,Champ Westbrooks,RT,65
+628,Arizona State,Ian Hershey,P,64
+628,Arizona State,Maurice Williams Ii,FS,64
+628,Arizona State,Makua Pule,C,64
+628,Arizona State,Cory Butler Jr,WR,63
+628,Arizona State,Chris Johnson Ii,CB,63
+628,Arizona State,Reggie Hadley,FB,63
+628,Arizona State,Kanyon Floyd,P,62
+628,Arizona State,Terrell Kim,RG,62
+628,Arizona State,Kyle Scott,RG,61
+628,Arizona State,Montana Warren,SS,61
+628,Arizona State,Cary Thornhill,RT,61
+628,Arizona State,Uriah Neloms,WR,60
+628,Arizona State,Desean Bryant Jr,C,60
+628,Arizona State,Jayden Fortier,TE,59
+628,Arizona State,Navi Bruzon,QB,57
+628,Arizona State,Cameron Dyer,QB,55
+628,Arizona State,Manamo Ui Muti,LT,55
+628,Arizona State,Maki Stewart,RG,55
+628,Arizona State,Remy Archer,RT,54
+628,Arizona State,Albert Smith Iii,LOLB,54
+628,Arizona State,Joey Su A,LG,53
+628,Arizona State,Russ Mitchell,MLB,53
+628,Arizona State,Ja Mario Van Dyke,SS,53
+628,Arizona State,Carston Kieffer,K,49
+629,Arkansas,Fernando Carmona,LG,92
+629,Arkansas,O Mega Blake,WR,87
+629,Arkansas,Taylen Green,QB,86
+629,Arkansas,Cameron Ball,DT,85
+629,Arkansas,Kani Walker,CB,85
+629,Arkansas,Jordan Young,CB,84
+629,Arkansas,Xavian Sorey Jr,MLB,84
+629,Arkansas,Jj Hollingsworth,DT,84
+629,Arkansas,Jaheim Singletary,CB,83
+629,Arkansas,Raylen Sharpe,WR,83
+629,Arkansas,David Oke,DT,83
+629,Arkansas,Larry Worth Iii,SS,82
+629,Arkansas,Kam Shanks,WR,82
+629,Arkansas,Selman Bridges,CB,82
+629,Arkansas,Caden Kitler,C,82
+629,Arkansas,Andreas Paaske,TE,82
+629,Arkansas,Corey Robinson Ii,LT,81
+629,Arkansas,Danny Saili,DT,80
+629,Arkansas,Ismael Cisse,WR,79
+629,Arkansas,Stephen Dix Jr,ROLB,78
+629,Arkansas,Miguel Mitchell,FS,78
+629,Arkansas,Caleb Wooden,FS,77
+629,Arkansas,Jordan Anthony,WR,77
+629,Arkansas,Keyshawn Blackstock,RG,77
+629,Arkansas,Julian Neal,CB,77
+629,Arkansas,Ian Geffrard,DT,76
+629,Arkansas,Rohan Jones,TE,75
+629,Arkansas,Bryce Stephens,WR,75
+629,Arkansas,Kobe Branham,RG,75
+629,Arkansas,Keshawn Davila,CB,75
+629,Arkansas,Jalen Brown,WR,74
+629,Arkansas,Shaq Mcroy,RT,74
+629,Arkansas,Trever Jackson,QB,74
+629,Arkansas,Andy Jean,WR,74
+629,Arkansas,Brooks Edmonson,C,74
+629,Arkansas,Quentavius Scandrett,SS,73
+629,Arkansas,Tavion Wallace,ROLB,73
+629,Arkansas,Bradley Shaw,MLB,73
+629,Arkansas,Preston Davis,MLB,73
+629,Arkansas,Courtney Crutchfield,WR,72
+629,Arkansas,Tim Dawn,C,72
+629,Arkansas,Devin Bale,P,71
+629,Arkansas,Marcus Dumervil,RT,70
+629,Arkansas,Kevin Oatis,DT,69
+629,Arkansas,Kaleb James,DT,69
+629,Arkansas,Kash Courtney,LG,68
+629,Arkansas,Keiundre Johnson,ROLB,68
+629,Arkansas,Reginald Colebrook,DT,67
+629,Arkansas,Ashton Ngo,TE,67
+629,Arkansas,Darius Rison,FB,67
+629,Arkansas,Terryon Reno,TE,67
+629,Arkansas,Jaden Platt,TE,66
+629,Arkansas,E Marion Harris,RT,66
+629,Arkansas,Erick Cranford,FS,66
+629,Arkansas,Ja Kayden Ferguson,WR,66
+629,Arkansas,Cj Brown,WR,66
+629,Arkansas,Gavin Rush,P,65
+629,Arkansas,Grayson Wilson,QB,65
+629,Arkansas,Wyatt Simmons,MLB,65
+629,Arkansas,Taijh Overton,FS,65
+629,Arkansas,Jaden Allen,CB,64
+629,Arkansas,Max Schmidly,TE,63
+629,Arkansas,Derrius Kidwell,LOLB,62
+629,Arkansas,Bubba Craig,LG,61
+629,Arkansas,Blake Cherry,RG,59
+629,Arkansas,Kj Jackson,QB,58
+629,Arkansas,Blake Ford,K,58
+629,Arkansas,Ahkhari Johnson,FS,57
+629,Arkansas,Scott Starzyk,K,56
+629,Arkansas,Justin Logan,ROLB,55
+629,Arkansas,Jameson Woodrow,MLB,48
+629,Arkansas,Kavion Broussard,LT,44
+630,Arkansas State,Corey Rucker,WR,87
+630,Arkansas State,Wil Saxton,LG,87
+630,Arkansas State,Ag Mcghee,FS,85
+630,Arkansas State,Jaylen Raynor,QB,83
+630,Arkansas State,Quincy Wright,DT,83
+630,Arkansas State,Noah Smith,RT,83
+630,Arkansas State,Avante Dickerson,CB,82
+630,Arkansas State,Ethan Crawford,QB,82
+630,Arkansas State,Devyn Curtis,MLB,82
+630,Arkansas State,Nana Burris,WR,81
+630,Arkansas State,Tristian Smith,RG,80
+630,Arkansas State,Chris Boti,DT,79
+630,Arkansas State,Javante Mackey,MLB,79
+630,Arkansas State,Riley Mcgehee,LT,79
+630,Arkansas State,Austin Woods,RG,78
+630,Arkansas State,Hayden O Neal,ROLB,77
+630,Arkansas State,Trenton Alan Yowe,CB,76
+630,Arkansas State,Kyle Taylor,ROLB,76
+630,Arkansas State,Daniel Demery,FS,75
+630,Arkansas State,Gabe Fortson,C,75
+630,Arkansas State,Hunter Summers,WR,75
+630,Arkansas State,Cameron Ambrose,RT,75
+630,Arkansas State,Jj Harrell,WR,74
+630,Arkansas State,Damarcco Blanton,WR,74
+630,Arkansas State,Brandon Greil,FS,73
+630,Arkansas State,Noah Hacker,LT,73
+630,Arkansas State,Aaron Alexander,ROLB,72
+630,Arkansas State,James Reed Iii,CB,72
+630,Arkansas State,Zuri Madison,LG,72
+630,Arkansas State,Aleric Watson,RT,72
+630,Arkansas State,Trevon Howard,SS,71
+630,Arkansas State,Brandon Barnes Jr,FS,71
+630,Arkansas State,Sean Martin,LOLB,70
+630,Arkansas State,Rashaun Coleman,QB,70
+630,Arkansas State,Tyler Little,TE,70
+630,Arkansas State,Alexander Greene,MLB,70
+630,Arkansas State,Cody Sigler,DT,70
+630,Arkansas State,Jordan Sample,LOLB,70
+630,Arkansas State,Chace Stratford,LT,70
+630,Arkansas State,Erik Coakley Hall,FB,70
+630,Arkansas State,Isaiah Hornsby,CB,69
+630,Arkansas State,Chase Bogle,MLB,69
+630,Arkansas State,Jimmy Spillman,CB,68
+630,Arkansas State,Cade Channell,LT,68
+630,Arkansas State,Malekhi Weedon,FS,68
+630,Arkansas State,Walker Davis,C,68
+630,Arkansas State,Clune Van Andel,K,67
+630,Arkansas State,Alex Colbert,P,67
+630,Arkansas State,Chauncy Cobb,WR,67
+630,Arkansas State,Mason Myers,C,67
+630,Arkansas State,Luke Wisham,SS,66
+630,Arkansas State,Evan Brown,FS,66
+630,Arkansas State,Drew Nicolson,TE,66
+630,Arkansas State,Simeon Mitchell,DT,65
+630,Arkansas State,Timothy Gulley,DT,65
+630,Arkansas State,Cedric Franklin Ii,SS,65
+630,Arkansas State,Josh Stone,CB,65
+630,Arkansas State,Kemari Nix,LOLB,65
+630,Arkansas State,Javeon Fricks,TE,64
+630,Arkansas State,Nigel Nelson,ROLB,64
+630,Arkansas State,Tyler Fortenberry,TE,63
+630,Arkansas State,Pat Fargas,ROLB,63
+630,Arkansas State,Trason Hunt,LG,63
+630,Arkansas State,Romel Stevens,WR,62
+630,Arkansas State,Ryan Rivers,QB,59
+630,Arkansas State,Dan Tay Ward Jr,RT,59
+630,Arkansas State,Clayton Amaya,K,55
+630,Arkansas State,Rodd Curtis,RG,54
+630,Arkansas State,Jabari Bush,TE,52
+630,Arkansas State,Josh Flowers,QB,49
+631,Army,Brady Small,C,90
+631,Army,Will Jeffcoat,LG,87
+631,Army,Ned Brady,LT,87
+631,Army,Casey Larkin,FS,86
+631,Army,Tanner Bivins,RG,86
+631,Army,Kody Harris Miller,DT,85
+631,Army,Jake Rendina,FB,85
+631,Army,Liam Fortner,WR,85
+631,Army,Kalib Fortner,MLB,83
+631,Army,Jaydan Mayes,CB,83
+631,Army,Jarel Dickson,FB,83
+631,Army,Gavin Shields,FS,83
+631,Army,Christian Yousefzadeh,ROLB,83
+631,Army,Markus Timmons,DT,83
+631,Army,Andon Thomas,MLB,82
+631,Army,Lavar Thompson,RT,82
+631,Army,Noah Short,WR,81
+631,Army,Justin Weaver,CB,81
+631,Army,Collin Matteson,SS,81
+631,Army,Eric Ford,LOLB,81
+631,Army,Cj Martin,CB,80
+631,Army,Aj Williams,FB,80
+631,Army,Parker Poloskey,TE,80
+631,Army,Jacob Tuioti,DT,79
+631,Army,Lane Parks,C,79
+631,Army,Noah Nixon,MLB,79
+631,Army,Isaiah Birl,LOLB,78
+631,Army,Tobi Olawole,WR,78
+631,Army,Baylor Newsom,MLB,77
+631,Army,Samari Howard,WR,77
+631,Army,Duane Walker,LG,77
+631,Army,Dewayne Coleman,QB,76
+631,Army,Tyler Lee,LG,76
+631,Army,Braden Bartosh,LG,75
+631,Army,Christopher Williams,FS,75
+631,Army,Brandon Wraalstad,RG,75
+631,Army,Dillon Stowers,DT,75
+631,Army,Nick Hadley,RT,75
+631,Army,Lloyd Benson Iii,WR,75
+631,Army,Zach Mundell,QB,74
+631,Army,Caden Brungard,MLB,74
+631,Army,Kyle Kloska,C,73
+631,Army,Cole Searight,CB,73
+631,Army,Matt Board,C,73
+631,Army,Brennan Fisher,MLB,73
+631,Army,Phil Timmerman,LG,72
+631,Army,Jabril Williams,CB,72
+631,Army,Kavon Pointer,WR,72
+631,Army,Ish Taylor,CB,71
+631,Army,Isaiah Jackson,LT,71
+631,Army,Dallas Traylor,SS,71
+631,Army,Jaxon Hammond,CB,70
+631,Army,Larry Pickett Jr,FS,70
+631,Army,Caleb Williams,SS,69
+631,Army,Cale Hellums,QB,69
+631,Army,Devan Moss,CB,69
+631,Army,Robert Houston,CB,67
+631,Army,Brendan Owens,SS,66
+631,Army,Ethan Washington,QB,65
+631,Army,Brian Dyer,TE,65
+631,Army,Myles Wright,TE,64
+631,Army,Daniel Ogordi,SS,62
+631,Army,Owen Walter,TE,62
+631,Army,James Wagenseller,P,60
+631,Army,Randy Farris,TE,60
+631,Army,Shane Pelton,C,60
+631,Army,Anderson Britton,K,52
+631,Army,Dawson Jones,K,51
+631,Army,Cooper Allan,P,50
+632,Auburn,Eric Singleton Jr,WR,92
+632,Auburn,Cam Coleman,WR,89
+632,Auburn,Connor Lew,C,88
+632,Auburn,Mason Murphy,RT,88
+632,Auburn,Raion Strader,CB,87
+632,Auburn,Dillon Wade,LG,87
+632,Auburn,Xavier Chaplin,LT,87
+632,Auburn,Kayin Lee,CB,85
+632,Auburn,Jeremiah Wright,RG,85
+632,Auburn,Jackson Arnold,QB,84
+632,Auburn,Rayshawn Pleasant,CB,84
+632,Auburn,Preston Howard,TE,83
+632,Auburn,Brandon Frazier,TE,83
+632,Auburn,Jay Hardy,DT,82
+632,Auburn,Robert Woodyard Jr,MLB,82
+632,Auburn,Dallas Walker,DT,81
+632,Auburn,Horatio Fields,WR,81
+632,Auburn,Ashton Daniels,QB,80
+632,Auburn,Caleb Wheatland,MLB,80
+632,Auburn,Tate Johnson,TE,80
+632,Auburn,Malik Blocton,DT,79
+632,Auburn,Izavion Miller,LT,79
+632,Auburn,Demarcus Riddick,ROLB,79
+632,Auburn,Jay Crawford,CB,78
+632,Auburn,Malcolm Simmons,WR,78
+632,Auburn,Paul Thompson Jr,SS,78
+632,Auburn,Kaleb Harris,SS,76
+632,Auburn,Jahquez Robinson,SS,76
+632,Auburn,Seth Wilfred,RG,76
+632,Auburn,Reed Hughes,TE,76
+632,Auburn,Quientrail Jamison Travis,DT,75
+632,Auburn,Taye Seymore,FS,75
+632,Auburn,Doug Stein,K,74
+632,Auburn,Coleman Granberry,MLB,74
+632,Auburn,Alexander Reeves,FS,73
+632,Auburn,Tyler Johnson,RT,73
+632,Auburn,Eric Winters,SS,73
+632,Auburn,Broderick Shull,RT,73
+632,Auburn,Malik Autry,DT,72
+632,Auburn,Champ Anthony,CB,72
+632,Auburn,Xavier Atkins,ROLB,71
+632,Auburn,Kail Ellis,C,71
+632,Auburn,Zykeivous Walker,DT,70
+632,Auburn,Anquon Fegans,FS,70
+632,Auburn,Bryce Deas,MLB,70
+632,Auburn,Blake Woodby,CB,69
+632,Auburn,Kensley Louidor Faustin,FS,69
+632,Auburn,Bryce Cain,WR,69
+632,Auburn,Perry Thompson,WR,68
+632,Auburn,Elijah Melendez,MLB,68
+632,Auburn,Donovan Starr,CB,67
+632,Auburn,Jakaleb Faulk,ROLB,67
+632,Auburn,Clay Wedin,RG,67
+632,Auburn,Allen Patton,P,66
+632,Auburn,Hollis Davidson,TE,66
+632,Auburn,Rich Goldstein,FB,66
+632,Auburn,Tai Buster,LT,65
+632,Auburn,Jacobe Ward,LG,64
+632,Auburn,Harrison Clemmer,C,64
+632,Auburn,Hudson Kaak,P,63
+632,Auburn,Dylan Senda,C,63
+632,Auburn,Alex Mcpherson,K,62
+632,Auburn,Jourdin Crawford,DT,62
+632,Auburn,Jamonta Waller,LOLB,62
+632,Auburn,Towns Mcgough,K,61
+632,Auburn,Sam Turner,WR,61
+632,Auburn,Ed Backus,LT,60
+632,Auburn,D J Barber,ROLB,59
+632,Auburn,A Mon Lane Ganus,CB,58
+632,Auburn,Dwight Westerman,K,56
+632,Auburn,Deuce Knight,QB,55
+632,Auburn,Joe Phillips,LOLB,51
+632,Auburn,Deandre Carter,LG,45
+633,Ball State,Carey Robinson,RG,90
+633,Ball State,Seth Bolton,RG,88
+633,Ball State,Chris Hood,LT,84
+633,Ball State,Jack Beebe,ROLB,81
+633,Ball State,Jalon Jones,CB,80
+633,Ball State,Darin Conley,DT,79
+633,Ball State,Cole Mosier,C,78
+633,Ball State,Nick Presley,WR,78
+633,Ball State,Maximus Webster,TE,77
+633,Ball State,Ty Robinson,WR,77
+633,Ball State,Alfred Chea,ROLB,77
+633,Ball State,Qian Magwood,WR,76
+633,Ball State,Hunter Sanderson,DT,76
+633,Ball State,Willizhuan Yates,CB,75
+633,Ball State,Otto Hess,C,75
+633,Ball State,Luke Dalton,LG,75
+633,Ball State,Roman Pearson,CB,75
+633,Ball State,Zach Bandy,LG,75
+633,Ball State,Joey Stemler,MLB,74
+633,Ball State,Elisha Durham,WR,74
+633,Ball State,Eric Weatherly,WR,73
+633,Ball State,Ameir Glenn,DT,73
+633,Ball State,Jamarion Mcdougle,WR,73
+633,Ball State,Jahmad Harmon,CB,73
+633,Ball State,Brandon Blackburn,LT,73
+633,Ball State,Drew Hughes,DT,72
+633,Ball State,Caden Britton,TE,72
+633,Ball State,Avery Stuart,FS,72
+633,Ball State,Michael Gravely Jr,SS,71
+633,Ball State,Jackson Wiegold,MLB,71
+633,Ball State,Caden Johnson,MLB,71
+633,Ball State,Zavier Simpson,LOLB,71
+633,Ball State,Cole Earlewine,SS,71
+633,Ball State,Dahya Patel,WR,71
+633,Ball State,Kiael Kelly,QB,70
+633,Ball State,Eric Mcclain,CB,70
+633,Ball State,Isaac Lucas,RG,70
+633,Ball State,Tristan Cook,RT,70
+633,Ball State,Deondre Shepherd,FS,69
+633,Ball State,Cody Smith,RT,69
+633,Ball State,Antwan Fraser,LOLB,68
+633,Ball State,Jackson Constantine,LG,68
+633,Ball State,Ashton Whitner,LOLB,67
+633,Ball State,Grant Haworth,C,67
+633,Ball State,Garrick Yancey,FS,66
+633,Ball State,Brock Williams,TE,66
+633,Ball State,Glenn Matlock Bell,LT,66
+633,Ball State,Scott Hudson,DT,66
+633,Ball State,Will Windsor,RG,66
+633,Ball State,Isaiah Thacker,WR,66
+633,Ball State,Alex Kozan,TE,65
+633,Ball State,Derek Fields,FS,65
+633,Ball State,Walter Taylor Iii,QB,64
+633,Ball State,Kyle Winters,C,64
+633,Ball State,Oscar Sheldon,SS,63
+633,Ball State,Joe Graves,K,62
+633,Ball State,Keith Knoll,LG,62
+633,Ball State,Chris Redfield,RT,61
+633,Ball State,Jackson Ruess,RG,61
+633,Ball State,Trey Firestone,WR,61
+633,Ball State,Cole Stumbaugh,P,59
+633,Ball State,Bobby Scroggins,LT,59
+633,Ball State,Brenton Geathers,TE,57
+633,Ball State,Jordan Suggs,CB,57
+633,Ball State,Carson Holmer,K,55
+633,Ball State,Zac Raymont,MLB,54
+633,Ball State,Aidan Leffler,QB,54
+633,Ball State,J T Branch,FB,53
+633,Ball State,Bodie Derrer,QB,47
+645,Coastal Carolina,Luke Murphy,MLB,85
+645,Coastal Carolina,Wyatt Gedeon,MLB,84
+645,Coastal Carolina,Thomas Johnson,C,84
+645,Coastal Carolina,Malcolm Gillie,WR,84
+645,Coastal Carolina,Shane Bruce,ROLB,84
+645,Coastal Carolina,Jameson Tucker,WR,83
+645,Coastal Carolina,Cane Berrong,TE,83
+645,Coastal Carolina,Tray Brown,MLB,83
+645,Coastal Carolina,Abraham Temoney Iii,SS,81
+645,Coastal Carolina,Darrion Henry Young,DT,81
+645,Coastal Carolina,Heston Edwards,LG,81
+645,Coastal Carolina,Anthony Walton,RG,81
+645,Coastal Carolina,Nick Del Grande,LT,80
+645,Coastal Carolina,Lionell Whitaker,CB,80
+645,Coastal Carolina,Dominic Rijos,LT,80
+645,Coastal Carolina,Emmett Brown,QB,79
+645,Coastal Carolina,Zach Courtney,TE,79
+645,Coastal Carolina,Tad Hudson,QB,79
+645,Coastal Carolina,Sawyer Goram Welch,DT,78
+645,Coastal Carolina,Mj Morris,QB,78
+645,Coastal Carolina,Xamarion Gordon,SS,78
+645,Coastal Carolina,Joseph Hanson,RT,78
+645,Coastal Carolina,Dre Pinckney,SS,77
+645,Coastal Carolina,Ja Marion Wayne,WR,76
+645,Coastal Carolina,Brooks Johnson,TE,76
+645,Coastal Carolina,Aamarii Notice,DT,76
+645,Coastal Carolina,Larry Garfield,QB,75
+645,Coastal Carolina,Malick Meiga,WR,75
+645,Coastal Carolina,Julius Tate,RG,75
+645,Coastal Carolina,Roquan Barber,QB,74
+645,Coastal Carolina,Jeffrey Ugochukwu,CB,74
+645,Coastal Carolina,Myles Mooyoung,CB,74
+645,Coastal Carolina,Dante Thomas,FS,73
+645,Coastal Carolina,Bryson Graves,WR,73
+645,Coastal Carolina,Se Von Mcdowell,ROLB,73
+645,Coastal Carolina,Fredd Adams,CB,73
+645,Coastal Carolina,Brayson Mciver,C,73
+645,Coastal Carolina,Jayden Jackson,CB,73
+645,Coastal Carolina,Avyonne Jones,FS,72
+645,Coastal Carolina,Walt Gray,MLB,72
+645,Coastal Carolina,Matt Woodley,DT,72
+645,Coastal Carolina,Cameron Wright,WR,71
+645,Coastal Carolina,Dontae Lunan,ROLB,71
+645,Coastal Carolina,Kain Mcdonald,LG,71
+645,Coastal Carolina,Xavier Mcintyre,FS,71
+645,Coastal Carolina,Geajorm Akpaloo,MLB,71
+645,Coastal Carolina,Nate Merchant,TE,71
+645,Coastal Carolina,Tray Franklin,RT,70
+645,Coastal Carolina,Robby Washington,CB,70
+645,Coastal Carolina,Daniel Jones,LT,69
+645,Coastal Carolina,Joshua Campbell,RG,69
+645,Coastal Carolina,Trishstin Glass,WR,68
+645,Coastal Carolina,Myles Woods,CB,67
+645,Coastal Carolina,O J O Neal,WR,67
+645,Coastal Carolina,John Kirkpatrick,TE,67
+645,Coastal Carolina,Xakery Wiedner,WR,66
+645,Coastal Carolina,Cameron Avery,LOLB,66
+645,Coastal Carolina,Trevard Luck,LG,65
+645,Coastal Carolina,Zach Cody,CB,64
+645,Coastal Carolina,Cade Adams,RG,64
+645,Coastal Carolina,Chase Jackson,SS,64
+645,Coastal Carolina,Deshawn Bush,FB,62
+645,Coastal Carolina,Parker Jennings,FS,62
+645,Coastal Carolina,Seth Byron,MLB,62
+645,Coastal Carolina,Nate Gregory,ROLB,62
+645,Coastal Carolina,Juan Bentley,LT,61
+645,Coastal Carolina,Emile Sebafundi,P,60
+645,Coastal Carolina,Jamichael Pritchett,SS,56
+645,Coastal Carolina,Nick Rudd Johnson,FS,55
+645,Coastal Carolina,Haden Tessier,K,54
+645,Coastal Carolina,Mack West,P,53
+645,Coastal Carolina,Travis Nesbitt,DT,51
+647,Colorado State,Armani Winfield,WR,86
+647,Colorado State,Tanner Morley,LG,86
+647,Colorado State,Ayden Hector,CB,85
+647,Colorado State,Rocky Beers,TE,84
+647,Colorado State,Trevyn Heil,C,84
+647,Colorado State,Jacob Ellis,MLB,84
+647,Colorado State,Aaron Karas,RT,83
+647,Colorado State,Jernias Tafia,DT,83
+647,Colorado State,Brayden Fowler Nicolosi,QB,80
+647,Colorado State,Jahari Rogers,CB,80
+647,Colorado State,Gabe Jones,DT,80
+647,Colorado State,Quinn Hatch,LG,80
+647,Colorado State,John Holthaus,LT,80
+647,Colorado State,Dylan Phelps,CB,79
+647,Colorado State,Jaxxon Warren,TE,79
+647,Colorado State,Chandler Brown,RT,79
+647,Colorado State,Tahj Bullock,QB,78
+647,Colorado State,Alex Foster,LG,78
+647,Colorado State,Jared Isaac,FB,78
+647,Colorado State,Jake Jarmolowich,FS,77
+647,Colorado State,Jordan Ross,WR,76
+647,Colorado State,Andrew Laurich,DT,76
+647,Colorado State,Cannon Valenzuela,LOLB,76
+647,Colorado State,Cj Blocker,CB,75
+647,Colorado State,Tommy Maher,WR,75
+647,Colorado State,Petey Tucker,WR,75
+647,Colorado State,Drew Rodriguez,MLB,75
+647,Colorado State,Aitor Urionabarrenechea,RG,75
+647,Colorado State,Jaseim Mitchell,LOLB,75
+647,Colorado State,Trey Vincent,SS,74
+647,Colorado State,Christian Martin,LT,74
+647,Colorado State,Lemondre Joe,CB,74
+647,Colorado State,Kentez Allen,LG,74
+647,Colorado State,Owen Long,ROLB,73
+647,Colorado State,Jackson Brousseau,QB,73
+647,Colorado State,William Wortmann,LT,72
+647,Colorado State,Dante Scott,FS,72
+647,Colorado State,Zach Smith,RT,72
+647,Colorado State,Jake Dennis,TE,72
+647,Colorado State,Kojo Antwi,WR,71
+647,Colorado State,Carlos Anaya,TE,71
+647,Colorado State,Stephon Daily,WR,71
+647,Colorado State,Jace Bellah,SS,71
+647,Colorado State,Jett Vincent,FS,70
+647,Colorado State,Lavon Brown,WR,70
+647,Colorado State,Chance Jenkins,WR,70
+647,Colorado State,Robert Edmonson Jr,ROLB,70
+647,Colorado State,Monjaro Senegal,RG,68
+647,Colorado State,Landon Bell,WR,67
+647,Colorado State,Joshua Medders,K,65
+647,Colorado State,Stan Hunt,RG,65
+647,Colorado State,D Angelo Hagans,FS,65
+647,Colorado State,Ed Mari Binion,MLB,65
+647,Colorado State,Darius Curry,QB,64
+647,Colorado State,Nathan Sutcliffe,P,63
+647,Colorado State,Mason Muaau,TE,62
+647,Colorado State,A J Noland,SS,61
+647,Colorado State,Berlin Lillard,LG,61
+647,Colorado State,Jaden Landrum,LOLB,60
+647,Colorado State,Chance Harrison,CB,57
+647,Colorado State,Raekwon Teal,DT,55
+647,Colorado State,Phillip Ocon,C,55
+647,Colorado State,Payne Williams Iii,K,54
+647,Colorado State,Braden Hales,RG,54
+647,Colorado State,Walker Himebauch,TE,54
+647,Colorado State,Lorenzo Franks,DT,53
+647,Colorado State,Bryan Hansen,P,50
+654,Florida State,Jeremiah Wilson,CB,90
+654,Florida State,Micah Pettus,RT,89
+654,Florida State,Darrell Jackson Jr,DT,89
+654,Florida State,Richie Leonard Iv,LG,89
+654,Florida State,Shyheim Brown,SS,88
+654,Florida State,Elijah Herring,ROLB,88
+654,Florida State,Tommy Castellanos,QB,87
+654,Florida State,Randy Pittman Jr,TE,87
+654,Florida State,Deante Mccray,DT,86
+654,Florida State,Gunnar Hansen,LT,86
+654,Florida State,Luke Petitbon,C,85
+654,Florida State,Squirrel White,WR,85
+654,Florida State,Duce Robinson,WR,84
+654,Florida State,Stefon Thompson,MLB,84
+654,Florida State,Adrian Medley,RG,84
+654,Florida State,Markeston Douglas,TE,83
+654,Florida State,Daniel Lyons,DT,81
+654,Florida State,Omar Graham Jr,ROLB,81
+654,Florida State,Jacob Rizy,C,81
+654,Florida State,Quindarrius Jones,CB,77
+654,Florida State,Brock Glenn,QB,77
+654,Florida State,K J Kirkland,FS,76
+654,Florida State,Blake Nichelson,MLB,76
+654,Florida State,Lawayne Mccoy,WR,76
+654,Florida State,Conrad Hussey,SS,76
+654,Florida State,Justin Cryer,MLB,75
+654,Florida State,Bryson Estes,RG,74
+654,Florida State,Edwin Joseph,CB,73
+654,Florida State,Charles Lester Iii,CB,73
+654,Florida State,Earl Little Ii,FS,73
+654,Florida State,Gavin Blackwell,WR,73
+654,Florida State,Josh Raymond,LG,73
+654,Florida State,Ashlynd Barker,SS,72
+654,Florida State,Manasse Itete,LG,72
+654,Florida State,Andre Otto,LG,72
+654,Florida State,Caleb Lavallee,ROLB,71
+654,Florida State,Sean Poret,RG,71
+654,Florida State,Zae Thomas,CB,70
+654,Florida State,Mario Nash Jr,RG,70
+654,Florida State,Kj Sampson,DT,69
+654,Florida State,Jayvan Boggs,WR,69
+654,Florida State,Kevin Wynn,DT,68
+654,Florida State,Mason Arnold,TE,68
+654,Florida State,Ethan Pritchard,MLB,67
+654,Florida State,Tanner Applewhite,QB,66
+654,Florida State,Tae Shaun Gelsey,TE,66
+654,Florida State,Tyeland Coleman,DT,66
+654,Florida State,Kevin Sperry,QB,65
+654,Florida State,Wade Mclaughlin,TE,65
+654,Florida State,Jaelyne Matthews,LT,65
+654,Florida State,Lucas Simmons,LT,64
+654,Florida State,Cai Bates,CB,64
+654,Florida State,Ja Bril Rawls,CB,64
+654,Florida State,Reshard Miller,C,64
+654,Florida State,Brandon Garner,K,63
+654,Florida State,Bj Gibson,WR,63
+654,Florida State,Camdon Frier,WR,62
+654,Florida State,Jarvis Boatwright Jr,FS,61
+654,Florida State,Chase Loftin,TE,60
+654,Florida State,Jonathan Daniels,RT,60
+654,Florida State,Jayden Todd,RT,60
+654,Florida State,Mac Chiumento,P,59
+654,Florida State,Jayden Parrish,LOLB,59
+654,Florida State,Jake Weinberg,K,58
+654,Florida State,Max Redmon,FS,58
+654,Florida State,Ike Copeland,FB,58
+654,Florida State,Tye Hylton,RG,56
+654,Florida State,Ashton Bracewell,LOLB,54
+654,Florida State,Zonovan Redd,LT,52
+655,Fresno State,Al Zillion Hamilton,CB,88
+655,Fresno State,E J Warner,QB,88
+655,Fresno State,Jacob Spomer,C,86
+655,Fresno State,Jadon Pearson,ROLB,84
+655,Fresno State,Rolan Fullwood,RT,84
+655,Fresno State,Ezra Christensen,DT,84
+655,Fresno State,Jordan Brown,WR,84
+655,Fresno State,Josiah Ayon,WR,83
+655,Fresno State,Toreon Penright,LT,83
+655,Fresno State,Campbell Mcharg,RG,82
+655,Fresno State,Jakari Embry,CB,81
+655,Fresno State,Michael Jordan Jr,DT,81
+655,Fresno State,Jayden Davis,FS,80
+655,Fresno State,Josiah Freeman,WR,80
+655,Fresno State,Edward Fonua,LG,80
+655,Fresno State,Simeon Harris,CB,80
+655,Fresno State,Jayden Mandal,QB,79
+655,Fresno State,Auckland Asiata,DT,79
+655,Fresno State,Gino Quinones,LG,79
+655,Fresno State,Deijon Laffitte,DT,77
+655,Fresno State,Tim Thomas,MLB,76
+655,Fresno State,Jordan Malau Ulu,WR,76
+655,Fresno State,Camryn Bracha,SS,76
+655,Fresno State,Sammie Hunter,CB,76
+655,Fresno State,Jayon Farrar,WR,76
+655,Fresno State,Ponafatu Kamuta,C,75
+655,Fresno State,Martin Owusu,DT,74
+655,Fresno State,Jahlil Mcclain,WR,74
+655,Fresno State,Julian Polendo,LG,74
+655,Fresno State,Demetrius Scantling,FB,74
+655,Fresno State,Ethan Dasmann,LT,74
+655,Fresno State,K Vion Thunderbird,MLB,73
+655,Fresno State,Jake Tarwater,TE,73
+655,Fresno State,Rl Miller,SS,73
+655,Fresno State,Brayden Walton,LT,73
+655,Fresno State,Richie Anderson,TE,72
+655,Fresno State,Jomarion Briggs,CB,72
+655,Fresno State,Jairus Satele,DT,72
+655,Fresno State,Matai Bell,RG,72
+655,Fresno State,Gavin Correia,TE,72
+655,Fresno State,Wesley Brown,TE,72
+655,Fresno State,Seth Scheidt,MLB,72
+655,Fresno State,Braylan Henderson,RT,71
+655,Fresno State,Rj Regan,SS,70
+655,Fresno State,Kyson Van Vugt,TE,70
+655,Fresno State,Ryan Wilson,SS,70
+655,Fresno State,Andre Cobb,CB,70
+655,Fresno State,Kamron Beachem,TE,69
+655,Fresno State,Logan Studt,ROLB,69
+655,Fresno State,Dylan Lynch,K,68
+655,Fresno State,Justin Johnson,ROLB,68
+655,Fresno State,Ethan Tierney,FS,68
+655,Fresno State,Marcus Simien,RG,67
+655,Fresno State,Marsel Akins,RT,67
+655,Fresno State,Trevor Judino,LOLB,66
+655,Fresno State,Damar Daniels,C,66
+655,Fresno State,Troy Van Dyke,RG,65
+655,Fresno State,Cj Lake,LOLB,64
+655,Fresno State,Ah Marion Ashley,CB,64
+655,Fresno State,Paul Webster,QB,63
+655,Fresno State,Alex Barnard,LOLB,62
+655,Fresno State,Clay Lawrence,P,61
+655,Fresno State,Loyall Mouzon,CB,61
+655,Fresno State,Gerayas Grimes,FS,59
+655,Fresno State,Mason York,LT,58
+655,Fresno State,Kiontre Harris,CB,58
+655,Fresno State,Marquise Thorpe Taylor,RT,57
+655,Fresno State,Cam Cole,CB,57
+655,Fresno State,Tytus Khajavi,MLB,55
+655,Fresno State,Connor Tripp,K,53
+655,Fresno State,Nick Verdugo,P,51
+655,Fresno State,Jaden Carrillo,CB,51
+656,Georgia,Christen Miller,DT,92
+656,Georgia,C J Allen,MLB,91
+656,Georgia,Kj Bolden,FS,91
+656,Georgia,Dillon Bell,WR,91
+656,Georgia,Oscar Delp,TE,90
+656,Georgia,Daylen Everette,CB,90
+656,Georgia,Earnest Greene Iii,RT,89
+656,Georgia,Zachariah Branch,WR,88
+656,Georgia,Colbie Young,WR,88
+656,Georgia,Monroe Freeling,LT,87
+656,Georgia,Noah Thomas,WR,87
+656,Georgia,London Humphreys,WR,86
+656,Georgia,Drew Bobo,C,85
+656,Georgia,Micah Morris,LG,84
+656,Georgia,Chris Cole,ROLB,82
+656,Georgia,Jacorey Thomas,SS,81
+656,Georgia,Xzavier Mcleod,DT,81
+656,Georgia,Lawson Luckie,TE,80
+656,Georgia,Daniel Harris,CB,80
+656,Georgia,Adrian Maddox,FS,80
+656,Georgia,Raylen Wilson,ROLB,79
+656,Georgia,Jaden Harris,SS,79
+656,Georgia,Zion Branch,SS,78
+656,Georgia,Gunner Stockton,QB,78
+656,Georgia,Jamal Meriweather,LT,77
+656,Georgia,Justin Williams,MLB,76
+656,Georgia,Nnamdi Ogboko,DT,76
+656,Georgia,Ryan Puglisi,QB,76
+656,Georgia,Joenel Aguero,FS,75
+656,Georgia,Ellis Robinson Iv,CB,75
+656,Georgia,Josh Horton,DT,75
+656,Georgia,Trevor Holton,SS,75
+656,Georgia,Nasir Johnson,DT,75
+656,Georgia,Malachi Toliver,C,75
+656,Georgia,Terrell Foster,MLB,75
+656,Georgia,Beau Gardner,TE,75
+656,Georgia,Brett Thorson,P,74
+656,Georgia,Daniel Calhoun,RG,74
+656,Georgia,Zayden Walker,ROLB,74
+656,Georgia,Marcus Harrison,RG,74
+656,Georgia,Sacovie White,WR,74
+656,Georgia,Waltclaire Flynn,C,74
+656,Georgia,Jordan Hall,DT,73
+656,Georgia,Demello Jones,CB,73
+656,Georgia,Talyn Taylor,WR,73
+656,Georgia,Darren Ikinnagbon,LOLB,72
+656,Georgia,Michael Uini,LG,72
+656,Georgia,Kyron Jones,FS,72
+656,Georgia,Mason Short,RG,72
+656,Georgia,Cole Speer,WR,71
+656,Georgia,Peyton Woodring,K,70
+656,Georgia,Jaxson Norman,RT,70
+656,Georgia,Elyiss Williams,TE,70
+656,Georgia,Jaden Reddell,TE,70
+656,Georgia,Cj Wiley,WR,70
+656,Georgia,Todd Robinson,FS,70
+656,Georgia,Anthony Kruah,MLB,69
+656,Georgia,Landon Roldan,WR,68
+656,Georgia,Drew Miller,P,68
+656,Georgia,Elijah Griffin,DT,67
+656,Georgia,Liam Badger,K,67
+656,Georgia,Liam Perry,FB,67
+656,Georgia,Juan Gaston,LT,65
+656,Georgia,Ondre Evans,CB,65
+656,Georgia,Cortez Smith,RG,65
+656,Georgia,Daquincy Dumas,ROLB,65
+656,Georgia,Bo Hughley,RT,64
+656,Georgia,Ethan Barbour,TE,63
+656,Georgia,Jordan Thomas,DT,61
+656,Georgia,Nyier Daniels,RT,60
+656,Georgia,Hezekiah Millender,QB,58
+656,Georgia,Brian Rayford,LT,46
+657,Georgia Southern,Caleb Cook,RG,90
+657,Georgia Southern,Latrell Bullard,DT,86
+657,Georgia Southern,Chance Carroll,C,86
+657,Georgia Southern,Josh Dallas,WR,85
+657,Georgia Southern,Pichon Wimbley,LG,85
+657,Georgia Southern,River Helms,TE,84
+657,Georgia Southern,Dalen Cobb,WR,84
+657,Georgia Southern,Camden Brown,WR,84
+657,Georgia Southern,Vince Hall,LT,84
+657,Georgia Southern,Chandler Strong,C,83
+657,Georgia Southern,Justin Meyers,SS,83
+657,Georgia Southern,Chance Gamble,CB,82
+657,Georgia Southern,Jc French,QB,82
+657,Georgia Southern,Marcus Sanders Jr,WR,82
+657,Georgia Southern,Ayden Jackson,CB,81
+657,Georgia Southern,Ahmon Green,TE,81
+657,Georgia Southern,Kyle Frazier,LG,81
+657,Georgia Southern,Johnnie Brown Iii,RT,81
+657,Georgia Southern,Gabe Alexander,LT,81
+657,Georgia Southern,Tracy Hill Jr,CB,80
+657,Georgia Southern,Uche Iloh,DT,80
+657,Georgia Southern,Robert Wright Jr,RT,79
+657,Georgia Southern,Caelan Williams,LT,79
+657,Georgia Southern,Davon Hicks,MLB,78
+657,Georgia Southern,Sam Kenerson,WR,78
+657,Georgia Southern,Keanon Nixon,MLB,78
+657,Georgia Southern,Dylan Gary,WR,76
+657,Georgia Southern,Brendan Harrington,ROLB,76
+657,Georgia Southern,Jakwon Mcginney,DT,76
+657,Georgia Southern,Prince Green Iii,FS,75
+657,Georgia Southern,Carlo Thompson,SS,75
+657,Georgia Southern,Dion Gillislee,FS,75
+657,Georgia Southern,Brandon Tyson,MLB,74
+657,Georgia Southern,Collin Clancy,LT,74
+657,Georgia Southern,Ethan Pouncey,CB,73
+657,Georgia Southern,Brian Green Jr,WR,73
+657,Georgia Southern,Darrell Anthony,ROLB,73
+657,Georgia Southern,Weston Bryan,QB,72
+657,Georgia Southern,Antonio White Jr,FS,72
+657,Georgia Southern,Jacob Hammonds,ROLB,72
+657,Georgia Southern,Jamari Whitehead,MLB,72
+657,Georgia Southern,Elija Walton,TE,71
+657,Georgia Southern,Marcus Downs,DT,71
+657,Georgia Southern,Jeremiah Ticket,DT,71
+657,Georgia Southern,Jayden Davis,SS,70
+657,Georgia Southern,Henry Gregory,TE,70
+657,Georgia Southern,Brad Franklin,LG,69
+657,Georgia Southern,Tytus Jackson,RG,69
+657,Georgia Southern,Turner Helton,QB,69
+657,Georgia Southern,Dwight Stewart,RG,68
+657,Georgia Southern,Tyler Budge,QB,68
+657,Georgia Southern,Aj Brown,CB,67
+657,Georgia Southern,Marcus Peoples,FB,67
+657,Georgia Southern,Caleb Butler,LOLB,67
+657,Georgia Southern,Donnie Johnson,RG,67
+657,Georgia Southern,Eli Anders,LOLB,67
+657,Georgia Southern,Matt Farmer,LG,65
+657,Georgia Southern,Cj Allen,ROLB,65
+657,Georgia Southern,Alex Smith,P,64
+657,Georgia Southern,Emmett Walker,MLB,64
+657,Georgia Southern,Matthew Williams,RT,64
+657,Georgia Southern,Elijah Fears,DT,64
+657,Georgia Southern,Romeo Meeks,LG,62
+657,Georgia Southern,Tre Anderson,FB,61
+657,Georgia Southern,Ethan Williams,C,61
+657,Georgia Southern,Gaines Wood,TE,60
+657,Georgia Southern,Jeremiah Ware,WR,59
+657,Georgia Southern,Carlos Miner,CB,58
+657,Georgia Southern,Devin Collier,FS,58
+657,Georgia Southern,Donal Dempsey,K,52
+657,Georgia Southern,Elijah Ffrench,FS,52
+657,Georgia Southern,Blake Weiss,K,48
+658,Georgia State,Henry Bryant,DT,88
+658,Georgia State,Ted Hurst,WR,87
+658,Georgia State,Christian Veilleux,QB,85
+658,Georgia State,Josiah Robinson,ROLB,83
+658,Georgia State,Alec Johnson,C,83
+658,Georgia State,Will Larkins,LT,82
+658,Georgia State,Damaine Wilson,MLB,80
+658,Georgia State,Leo Blackburn,WR,80
+658,Georgia State,D Icey Hopkins,FS,79
+658,Georgia State,Sir Mells,DT,79
+658,Georgia State,Jordan Huff,SS,79
+658,Georgia State,Fuches Lewis Ii,DT,77
+658,Georgia State,Javon Robinson,WR,77
+658,Georgia State,Jaylen Jones,FS,77
+658,Georgia State,Tyhler Williams,C,77
+658,Georgia State,Derrick Maxey Iii,SS,76
+658,Georgia State,Rex Downing,RT,76
+658,Georgia State,Dj Riles,WR,75
+658,Georgia State,Antonio Wesley,ROLB,74
+658,Georgia State,Jon Holt,ROLB,74
+658,Georgia State,Jeff Burton,RG,73
+658,Georgia State,Chams Diagne,CB,73
+658,Georgia State,Alex Mullings,DT,73
+658,Georgia State,Mason Cook,LG,72
+658,Georgia State,Avion Mcbride,TE,72
+658,Georgia State,Tyler Scott,CB,72
+658,Georgia State,Dominic Johnson,LT,72
+658,Georgia State,Michael Fitzmeyer,TE,71
+658,Georgia State,Sage Reynolds,WR,71
+658,Georgia State,Justin Battle,CB,70
+658,Georgia State,Deandre Duffus,LG,70
+658,Georgia State,Deuce Walker,CB,70
+658,Georgia State,Neil Sledge,LG,70
+658,Georgia State,Lane Wadle,TE,70
+658,Georgia State,Cameran Brown,QB,69
+658,Georgia State,D Andre Lavassaur,C,68
+658,Georgia State,James Dodd,TE,67
+658,Georgia State,Donovan Funsch,RG,67
+658,Georgia State,Bernard Causey,CB,67
+658,Georgia State,Ethan Charles,LG,67
+658,Georgia State,Austin Mcgee,WR,65
+658,Georgia State,Kyle Washington,WR,65
+658,Georgia State,Kedrick Walker,LOLB,65
+658,Georgia State,Robert Montgomery,RG,65
+658,Georgia State,Tj Stanley,QB,64
+658,Georgia State,Matthew Erickson,TE,62
+658,Georgia State,Zachary Davis,MLB,62
+658,Georgia State,Coby Owens,ROLB,62
+658,Georgia State,Jaden Roper,DT,61
+658,Georgia State,Fabian Keith,CB,60
+658,Georgia State,Charlie Patterson,RG,59
+658,Georgia State,Liam Rickman,K,59
+658,Georgia State,Buddy Prewitt,FB,59
+658,Georgia State,D Ontae Fulton,WR,59
+658,Georgia State,Demarcus Rudiger,DT,59
+658,Georgia State,Pj Hatter,QB,58
+658,Georgia State,Micah Davis,RG,58
+658,Georgia State,Jartavius Flounoy,DT,57
+658,Georgia State,Aj Andrews,LT,56
+658,Georgia State,Ronnie Crum,SS,56
+658,Georgia State,Joseph Reliford,RT,56
+658,Georgia State,Greyson Bailey,FS,55
+658,Georgia State,Braeden Mcalister,K,54
+658,Georgia State,Jacob Grant,RT,54
+658,Georgia State,Brent Washington,MLB,53
+658,Georgia State,D J Harold,DT,52
+658,Georgia State,D J Oldacre,FS,51
+658,Georgia State,Mason Harmon,MLB,46
+659,Georgia Tech,Eric Rivers,WR,92
+659,Georgia Tech,Haynes King,QB,89
+659,Georgia Tech,Joe Fusile,LG,89
+659,Georgia Tech,Keylan Rutledge,RG,88
+659,Georgia Tech,Dean Patterson,WR,88
+659,Georgia Tech,Malachi Carney,RT,88
+659,Georgia Tech,Malik Rutherford,WR,87
+659,Georgia Tech,Clayton Powell Lee,FS,87
+659,Georgia Tech,Jordan Van Den Berg,DT,86
+659,Georgia Tech,Kyle Efford,MLB,85
+659,Georgia Tech,Akelo Stone,DT,85
+659,Georgia Tech,Rodney Shelley,CB,84
+659,Georgia Tech,Benjamin Galloway,RG,84
+659,Georgia Tech,Ahmari Harvey,CB,83
+659,Georgia Tech,Matthew Alexander,DT,83
+659,Georgia Tech,Isiah Canion,WR,83
+659,Georgia Tech,Ethan Mackenny,LT,83
+659,Georgia Tech,E J Lightsey,ROLB,82
+659,Georgia Tech,Melvin Jordan Iv,MLB,81
+659,Georgia Tech,Omar Daniels,FS,81
+659,Georgia Tech,Shymeik Jones,DT,81
+659,Georgia Tech,Brett Seither,TE,80
+659,Georgia Tech,Zachary Tobe,CB,79
+659,Georgia Tech,Bryson Shoemaker,LT,79
+659,Georgia Tech,Kareem Mccoy,DT,79
+659,Georgia Tech,Jyron Gilmore,CB,78
+659,Georgia Tech,Debron Gatling,WR,77
+659,Georgia Tech,Luke Whiting,TE,76
+659,Georgia Tech,Harrison Moore,LG,76
+659,Georgia Tech,Jameson Riggs,RG,76
+659,Georgia Tech,Daiquan White,CB,75
+659,Georgia Tech,Jackson Hamilton,MLB,75
+659,Georgia Tech,Savion Riley,FS,74
+659,Georgia Tech,Tana Alo Tupuola,C,74
+659,Georgia Tech,J T Byrne,TE,73
+659,Georgia Tech,Peyton Joseph,RT,73
+659,Georgia Tech,Christian Pritchett,SS,73
+659,Georgia Tech,Aaron Philo,QB,73
+659,Georgia Tech,Zion Taylor,WR,73
+659,Georgia Tech,Landen Marshall,DT,72
+659,Georgia Tech,Zack Jacobs,C,72
+659,Georgia Tech,Ryan Purves,RG,71
+659,Georgia Tech,Bailey Stockton,WR,70
+659,Georgia Tech,Ronnie Phillips,TE,70
+659,Georgia Tech,Ian Lawrence,P,68
+659,Georgia Tech,Blake Belin,DT,68
+659,Georgia Tech,Marshall Nichols,P,67
+659,Georgia Tech,Jon Mitchell,CB,67
+659,Georgia Tech,Nico Dowdell,CB,67
+659,Georgia Tech,Kingsley Adams,LT,67
+659,Georgia Tech,Graham Knowles,QB,67
+659,Georgia Tech,Aidan Birr,K,66
+659,Georgia Tech,Luke Harpring,TE,66
+659,Georgia Tech,Kelvin Hill,CB,66
+659,Georgia Tech,Cam Jones,LG,66
+659,Georgia Tech,Ahman King,QB,65
+659,Georgia Tech,Jordan Floyd,RT,64
+659,Georgia Tech,Elgin Sessions,FS,64
+659,Georgia Tech,Markus Edmonds,RT,64
+659,Georgia Tech,Darryl Lane,FB,63
+659,Georgia Tech,Andrew Rosinski,LT,62
+659,Georgia Tech,Felipe Grimes,QB,58
+659,Georgia Tech,Nakell Manning,SS,58
+659,Georgia Tech,Troy Stevenson Iv,CB,57
+659,Georgia Tech,Jason Temple,ROLB,57
+659,Georgia Tech,Max Traxell,FS,56
+659,Georgia Tech,Marcus Marshall,TE,55
+659,Georgia Tech,Kerry Witherspoon,RT,54
+659,Georgia Tech,Jonorian Foots,LOLB,54
+659,Georgia Tech,Myles Forristall,LOLB,54
+659,Georgia Tech,Tah J Butler,ROLB,44
+660,Hawaii,Logan Taylor,MLB,87
+660,Hawaii,Sergio Muasau,LG,87
+660,Hawaii,Jalen Smith,ROLB,86
+660,Hawaii,Peter Manuma,SS,85
+660,Hawaii,Kuao Peihopa,RG,85
+660,Hawaii,Nick Cenacle,WR,84
+660,Hawaii,Virdel Edwards Ii,CB,84
+660,Hawaii,De Jon Benton,DT,84
+660,Hawaii,Pofele Ashlock,WR,83
+660,Hawaii,Elijah Palmer,CB,83
+660,Hawaii,Christian Perry,LT,82
+660,Hawaii,Kilinahe Mendiola Jensen,FS,81
+660,Hawaii,Jackson Harris,WR,80
+660,Hawaii,Jamar Sekona,DT,80
+660,Hawaii,Jamih Otis,ROLB,79
+660,Hawaii,James Milovale,RT,79
+660,Hawaii,Warren Lafaele,LOLB,78
+660,Hawaii,Karsyn Pupunu,WR,77
+660,Hawaii,Jaheim Wilson Jones,CB,75
+660,Hawaii,Kona Moore,FS,75
+660,Hawaii,Devyn King,CB,75
+660,Hawaii,Semaj James,CB,75
+660,Hawaii,Deliyon Freeman,CB,75
+660,Hawaii,Qwyn Williams,DT,75
+660,Hawaii,Micah Alejado,QB,74
+660,Hawaii,Ethan Spencer,C,74
+660,Hawaii,Dom Philbin,FS,74
+660,Hawaii,Zaden Mariteragi,MLB,74
+660,Hawaii,Julian Smith,SS,73
+660,Hawaii,Anthony Sagapolutele,DT,73
+660,Hawaii,Tim Malo,SS,72
+660,Hawaii,Matagi Thompson,CB,72
+660,Hawaii,Jason Bailey,LOLB,72
+660,Hawaii,Judah Kaio,LG,72
+660,Hawaii,Tasi Tadio,MLB,72
+660,Hawaii,Devon Tauaefa,TE,71
+660,Hawaii,Brandon White,WR,71
+660,Hawaii,Luther Mccoy,DT,71
+660,Hawaii,Dean Briski,LT,71
+660,Hawaii,Junior Fiaui,ROLB,71
+660,Hawaii,Aiden Mccomber,DT,71
+660,Hawaii,Kt Carter,LT,71
+660,Hawaii,Oakie Salave A,TE,70
+660,Hawaii,Luke Weaver,QB,70
+660,Hawaii,Larry Booth,TE,69
+660,Hawaii,Jay Tauala Harris,RG,69
+660,Hawaii,Riis Weber,SS,68
+660,Hawaii,Tama Uiliata,WR,68
+660,Hawaii,Corey Reisner,FB,68
+660,Hawaii,Dermaricus Davis,QB,67
+660,Hawaii,Lautaimi Manuma,RT,67
+660,Hawaii,Tu I Muti,C,67
+660,Hawaii,Lawrence Leiato,CB,66
+660,Hawaii,Dillon Davenport,RG,65
+660,Hawaii,Caleb Freeman,QB,64
+660,Hawaii,Akeem Henson,LOLB,64
+660,Hawaii,Lance Snell,WR,64
+660,Hawaii,Boogie Henderson,C,64
+660,Hawaii,Matthew Sherels,FS,63
+660,Hawaii,Lucas Borrow,P,62
+660,Hawaii,Kansei Matsuzawa,K,61
+660,Hawaii,Alika Cavaco Amoy,ROLB,61
+660,Hawaii,Wendell Crothers,CB,60
+660,Hawaii,Kayson Gallimore,WR,58
+660,Hawaii,Damon Brazill,WR,58
+660,Hawaii,Randy Mccoy,CB,57
+660,Hawaii,Dewuan Walton,TE,56
+660,Hawaii,Jamichael Powell,DT,55
+660,Hawaii,Erik Atkins,LT,55
+660,Hawaii,Marco Togia Johnson,LG,54
+660,Hawaii,Caleb Sempebwa,K,49
+660,Hawaii,Nazaiah Caravallo,MLB,48
+661,Houston,Tanner Koziol,TE,92
+661,Houston,Wrook Brown,SS,88
+661,Houston,Jason Brooks Jr,LG,87
+661,Houston,Eddie Walls Iii,LOLB,87
+661,Houston,Jesus Machado,MLB,86
+661,Houston,Alvin Ebosele,LT,85
+661,Houston,Devan Williams,WR,85
+661,Houston,Amare Thomas,WR,84
+661,Houston,Luke Mcgary,TE,84
+661,Houston,Mckenzie Agnello,C,84
+661,Houston,Matthew Wykoff,RG,84
+661,Houston,Everitt Rogers,DT,84
+661,Houston,Conner Weigman,QB,83
+661,Houston,Marc Stampley Ii,CB,83
+661,Houston,Stephon Johnson,WR,83
+661,Houston,Corey Platt Jr,ROLB,83
+661,Houston,Xavier Stillman,DT,83
+661,Houston,Carmycah Glass,ROLB,82
+661,Houston,Jayden York,TE,82
+661,Houston,Latrell Mccutchin Sr,CB,82
+661,Houston,Jalen Garner,MLB,82
+661,Houston,Kentrell Webb,FS,82
+661,Houston,Marquis Shoulders,WR,82
+661,Houston,Sione Fotu,MLB,82
+661,Houston,Harvey Broussard,WR,81
+661,Houston,Joshua Donald,DT,81
+661,Houston,Larry Crawford,RT,81
+661,Houston,David Ndukwe,LT,80
+661,Houston,Jonathan Hutchins,RT,80
+661,Houston,J D Rhym,CB,79
+661,Houston,Cayden Bowie,LG,79
+661,Houston,Will James,CB,78
+661,Houston,Zeon Chriss,QB,78
+661,Houston,Dalton Merryman,RT,78
+661,Houston,Demetrius Hunter,C,77
+661,Houston,Brendon Bailey,SS,76
+661,Houston,Phil Agnew,RT,75
+661,Houston,Dayven Mullins,LT,75
+661,Houston,Mekhi Mews,WR,73
+661,Houston,Austin Mondale,LG,73
+661,Houston,Zavian Tibbs,DT,73
+661,Houston,Ronnell Mclain,RG,71
+661,Houston,Christian Brathwaite,ROLB,70
+661,Houston,Zaylen Cormier,WR,70
+661,Houston,Spencer Sims,RG,70
+661,Houston,Johnsley Barbas,SS,70
+661,Houston,Cedric Melton,RT,70
+661,Houston,Josh Springs Howard,RG,68
+661,Houston,Shareef Williams,FB,68
+661,Houston,Jordan Allen,SS,67
+661,Houston,Koby Young,WR,67
+661,Houston,Jacob Garza,TE,67
+661,Houston,Jacory Thurman,TE,66
+661,Houston,Ethan Sanchez,K,64
+661,Houston,Hunter Mcguire,DT,64
+661,Houston,Deion Gatewood,DT,64
+661,Houston,Ashton Dickerson,LOLB,64
+661,Houston,Alvin Williamson Jr,CB,64
+661,Houston,Richmond Ugochukwu,MLB,62
+661,Houston,Kaleb Thomas,TE,61
+661,Houston,Traville Frederick Jr,TE,61
+661,Houston,Liam Dougherty,P,60
+661,Houston,Jamaal Shaw,CB,60
+661,Houston,Carmello Brooks,DT,57
+661,Houston,Alex Abbott,P,54
+661,Houston,Derek Joiner,RG,54
+661,Houston,Allen Clark,K,50
+661,Houston,Jake Sock,QB,49
+661,Houston,Austin Carlisle,QB,48
+662,Illinois,Josh Kreutz,C,93
+662,Illinois,Gabe Jacas,LOLB,92
+662,Illinois,J C Davis,LT,90
+662,Illinois,Xavier Scott,CB,90
+662,Illinois,Luke Altmyer,QB,89
+662,Illinois,Josh Gesky,LG,89
+662,Illinois,Leon Lowery Jr,LOLB,89
+662,Illinois,Matthew Bailey,SS,88
+662,Illinois,Miles Scott,FS,87
+662,Illinois,Dylan Rosiek,MLB,87
+662,Illinois,Torrie Cox Jr,CB,86
+662,Illinois,Hudson Clement,WR,85
+662,Illinois,Melvin Priestly,RT,85
+662,Illinois,Curt Neal,DT,85
+662,Illinois,Gentle Hunt,DT,85
+662,Illinois,Ayden Knapik,LT,84
+662,Illinois,Justin Bowick,WR,83
+662,Illinois,Kenenna Odeluga,ROLB,83
+662,Illinois,Kaleb Patterson,CB,82
+662,Illinois,Hank Beatty,WR,82
+662,Illinois,Tyler Strain,CB,82
+662,Illinois,Ashton Hollins,WR,82
+662,Illinois,Alec Bryant,LOLB,82
+662,Illinois,James Kreutz,ROLB,82
+662,Illinois,Brandon Henderson,RG,81
+662,Illinois,Collin Dixon,WR,81
+662,Illinois,Tanner Arkin,TE,80
+662,Illinois,Cole Rusk,TE,80
+662,Illinois,Ethan Hampton,QB,79
+662,Illinois,Malik Elzy,WR,79
+662,Illinois,Christian Abney,TE,77
+662,Illinois,Davin Stoffel,TE,76
+662,Illinois,Mario Sanders Ii,WR,76
+662,Illinois,Jaheim Clarke,CB,75
+662,Illinois,Grant Beerman,MLB,75
+662,Illinois,Ismael Kante,MLB,75
+662,Illinois,Mac Resetich,FS,74
+662,Illinois,Dezmond Schuster,RG,74
+662,Illinois,Dante Merriweather,FB,73
+662,Illinois,Brett Lanning,LT,73
+662,Illinois,Brayden Trimble,WR,71
+662,Illinois,Grayson Griffin,SS,71
+662,Illinois,Michael Mcdonough,C,71
+662,Illinois,Tanner Heckel,CB,70
+662,Illinois,Isaiah White,DT,69
+662,Illinois,Patrick Mahoney Iii,TE,69
+662,Illinois,Eddie Tuerk,LG,69
+662,Illinois,Lane Hansen,TE,69
+662,Illinois,Daniel Brown,ROLB,68
+662,Illinois,Alexander Capka Jones,WR,68
+662,Illinois,Tj Mcmillen,C,68
+662,Illinois,Zafir Stewart,RT,68
+662,Illinois,David Olano,K,67
+662,Illinois,Tywan Cox,FS,67
+662,Illinois,Andre Lovett Jr,FS,67
+662,Illinois,Kellen Francis,RG,67
+662,Illinois,Desmond Straughton,SS,66
+662,Illinois,Caris Mills,LT,66
+662,Illinois,Eldon Washington,RT,66
+662,Illinois,Luke Zardzin,MLB,66
+662,Illinois,Keelan Crimmins,P,65
+662,Illinois,Brandon Hansen,LG,65
+662,Illinois,Robert Jones Iii,CB,64
+662,Illinois,Tyree Booth,LOLB,64
+662,Illinois,Carson Boyd,QB,62
+662,Illinois,Xanai Scott,FS,62
+662,Illinois,Angelo Mccullom,DT,61
+662,Illinois,Trey Petty,QB,59
+662,Illinois,Saboor Karriem,SS,59
+662,Illinois,Vernon Woodward Iii,CB,59
+662,Illinois,Malachi Hood,MLB,56
+662,Illinois,Jershaun Newton,QB,52
+662,Illinois,Chad Shaffer,K,50
+663,Indiana,Elijah Sarratt,WR,93
+663,Indiana,D Angelo Ponds,CB,92
+663,Indiana,Aiden Fisher,ROLB,90
+663,Indiana,Amare Ferrell,SS,90
+663,Indiana,Carter Smith,LT,89
+663,Indiana,Bray Lynch,LG,88
+663,Indiana,Hosea Wheeler,DT,88
+663,Indiana,Fernando Mendoza,QB,87
+663,Indiana,Tyrique Tucker,DT,87
+663,Indiana,Holden Staes,TE,87
+663,Indiana,Kellan Wyatt,LOLB,87
+663,Indiana,Pat Coogan,C,87
+663,Indiana,Kahlil Benson,RG,87
+663,Indiana,Devan Boykin,SS,86
+663,Indiana,Drew Evans,LG,85
+663,Indiana,E J Williams Jr,WR,84
+663,Indiana,Omar Cooper Jr,WR,83
+663,Indiana,James Bomba,TE,83
+663,Indiana,Jonathan Brady,WR,82
+663,Indiana,Makai Jackson,WR,82
+663,Indiana,Riley Nowakowski,TE,82
+663,Indiana,Louis Moore,FS,81
+663,Indiana,Grant Wilson,QB,81
+663,Indiana,Tyler Morris,WR,79
+663,Indiana,Ryland Gandy,CB,79
+663,Indiana,Donnie Barton,ROLB,79
+663,Indiana,Randall Shelby,MLB,78
+663,Indiana,Jamari Sharpe,CB,77
+663,Indiana,Amariyun Knighten,CB,77
+663,Indiana,Dominique Ratcliff,DT,76
+663,Indiana,Zen Michalski,RT,76
+663,Indiana,Kaiden Turner,ROLB,76
+663,Indiana,Mario Landino,LOLB,76
+663,Indiana,Bryson Bonds,SS,75
+663,Indiana,Rolijah Hardy,MLB,75
+663,Indiana,Eric Gillespie,FS,74
+663,Indiana,Isaiah Jones,MLB,74
+663,Indiana,Mitch Verstegen,C,74
+663,Indiana,Morris Montgomery,QB,73
+663,Indiana,Lebron Bond,WR,71
+663,Indiana,Andrew Barker,TE,71
+663,Indiana,Baylor Wilkin,RG,70
+663,Indiana,Myles Kendrick,WR,70
+663,Indiana,Mark Langston,TE,70
+663,Indiana,Sammy Edgar,LG,69
+663,Indiana,Jeff Utzinger,MLB,69
+663,Indiana,Nicolas Radicic,K,68
+663,Indiana,Lance Dent,FS,68
+663,Indiana,Matt Marek,RT,68
+663,Indiana,Seaonta Stewart Jr,SS,67
+663,Indiana,Dontrae Henderson,CB,67
+663,Indiana,Mitch Mccarthy,P,66
+663,Indiana,Evan Lawrence,RT,66
+663,Indiana,Kyler Garcia,DT,65
+663,Indiana,Ronald Mcsprings,CB,65
+663,Indiana,Kendall Montgomery,CB,64
+663,Indiana,Alberto Mendoza,QB,62
+663,Indiana,Keshawn Barker,FB,62
+663,Indiana,Evan Parker,RG,59
+663,Indiana,Jack Greer,C,59
+663,Indiana,Caleb Pickett,WR,58
+663,Indiana,Austin Leibfried,RG,57
+663,Indiana,Tyrell Norwood,WR,57
+663,Indiana,Kyle Martin,TE,56
+663,Indiana,Corbin Crawford,K,56
+663,Indiana,Adedamola Ajani,LG,54
+663,Indiana,Jah Jah Boyd,CB,54
+663,Indiana,J Mari Monette,DT,47
+663,Indiana,Stephen Downs,MLB,44
+686,Minnesota,Koi Perich,FS,91
+686,Minnesota,Aidan Gousby,FS,87
+686,Minnesota,Javon Tracy,WR,86
+686,Minnesota,Kerry Brown,SS,85
+686,Minnesota,Jameson Geers,TE,85
+686,Minnesota,Ashton Beers,C,85
+686,Minnesota,Deven Eastern,DT,84
+686,Minnesota,Logan Loya,WR,84
+686,Minnesota,Jalen Logan Redding,DT,84
+686,Minnesota,Mo Omonode,DT,84
+686,Minnesota,Maverick Baranowski,MLB,84
+686,Minnesota,Marcellus Marshall,RG,84
+686,Minnesota,Le Meke Brockington,WR,84
+686,Minnesota,Greg Johnson,LG,83
+686,Minnesota,Jeff Roberson,ROLB,83
+686,Minnesota,Devon Williams,ROLB,82
+686,Minnesota,Emmett Morehead,QB,82
+686,Minnesota,Kahlee Tafai,LT,81
+686,Minnesota,Dylan Ray,RT,80
+686,Minnesota,Za Quan Bryan,CB,78
+686,Minnesota,Darius Green,SS,78
+686,Minnesota,Derik Lecaptain,ROLB,78
+686,Minnesota,Tony Nelson,RG,76
+686,Minnesota,Malachi Coleman,WR,75
+686,Minnesota,Reese Tripp,LG,75
+686,Minnesota,Quentin Redding,WR,75
+686,Minnesota,Nathan Roy,LT,75
+686,Minnesota,Joey Gerlach,MLB,75
+686,Minnesota,Jaden Ball,RT,75
+686,Minnesota,Jai Onte Mcmillan,CB,75
+686,Minnesota,Kenric Lanier Ii,WR,75
+686,Minnesota,Rhyland Kelly,CB,74
+686,Minnesota,Matt Kingsbury,MLB,74
+686,Minnesota,Lonzo Glenn,WR,74
+686,Minnesota,Aluma Nkele,RT,73
+686,Minnesota,Mike Gerald,CB,73
+686,Minnesota,Donielle Hayes,WR,73
+686,Minnesota,Jerod Batts,QB,73
+686,Minnesota,Drew Wilson,LOLB,73
+686,Minnesota,Griffin Bates,LT,72
+686,Minnesota,Frank Bierman,TE,72
+686,Minnesota,Drake Lindsey,QB,71
+686,Minnesota,Jeimer Stuckey,SS,71
+686,Minnesota,Alan Soukup,TE,71
+686,Minnesota,Matthew Crowe Hills,RG,71
+686,Minnesota,Jerome Williams,LG,70
+686,Minnesota,John Nestor,CB,69
+686,Minnesota,Garrison Monroe,FS,69
+686,Minnesota,Drew Biber,TE,67
+686,Minnesota,Craig Lewis Brick,P,67
+686,Minnesota,Dylan Wittke,QB,67
+686,Minnesota,Spencer Alvarez,LT,66
+686,Minnesota,Pierce Walsh,TE,66
+686,Minnesota,Allen Upton,CB,65
+686,Minnesota,Caleb Mcgrath,P,65
+686,Minnesota,Dante Gaither,CB,64
+686,Minnesota,Zahir Rainer,FS,64
+686,Minnesota,Brady Denaburg,K,63
+686,Minnesota,Evan Romano,DT,63
+686,Minnesota,Payton Jones,DT,62
+686,Minnesota,Mason Carrier,ROLB,62
+686,Minnesota,Julian Johnson,TE,62
+686,Minnesota,Chaz Fleming,LOLB,61
+686,Minnesota,Brody Richter,P,60
+686,Minnesota,Tobias Needles,RT,60
+686,Minnesota,Kyle Mount,K,60
+686,Minnesota,Kevin Clark Marshall,LOLB,57
+686,Minnesota,Clark Whitley,FB,56
+686,Minnesota,Brett Carroll,C,55
+686,Minnesota,Max Shikenjanski,QB,53
+686,Minnesota,Kole Emerson,LT,48
+687,Mississippi State,Blake Shapen,QB,92
+687,Mississippi State,Isaac Smith,SS,88
+687,Mississippi State,Trevor Mayberry,RG,88
+687,Mississippi State,Jahron Manning,FS,85
+687,Mississippi State,Deago Brumfield,CB,85
+687,Mississippi State,Koby Keenum,C,85
+687,Mississippi State,Seydou Traore,TE,84
+687,Mississippi State,Jordan Mosley,WR,84
+687,Mississippi State,Blake Steen,RT,84
+687,Mississippi State,Albert Reese Iv,RT,84
+687,Mississippi State,Max Reese,TE,83
+687,Mississippi State,Nic Mitchell,MLB,83
+687,Mississippi State,Kedrick Bingley Jones,DT,83
+687,Mississippi State,Branden Jennings,LOLB,83
+687,Mississippi State,Jacoby Jackson,LG,83
+687,Mississippi State,Will Whitson,DT,82
+687,Mississippi State,Dwight Lewis Iii,CB,82
+687,Mississippi State,Derion Gullette,MLB,82
+687,Mississippi State,Kalvin Dinkins,DT,81
+687,Mississippi State,Kelley Jones,CB,81
+687,Mississippi State,Brenen Thompson,WR,81
+687,Mississippi State,Jayven Williams,CB,81
+687,Mississippi State,Jayvin James,RT,81
+687,Mississippi State,Colin Coates,DT,81
+687,Mississippi State,Jalen Smith,ROLB,80
+687,Mississippi State,Jaron Glover,WR,80
+687,Mississippi State,Tony Mitchell,SS,80
+687,Mississippi State,Brennan Smith,C,80
+687,Mississippi State,Ayden Williams,WR,79
+687,Mississippi State,Canon Boone,RG,79
+687,Mississippi State,Sam West,TE,79
+687,Mississippi State,Cam Thompson,WR,78
+687,Mississippi State,Zakari Tillman,ROLB,78
+687,Mississippi State,Jaray Bledsoe,DT,77
+687,Mississippi State,Hunter Washington,SS,77
+687,Mississippi State,Emeka Iloh,TE,77
+687,Mississippi State,Brylan Lanier,CB,77
+687,Mississippi State,Cameron Ball,TE,77
+687,Mississippi State,Lakendrick James,LOLB,77
+687,Mississippi State,Jamarcus Moye,DT,76
+687,Mississippi State,Tanner Johnson,SS,76
+687,Mississippi State,Luke Work,LT,76
+687,Mississippi State,Saquon Miles,RT,75
+687,Mississippi State,Wesley Davis,C,75
+687,Mississippi State,Trevion Williams,DT,74
+687,Mississippi State,Ja Bryis Stewart,SS,73
+687,Mississippi State,Kai Mcclendon,DT,73
+687,Mississippi State,Luke Kromenhoek,QB,72
+687,Mississippi State,Tyshun Willis,ROLB,72
+687,Mississippi State,Fatt Forrest,MLB,72
+687,Mississippi State,Aj Rice,MLB,71
+687,Mississippi State,Tj Lockhart,LG,70
+687,Mississippi State,Kaden Hatcher,TE,70
+687,Mississippi State,Spencer Dowland,LT,70
+687,Mississippi State,Zack Owens,RG,69
+687,Mississippi State,Quadir Winston,WR,69
+687,Mississippi State,Douglas Berry,P,69
+687,Mississippi State,Kyle Ferrie,K,68
+687,Mississippi State,Anthony Evans Iii,WR,68
+687,Mississippi State,Jamil Burroughs,DT,68
+687,Mississippi State,Jaekwon Bouldin,LT,67
+687,Mississippi State,Marlon Hauck,K,67
+687,Mississippi State,Jimothy Lewis Jr,RT,67
+687,Mississippi State,Tyler Woodard,FS,66
+687,Mississippi State,Savion Linton,ROLB,66
+687,Mississippi State,Vic Sutton,QB,65
+687,Mississippi State,Devan Webster,LOLB,63
+687,Mississippi State,Elijah Cannon,CB,62
+687,Mississippi State,Cyrus Reyes,FS,61
+687,Mississippi State,Rahim Garnett,FB,59
+687,Mississippi State,Keiland Franks,LT,55
+687,Mississippi State,Kamario Taylor,QB,54
+688,Missouri,Cayden Green,LG,92
+688,Missouri,Connor Tollison,C,92
+688,Missouri,Jalen Catalon,FS,91
+688,Missouri,Kevin Coleman Jr,WR,90
+688,Missouri,Daylan Carnell,SS,88
+688,Missouri,Chris Mcclellan,DT,87
+688,Missouri,Triston Newson,ROLB,87
+688,Missouri,Khalil Jacobs,MLB,87
+688,Missouri,Josiah Trotter,MLB,86
+688,Missouri,Stephen Hall,CB,86
+688,Missouri,Curtis Peagler,RG,86
+688,Missouri,Dominick Giudice,C,85
+688,Missouri,Keagen Trost,RT,85
+688,Missouri,Johnny Williams Iv,LT,84
+688,Missouri,Toriano Pride Jr,CB,83
+688,Missouri,Sterling Webb,DT,83
+688,Missouri,Jalen Marshall,DT,82
+688,Missouri,Caleb Flagg,SS,81
+688,Missouri,Brett Norfleet,TE,80
+688,Missouri,Vince Brown Ii,TE,80
+688,Missouri,Dreyden Norwood,CB,79
+688,Missouri,Jordon Harris,TE,79
+688,Missouri,Mose Phillips Iii,SS,79
+688,Missouri,Santana Banner,SS,79
+688,Missouri,Tyrone Pleasant,RT,79
+688,Missouri,Marquis Johnson,WR,78
+688,Missouri,Logan Reichert,RG,78
+688,Missouri,Beau Pribula,QB,77
+688,Missouri,James Madison Ii,WR,77
+688,Missouri,Sam Horn,QB,76
+688,Missouri,Nicholas Rodriguez,ROLB,76
+688,Missouri,Jaylen Early,LT,75
+688,Missouri,Joshua Manning,WR,75
+688,Missouri,Gavin Hoffman,TE,75
+688,Missouri,Tom Bates,LG,75
+688,Missouri,Brett Brown,QB,75
+688,Missouri,Marquis Gracial,DT,74
+688,Missouri,Bralen Henderson,DT,74
+688,Missouri,Matt Clancy,WR,74
+688,Missouri,Jude James,TE,73
+688,Missouri,Shaun Terry Ii,WR,72
+688,Missouri,Justin Bodford,DT,72
+688,Missouri,Brett Le Blanc,TE,71
+688,Missouri,Marvin Burks Jr,SS,70
+688,Missouri,Daniel Blood,WR,70
+688,Missouri,Matt Zollers,QB,70
+688,Missouri,Steve Bernard,TE,70
+688,Missouri,Junior Bird,LT,69
+688,Missouri,Tommy Reese,LOLB,69
+688,Missouri,Jeremiah Beasley,MLB,68
+688,Missouri,Trajen Greco,FS,66
+688,Missouri,Matt Crockett,RG,66
+688,Missouri,Dante Mcclellan,LOLB,65
+688,Missouri,Cj Bass Iii,FS,64
+688,Missouri,Caleb Pyfrom,LT,64
+688,Missouri,Kendall Tobias Mobley,FB,64
+688,Missouri,Mark Manfred Iii,CB,63
+688,Missouri,Shamar Mcneil,CB,63
+688,Missouri,Brandon Solis,RT,63
+688,Missouri,Sam Williams,DT,63
+688,Missouri,Jackson Hancock,FS,63
+688,Missouri,Blake Craig,K,62
+688,Missouri,Klay Donnell,ROLB,61
+688,Missouri,Nicholas Deloach Jr,CB,60
+688,Missouri,Jayven Richardson,LT,59
+688,Missouri,Joey Spears,LOLB,59
+688,Missouri,Joey Reynolds,K,59
+688,Missouri,Cameron Keys,CB,57
+688,Missouri,Tristan Wilson,LG,56
+688,Missouri,Ryan Jostes,RT,55
+688,Missouri,Connor Weselman,P,53
+688,Missouri,Eric Roberts,MLB,45
+62,Missouri State,Gary Clinton,TE,82
+62,Missouri State,Cristian Loaiza,LT,81
+62,Missouri State,Heath Smith,DT,79
+62,Missouri State,Jacob Clark,QB,78
+62,Missouri State,Hutson Lillibridge,RG,78
+62,Missouri State,James Blackstrain,WR,77
+62,Missouri State,Jmariyae Robinson,WR,77
+62,Missouri State,Cash Hudson,C,77
+62,Missouri State,Mitchell Toney,DT,76
+62,Missouri State,Jashawn Cooper,ROLB,76
+62,Missouri State,Hieko Malone,ROLB,76
+62,Missouri State,Noah Gardner,LT,76
+62,Missouri State,Thomas Anderson,CB,75
+62,Missouri State,Ronnel Johnson,WR,75
+62,Missouri State,Jared Lloyd,MLB,75
+62,Missouri State,Sean Reese,WR,75
+62,Missouri State,Ryan Mitchell,C,75
+62,Missouri State,Brandon Ventross,LG,75
+62,Missouri State,Tray Hunter Bell,MLB,75
+62,Missouri State,J J O Neal,FS,74
+62,Missouri State,Khalil Anderson,SS,74
+62,Missouri State,Navonn Barrett,CB,74
+62,Missouri State,Drew Viotto,QB,74
+62,Missouri State,Liam O Reilly,WR,74
+62,Missouri State,Eunique Valentine,LOLB,74
+62,Missouri State,Tanner Turner,FS,74
+62,Missouri State,Ryan Boyd,WR,74
+62,Missouri State,Todric Mcgee,SS,73
+62,Missouri State,Camron Williams,CB,73
+62,Missouri State,Dylan Simmons,CB,73
+62,Missouri State,Justin Curtis,LG,73
+62,Missouri State,Sterling Smithson,DT,73
+62,Missouri State,Matthew Greene,RG,73
+62,Missouri State,Jalen Brooks,LOLB,72
+62,Missouri State,Brendon Mcqueen,WR,72
+62,Missouri State,Zeus Lloyd,WR,72
+62,Missouri State,Gregory Alexis,SS,71
+62,Missouri State,Isaiah Mcmorris,WR,71
+62,Missouri State,Dillon Hipp,TE,70
+62,Missouri State,Davis Immerson,TE,70
+62,Missouri State,Kanye Young,MLB,69
+62,Missouri State,Keaton Renfro,FS,69
+62,Missouri State,Floyd Williams,CB,69
+62,Missouri State,Elijah Leonard,QB,69
+62,Missouri State,Dash Luke,WR,68
+62,Missouri State,Cole Feuerbacher,QB,68
+62,Missouri State,Ebubedike Nnabugwu,LT,68
+62,Missouri State,Jeron Askren,TE,67
+62,Missouri State,Dylan Dixson,CB,67
+62,Missouri State,Yousef Obeid,K,66
+62,Missouri State,Ben Liedtke,RG,65
+62,Missouri State,Josh Deal,K,65
+62,Missouri State,Logan Scrivner,C,65
+62,Missouri State,Antonio Smith,FS,64
+62,Missouri State,Tyree Bush,CB,64
+62,Missouri State,Milton Cross,RG,63
+62,Missouri State,Devin Rutherford,CB,63
+62,Missouri State,Barrett George,TE,63
+62,Missouri State,Stewart Mcdonald,P,62
+62,Missouri State,Jake Whiteside,TE,61
+62,Missouri State,Juan Nixon Jr,WR,61
+62,Missouri State,Quavez Demps,CB,60
+62,Missouri State,Anthony Mahar,MLB,60
+62,Missouri State,Bam Booker,LOLB,60
+62,Missouri State,Darius Webber,RT,60
+62,Missouri State,Gavin Kahler,TE,59
+62,Missouri State,Tremon Harris Iii,DT,59
+62,Missouri State,Pete Strand,FS,58
+62,Missouri State,Brayden Thompson,RT,55
+62,Missouri State,Montrell Holliday,LOLB,50
+689,Navy,Ben Purvis,LG,92
+689,Navy,Blake Horvath,QB,90
+689,Navy,Alex Tecza,FB,88
+689,Navy,Nathan Kent,WR,88
+689,Navy,Landon Robinson,DT,87
+689,Navy,Andrew Duhart,CB,85
+689,Navy,Griffen Willis,DT,85
+689,Navy,Braxton Woodson,QB,84
+689,Navy,Jaxson Campbell,LOLB,83
+689,Navy,Cody Howard,TE,82
+689,Navy,Cam Nichols,RG,82
+689,Navy,Luke Hutchison,WR,82
+689,Navy,Jabrian Davis,C,82
+689,Navy,Job Grant,MLB,82
+689,Navy,Anfernee Westbrooks,LT,82
+689,Navy,Irabonoise Oniha,CB,81
+689,Navy,Hoke Smith Ii,C,81
+689,Navy,Johnny Donaldson,ROLB,81
+689,Navy,Conner Lessane,SS,80
+689,Navy,Kendall Whiteside,DT,80
+689,Navy,Greyson Crawford,LG,80
+689,Navy,Shane Reynolds,FB,79
+689,Navy,Luke Molden,RT,79
+689,Navy,Peter Roll,SS,79
+689,Navy,Kush I Abraham,SS,78
+689,Navy,Giuseppe Sessi,SS,77
+689,Navy,Adam Walker Ii,FS,77
+689,Navy,Elijah Oatsvall,ROLB,77
+689,Navy,Ian Pourciau,MLB,77
+689,Navy,Kenzo Viteri,FB,76
+689,Navy,Kenneth Mcshan,LOLB,76
+689,Navy,Tyler Narayan,DT,76
+689,Navy,Matthew Seliga,FS,75
+689,Navy,Joshua Switzer,SS,75
+689,Navy,Casey Smith,WR,75
+689,Navy,Jake Lusk,DT,74
+689,Navy,Liam Barbee,MLB,74
+689,Navy,Thurman Fitzsimmons,FS,74
+689,Navy,Vic Listorti,FB,73
+689,Navy,Coleman Cauley,MLB,73
+689,Navy,Kahlil Francois,FS,73
+689,Navy,William Ingle,FB,72
+689,Navy,Evan Jackson,RG,72
+689,Navy,Jasean Mclean,LOLB,72
+689,Navy,Josh Hofmann,C,71
+689,Navy,Noah Bull,WR,71
+689,Navy,Matt Reyes,DT,69
+689,Navy,Drew Bonner,QB,67
+689,Navy,Bryce Allen,CB,67
+689,Navy,Bobby Valentine,LT,67
+689,Navy,Eli Livingston,RT,66
+689,Navy,Ron Watson,P,65
+689,Navy,Ramon Drake,LG,65
+689,Navy,Forrest Boyd,C,65
+689,Navy,Rayne Fry,TE,65
+689,Navy,Jashon Dewberry,QB,64
+689,Navy,Tim Reed,RG,64
+689,Navy,Nathan Kirkwood,K,63
+689,Navy,Nick Morris,LT,63
+689,Navy,Andrew Swinton,ROLB,63
+689,Navy,Tim Northgate,DT,62
+689,Navy,Chad Edmonds,CB,61
+689,Navy,Jaxson Snider,RT,61
+689,Navy,Lamichael Cosby,TE,59
+689,Navy,Shaq Clayton,TE,59
+689,Navy,David Stephens,MLB,59
+689,Navy,Maurice Parker,CB,57
+689,Navy,Taylor Ortega,ROLB,56
+689,Navy,Tommy Conway,LG,56
+689,Navy,Duke Meadows,LT,52
+689,Navy,Lance Gossett,K,44
+690,NC State,Justin Joly,TE,90
+690,NC State,T J Blanton,WR,90
+690,NC State,Anthony Carter Jr,LG,88
+690,NC State,Brian Nelson Ii,CB,87
+690,NC State,Sean Brown,ROLB,87
+690,NC State,Kenny Soares Jr,ROLB,87
+690,NC State,Tra Thomas,LOLB,87
+690,NC State,Jacarrius Peak,LT,86
+690,NC State,Teague Andersen,RT,85
+690,NC State,Jalen Grant,C,85
+690,NC State,Cian Slone,LOLB,85
+690,NC State,Caden Fordham,MLB,84
+690,NC State,Brandon Cleveland,DT,84
+690,NC State,Devon Marshall,CB,83
+690,NC State,Wesley Grimes,WR,83
+690,NC State,Jevony Jackson,LG,83
+690,NC State,Jj Johnson,SS,82
+690,NC State,Joseph Adedire,LOLB,82
+690,NC State,Chazz Wallace,DT,82
+690,NC State,Ja Maun Robinson,C,82
+690,NC State,Ja Had Carter,SS,81
+690,NC State,Noah Rogers,WR,80
+690,NC State,Jamie Porter,RG,80
+690,NC State,Rico Jackson,LT,79
+690,NC State,Floyd Morgan,RT,79
+690,NC State,Jackson Vick,CB,78
+690,NC State,Rente Hinton,FS,78
+690,NC State,Reid Mitchell,TE,78
+690,NC State,Jamel Johnson,CB,77
+690,NC State,Cj Bailey,QB,77
+690,NC State,Dante Daniels,TE,76
+690,NC State,Zane Williams,MLB,75
+690,NC State,Matt Mccabe,LG,75
+690,NC State,Justin Terrell,DT,74
+690,NC State,Clay Foltz,C,74
+690,NC State,Kelvon Mcbride,ROLB,74
+690,NC State,Daemon Fagan,FS,74
+690,NC State,Lex Thomas,QB,73
+690,NC State,Tyren Travers,MLB,73
+690,NC State,Keenan Jackson,WR,73
+690,NC State,Sean Weaver,C,73
+690,NC State,Gerald Kershaw,LOLB,72
+690,NC State,Jivan Baly,CB,72
+690,NC State,Sterling Dixon,LOLB,72
+690,NC State,Aiden Arias,TE,72
+690,NC State,Michael Gibbs,LG,71
+690,NC State,Zack Myers,SS,70
+690,NC State,Jake Stolt,QB,70
+690,NC State,Caden Noonkester,P,69
+690,NC State,Deanthony Green,TE,68
+690,NC State,Jonathan Paylor,WR,68
+690,NC State,Keyvonne King,DT,67
+690,NC State,Bucky Hendrickson,FB,67
+690,NC State,Jaren Sensabaugh,CB,66
+690,NC State,Garrett Mcvay,DT,66
+690,NC State,Trent Mitchell,LT,66
+690,NC State,Elijah Groves,ROLB,65
+690,NC State,Connor Doyle,RT,65
+690,NC State,Tank Boston,WR,65
+690,NC State,Bailey Benson,MLB,65
+690,NC State,Ronnie Royal Iii,FS,64
+690,NC State,Kanoah Vinesett,K,63
+690,NC State,Asaad Brown Jr,CB,63
+690,NC State,Terrell Anderson,WR,62
+690,NC State,Cooper Stinnett,WR,62
+690,NC State,Marvin Martin,FS,61
+690,NC State,Darion Rivers,RT,60
+690,NC State,Val Erickson,RG,59
+690,NC State,Brody Barnhardt,SS,59
+690,NC State,Kamen Smith,RG,56
+690,NC State,Will Wilson,QB,49
+690,NC State,Joshua Ofor,MLB,45
+690,NC State,Owen Fehr,P,40
+691,Nebraska,Javin Wright,MLB,93
+691,Nebraska,Dane Key,WR,88
+691,Nebraska,Ceyair Wright,CB,88
+691,Nebraska,Rocco Spindler,RG,88
+691,Nebraska,Elijah Jeudy,DT,88
+691,Nebraska,Dylan Raiola,QB,87
+691,Nebraska,Marques Watson Trent,ROLB,87
+691,Nebraska,Deshon Singleton,SS,87
+691,Nebraska,Elijah Pritchett,RT,85
+691,Nebraska,Henry Lutovsky,LG,85
+691,Nebraska,Marques Buford Jr,FS,84
+691,Nebraska,Sam Sledge,C,84
+691,Nebraska,Dasan Mccullough,LOLB,83
+691,Nebraska,Nyziah Hunter,WR,82
+691,Nebraska,Jacory Barney Jr,WR,82
+691,Nebraska,Justin Evans,C,82
+691,Nebraska,Teddy Prochazka,LT,82
+691,Nebraska,Heinrich Haarberg,TE,81
+691,Nebraska,Blye Hill,CB,81
+691,Nebraska,Gunnar Gottula,LT,80
+691,Nebraska,Malcolm Hartzog Jr,CB,80
+691,Nebraska,Mac Markway,TE,80
+691,Nebraska,Vincent Shavers Jr,ROLB,79
+691,Nebraska,Janiran Bonner,WR,79
+691,Nebraska,Turner Corcoran,LT,79
+691,Nebraska,Mario Buford,FS,78
+691,Nebraska,Dylan Rogers,MLB,77
+691,Nebraska,Grant Brix,RT,77
+691,Nebraska,Ryan Byrne,QB,77
+691,Nebraska,Tyler Knaak,RG,76
+691,Nebraska,Ben Knowles,WR,76
+691,Nebraska,Luke Lindenmeyer,TE,75
+691,Nebraska,Jamir Conn,CB,75
+691,Nebraska,Demitrius Bell,WR,75
+691,Nebraska,Dawson Merritt,ROLB,74
+691,Nebraska,Brock Knutson,LG,74
+691,Nebraska,Riley Van Poppel,DT,73
+691,Nebraska,Justyn Rhett,FS,73
+691,Nebraska,Marcos Davila,QB,73
+691,Nebraska,Dylan Parrott,DT,73
+691,Nebraska,Christian Jones,MLB,73
+691,Nebraska,Nolan Fennessy,C,73
+691,Nebraska,Barret Liebentritt,FB,73
+691,Nebraska,Kevin Gallic,TE,73
+691,Nebraska,Carter Nelson,TE,72
+691,Nebraska,Amare Sanders,CB,72
+691,Nebraska,Jalyn Gramstad,QB,72
+691,Nebraska,Jason Maciejczak,LG,72
+691,Nebraska,Willis Mcgahee Iv,LOLB,72
+691,Nebraska,Bryan Hales,RT,72
+691,Nebraska,Morgan Bullitt,SS,72
+691,Nebraska,Sua Lefotu,DT,72
+691,Nebraska,Aidan Flege,TE,72
+691,Nebraska,Derek Branch,FS,71
+691,Nebraska,Tanner Terch,WR,68
+691,Nebraska,Kyle Cunanan,K,67
+691,Nebraska,Junior Hewitt,MLB,66
+691,Nebraska,Jackson Carpenter,FS,65
+691,Nebraska,Maverick Noonan,LOLB,65
+691,Nebraska,Kamdyn Koch,P,64
+691,Nebraska,Amari Hutchins,CB,64
+691,Nebraska,Roger Gradney,SS,63
+691,Nebraska,Hugh Bates,CB,63
+691,Nebraska,Tristan Alvano,K,62
+691,Nebraska,Gibson Pyle,RG,62
+691,Nebraska,Phillip Morrow,RT,59
+691,Nebraska,Preston Taumua,C,57
+691,Nebraska,John Hohl,K,56
+691,Nebraska,Caleb Benning,SS,55
+691,Nebraska,Morris Gregory,RG,54
+691,Nebraska,Desean Levy,RT,54
+691,Nebraska,Jermaine Bethel,LOLB,50
+692,Nevada,Thomas Witte,DT,86
+692,Nevada,Aj Odums,CB,85
+692,Nevada,Jace Henry,TE,84
+692,Nevada,Nahji Logan,ROLB,82
+692,Nevada,Josh Grabowski,RG,82
+692,Nevada,Nick Rempert,WR,81
+692,Nevada,Andrew Madrigal,C,80
+692,Nevada,Jordan Brown,WR,80
+692,Nevada,Dylan Lopez,C,80
+692,Nevada,John Bolles,RT,80
+692,Nevada,Myles Williams,LOLB,79
+692,Nevada,Austin Harnetiaux,ROLB,79
+692,Nevada,Marshaun Brown,WR,79
+692,Nevada,Dj Warnell Jr,SS,78
+692,Nevada,Terrelle Lowell,CB,78
+692,Nevada,Marcus Bellon,WR,77
+692,Nevada,Stone Combs,MLB,77
+692,Nevada,Nathaneal Floyd,WR,77
+692,Nevada,Devin Gunter,FS,77
+692,Nevada,Edward Rhambo,CB,76
+692,Nevada,Aj Bianco,QB,76
+692,Nevada,Trenton Scott,LT,76
+692,Nevada,Nelson Ropati,DT,76
+692,Nevada,Marquis Ashley,WR,76
+692,Nevada,Zach Little,LG,76
+692,Nevada,Kasen Kinchen,FS,75
+692,Nevada,Nate Burleson Ii,WR,75
+692,Nevada,Adonis Woods,FB,75
+692,Nevada,Jayden O Rourke,TE,75
+692,Nevada,Chubba Purdy,QB,74
+692,Nevada,Dakota Thomas,WR,74
+692,Nevada,Bishop Turner,SS,74
+692,Nevada,Denario Hartwell,ROLB,74
+692,Nevada,Tyler Miller,RG,74
+692,Nevada,Kola Babalola,WR,74
+692,Nevada,Luke Greenfield,SS,73
+692,Nevada,Charles Brown,WR,73
+692,Nevada,Rj Esmon,LT,72
+692,Nevada,Colin Banning,RG,72
+692,Nevada,Logologo Va A,DT,72
+692,Nevada,Zavien Abercrombie,CB,70
+692,Nevada,Jalen Choice,RT,70
+692,Nevada,Zyron Mckenzie,MLB,70
+692,Nevada,Shonn Durham,LG,70
+692,Nevada,B J Stewart,SS,70
+692,Nevada,Lamarcus Holmes,LG,70
+692,Nevada,Peter Fleck,TE,69
+692,Nevada,Eric Garrison,K,68
+692,Nevada,Seth Perkins,TE,67
+692,Nevada,Julius Barnes Mcgee,CB,66
+692,Nevada,Jakobus Seth,LT,66
+692,Nevada,Hezekiah Anahu Ambrosio,ROLB,66
+692,Nevada,Jackson Barton,CB,66
+692,Nevada,Henry Sellards,RT,65
+692,Nevada,Keenan Hillman,FS,65
+692,Nevada,B J Kelley,LT,65
+692,Nevada,Glenn Williams,LT,64
+692,Nevada,Justin Wyatt Jr,FS,64
+692,Nevada,Sammy Ware,RT,63
+692,Nevada,Brandon Vance,QB,61
+692,Nevada,Sean Patterson,TE,61
+692,Nevada,Anthony Wolter,QB,60
+692,Nevada,Larry Knox,C,56
+692,Nevada,Isaiah Hodges,LG,56
+692,Nevada,David Paine Jr,DT,56
+692,Nevada,Adam Lambert,QB,55
+692,Nevada,Brad Brooks,P,55
+692,Nevada,Cesar Hopkins,MLB,55
+692,Nevada,Najee Foster,DT,53
+692,Nevada,Barry Cameron,MLB,53
+692,Nevada,Tyler Manship,P,52
+693,New Mexico,Tyler Kiehne,DT,87
+693,New Mexico,Randolph Kpai,ROLB,87
+693,New Mexico,Gabriel Lopez,DT,86
+693,New Mexico,Keagan Johnson,WR,84
+693,New Mexico,Mihalis Santorineos,MLB,83
+693,New Mexico,Richard Pearce,RG,82
+693,New Mexico,Jaxton Eck,ROLB,81
+693,New Mexico,Dereck Moore,FS,80
+693,New Mexico,Austin Brawley,FS,78
+693,New Mexico,Isaiah Sillemon,C,78
+693,New Mexico,Ky Won Mccray,SS,77
+693,New Mexico,Tevin Shaw,LT,77
+693,New Mexico,Dimitri Johnson,MLB,76
+693,New Mexico,Clint Stephens,SS,76
+693,New Mexico,Tavian Combs,SS,76
+693,New Mexico,Rj Adams,RT,76
+693,New Mexico,David Murphy,FS,76
+693,New Mexico,Abraham Williams,CB,76
+693,New Mexico,Gordon Staton,LOLB,76
+693,New Mexico,Drew Speech,CB,76
+693,New Mexico,Israel Mukwiza,LG,75
+693,New Mexico,Elvin Harris,LT,75
+693,New Mexico,Shawn Miller,WR,75
+693,New Mexico,Tyler Lawrence,RT,75
+693,New Mexico,Jack Layne,QB,74
+693,New Mexico,Michael Buckley,WR,74
+693,New Mexico,Isaiah Blair,WR,74
+693,New Mexico,Isaiah Roberts,FB,74
+693,New Mexico,Derek Hills,QB,73
+693,New Mexico,Nevell Brown,LG,73
+693,New Mexico,Aiden Valdez,TE,73
+693,New Mexico,Kader Diop,WR,73
+693,New Mexico,Hugh Dishman,MLB,73
+693,New Mexico,Brian Booker,DT,72
+693,New Mexico,Isaiah Chavez,QB,72
+693,New Mexico,Kaden Robnett,RG,72
+693,New Mexico,Jayden Sheridan,CB,72
+693,New Mexico,Azariah Levells,CB,72
+693,New Mexico,Hunter Haemker,MLB,72
+693,New Mexico,Jimmy Drayton,DT,72
+693,New Mexico,Cole Welliver,QB,71
+693,New Mexico,Albert Nunes,CB,71
+693,New Mexico,Caleb Coleman,SS,71
+693,New Mexico,Gabriel Motschenbacher,QB,70
+693,New Mexico,Travis Gray,LT,70
+693,New Mexico,Josh Perry,ROLB,70
+693,New Mexico,Malik Aliane,C,70
+693,New Mexico,C J Johnson,SS,69
+693,New Mexico,Kendrick Lennon,LOLB,69
+693,New Mexico,Dorian Thomas,TE,68
+693,New Mexico,Sa Kylee Woodard,RG,68
+693,New Mexico,Blake Ryan,C,68
+693,New Mexico,Jawuan Richmond,LOLB,67
+693,New Mexico,Clayton Edwards,CB,67
+693,New Mexico,Zhaiel Smith,WR,67
+693,New Mexico,Tim Gregg,RG,67
+693,New Mexico,Trey Dubuc,TE,66
+693,New Mexico,Frankie Edwards Iii,CB,65
+693,New Mexico,Cj Mcbean,FS,65
+693,New Mexico,Chris Gant Jr,SS,65
+693,New Mexico,Darren Mccullers,WR,65
+693,New Mexico,Luke Drzewiecki,K,63
+693,New Mexico,Shaun Redmon,DT,61
+693,New Mexico,Mikey Beck,WR,60
+693,New Mexico,Larry Carter,MLB,60
+693,New Mexico,James Hammond,TE,59
+693,New Mexico,Craig Peralta,RT,59
+693,New Mexico,Charles Steinkamp,P,58
+693,New Mexico,Antavious Houston,DT,54
+693,New Mexico,James Bailey,LG,54
+693,New Mexico,Martin Thurman,LG,52
+694,New Mexico State,Tyler Martinez,ROLB,85
+694,New Mexico State,Bj Tolo,RG,85
+694,New Mexico State,Nick Session,SS,84
+694,New Mexico State,Dakerric Hobbs,CB,82
+694,New Mexico State,Pj Johnson Iii,WR,82
+694,New Mexico State,Ma Kyi Lee,LT,82
+694,New Mexico State,Joshua Goines,TE,82
+694,New Mexico State,Cole Schnettgoecke,DT,81
+694,New Mexico State,Sone Aupiu,MLB,80
+694,New Mexico State,Adam Parks,TE,80
+694,New Mexico State,Josiah Charles,CB,79
+694,New Mexico State,Tj Pride,WR,78
+694,New Mexico State,Gavin Harris,TE,78
+694,New Mexico State,Lanar Kelley Jr,CB,78
+694,New Mexico State,Jabril White,FS,77
+694,New Mexico State,Armahn Hale,FS,76
+694,New Mexico State,Dillon Foley,RT,76
+694,New Mexico State,Ta Avili Tuitama,DT,76
+694,New Mexico State,Enzo Pierre Tayou,DT,76
+694,New Mexico State,Kyle Mccray,FS,76
+694,New Mexico State,Dj Hill Smith,FS,75
+694,New Mexico State,Tyler King,WR,75
+694,New Mexico State,Jerry Lydiatt,TE,74
+694,New Mexico State,Aj Williams,WR,74
+694,New Mexico State,Trevor Stephens,TE,74
+694,New Mexico State,Donovan Faupel,WR,74
+694,New Mexico State,Henry Davis Iii,DT,74
+694,New Mexico State,Kai Wheeler,C,74
+694,New Mexico State,Elijah Harvey,RT,74
+694,New Mexico State,Parker Awad,QB,73
+694,New Mexico State,Bernock Iya,FS,73
+694,New Mexico State,Bryant Jackson,MLB,73
+694,New Mexico State,Daquan Hodge,CB,72
+694,New Mexico State,Jr Hecklinski,LG,72
+694,New Mexico State,Jimmie Hill,ROLB,72
+694,New Mexico State,Eric Barton,P,71
+694,New Mexico State,Lukas Ungar,TE,71
+694,New Mexico State,Florian Staehler,LG,71
+694,New Mexico State,Naeten Mitchell,CB,69
+694,New Mexico State,Will Kendricks,CB,68
+694,New Mexico State,Enrique Hammond,SS,68
+694,New Mexico State,James Long,WR,68
+694,New Mexico State,Tim Black,RG,68
+694,New Mexico State,Nicholas Mcgraw,QB,67
+694,New Mexico State,Bryan Sherman,SS,67
+694,New Mexico State,Jon Harris,RT,67
+694,New Mexico State,Jayden Bell,WR,67
+694,New Mexico State,Izeyah Wright,WR,67
+694,New Mexico State,Armando Nieves,RT,66
+694,New Mexico State,Grant Cutler,QB,65
+694,New Mexico State,Sam Garcia,C,65
+694,New Mexico State,Shawn Telfer,FS,65
+694,New Mexico State,Jalen Brown,MLB,65
+694,New Mexico State,Keandre Woodberry,WR,64
+694,New Mexico State,Antoine Bozeman,WR,63
+694,New Mexico State,Eric Poole,ROLB,63
+694,New Mexico State,Jayvon Waller,FB,62
+694,New Mexico State,Terron Johns,TE,61
+694,New Mexico State,Taylor Spillman,LT,61
+694,New Mexico State,Hayden Harlan,RG,61
+694,New Mexico State,Matt Banks,WR,61
+694,New Mexico State,Shane Covington,C,61
+694,New Mexico State,Marcus Pressley,LOLB,60
+694,New Mexico State,Markese Moon,CB,60
+694,New Mexico State,Felix Whitfield,MLB,60
+694,New Mexico State,Antwuan Worley,WR,60
+694,New Mexico State,Madison Schaub,RG,59
+694,New Mexico State,Tevin Russell,MLB,59
+694,New Mexico State,Devin Jones,DT,58
+694,New Mexico State,Sioeli Helu,LG,57
+694,New Mexico State,Braxton May,TE,56
+694,New Mexico State,Danny Berry,CB,55
+694,New Mexico State,Tyler Berger,LG,55
+694,New Mexico State,David Barker,P,46
+717,South Alabama,Amaury Wiggins,RG,87
+717,South Alabama,Sam Williams,LG,87
+717,South Alabama,Dalton Hughes,MLB,86
+717,South Alabama,Ed Smith Iv,DT,85
+717,South Alabama,Blayne Myrick,ROLB,83
+717,South Alabama,Eddie Mullins,LOLB,83
+717,South Alabama,Malachi Preciado,C,82
+717,South Alabama,Jordan Davis,LT,81
+717,South Alabama,Devin Voisin,WR,81
+717,South Alabama,Wesley Miller,FS,81
+717,South Alabama,Zach Pyron,QB,80
+717,South Alabama,Kenton Jerido,RG,80
+717,South Alabama,Darius Mckenzie,MLB,79
+717,South Alabama,Jacoby Reese,LOLB,79
+717,South Alabama,Keyshawn Woodyard,WR,79
+717,South Alabama,Daniel Foster Allen,LT,78
+717,South Alabama,Anthony Eager,WR,77
+717,South Alabama,Christopher Wallace Jr,CB,77
+717,South Alabama,P J Pryor,C,77
+717,South Alabama,Trent Singleton,SS,76
+717,South Alabama,Asher Hale,LG,76
+717,South Alabama,Micah Woods,WR,76
+717,South Alabama,Mike Harris,FS,75
+717,South Alabama,Reid Gavin,RT,75
+717,South Alabama,Damyrion Darby,CB,75
+717,South Alabama,Jayvon Henderson,CB,75
+717,South Alabama,Brian Dillard,CB,75
+717,South Alabama,Julius Kidd,RG,75
+717,South Alabama,Ty Goodwill,FS,74
+717,South Alabama,Bishop Davenport,QB,73
+717,South Alabama,Rj Moss Jr,DT,73
+717,South Alabama,Ethan Hubbard,RT,73
+717,South Alabama,Chrystyile Caldwell,MLB,72
+717,South Alabama,Jaylen Booker,RT,72
+717,South Alabama,Cube Gurley,CB,72
+717,South Alabama,Anthony Brown,SS,71
+717,South Alabama,Clay Anthony,C,71
+717,South Alabama,Kaleb Jackson,FS,70
+717,South Alabama,Deuce Vance,CB,70
+717,South Alabama,Jared Jacobson,LG,70
+717,South Alabama,Parker Shattuck,ROLB,70
+717,South Alabama,Jeremy Scott,WR,70
+717,South Alabama,Wendell Hines,LOLB,69
+717,South Alabama,Adrian Griffin,C,69
+717,South Alabama,Rod Gibbs,TE,69
+717,South Alabama,Dallas Young,CB,69
+717,South Alabama,Dennis Overstreet,ROLB,69
+717,South Alabama,Cole Blaylock,SS,69
+717,South Alabama,Tywon Wray Jr,SS,68
+717,South Alabama,Nate Kitchens,TE,68
+717,South Alabama,Nehemiah Chandler,CB,67
+717,South Alabama,Jared Hollins,QB,67
+717,South Alabama,Leavy Johnson,LT,67
+717,South Alabama,Brayden Ramey,RG,66
+717,South Alabama,Alani Tiller,TE,66
+717,South Alabama,Trent Thomas,TE,65
+717,South Alabama,William Felton Iv,MLB,65
+717,South Alabama,Jerrian Graham,WR,65
+717,South Alabama,Tyree Short,WR,62
+717,South Alabama,Achilles Woods,DT,62
+717,South Alabama,Anthony Zaccaro,TE,61
+717,South Alabama,Aleksi Pulkkinen,P,60
+717,South Alabama,Ty Carroll,P,57
+717,South Alabama,Stephen Bushrod,LG,56
+717,South Alabama,Nate Barnett,RT,56
+717,South Alabama,Isaiah Peterson,FB,55
+717,South Alabama,Dominic Wiseman,DT,55
+717,South Alabama,Benji Fowler,LT,54
+717,South Alabama,Nathan Jennings,DT,53
+717,South Alabama,Logan Joellenbeck,LT,52
+717,South Alabama,Davis Little,K,50
+717,South Alabama,Hamilton Diboyan,K,44
+718,South Carolina,Lanorris Sellers,QB,91
+718,South Carolina,Jalon Kilgore,SS,89
+718,South Carolina,Dq Smith,FS,89
+718,South Carolina,Jared Brown,WR,87
+718,South Carolina,Cason Henry,RT,87
+718,South Carolina,Gabriel Brownlow Dindy,DT,86
+718,South Carolina,Judge Collier,CB,86
+718,South Carolina,Trovon Baugh,RG,85
+718,South Carolina,Jordan Dingle,TE,85
+718,South Carolina,Brady Hunt,TE,83
+718,South Carolina,Boaz Stanley,C,83
+718,South Carolina,Josiah Thompson,LT,82
+718,South Carolina,Davonte Miles,DT,82
+718,South Carolina,Cole Shiloh,WR,82
+718,South Carolina,Nyck Harbor,WR,79
+718,South Carolina,Vandrevius Jacobs,WR,79
+718,South Carolina,Jatavius Shivers,RT,79
+718,South Carolina,Rodney Newsom Jr,C,79
+718,South Carolina,Tree Babalade,LG,78
+718,South Carolina,Drew Overton,QB,78
+718,South Carolina,Maurice Brown Ii,TE,78
+718,South Carolina,Chase Sweigart,RG,78
+718,South Carolina,Brandon Cisse,CB,77
+718,South Carolina,Mazeo Bennett Jr,WR,77
+718,South Carolina,Gerald Kilgore,FS,77
+718,South Carolina,Shawn Murphy,ROLB,77
+718,South Carolina,Nick Sharpe,RG,77
+718,South Carolina,Tanard Smith,LT,77
+718,South Carolina,Ryan Brubaker,C,76
+718,South Carolina,Jayr Johnson,MLB,75
+718,South Carolina,Myles Norwood,CB,75
+718,South Carolina,David Bucey,FS,75
+718,South Carolina,Michael Smith,TE,73
+718,South Carolina,Peyton Williams,SS,73
+718,South Carolina,Justin Okoronkwo,ROLB,73
+718,South Carolina,Buddy Mack Iii,FS,72
+718,South Carolina,Luke Doty,WR,72
+718,South Carolina,Vicari Swain,CB,71
+718,South Carolina,Air Noland,QB,71
+718,South Carolina,Robert Putnam,K,71
+718,South Carolina,Lucas Stein,TE,71
+718,South Carolina,Monkell Goodwine,DT,70
+718,South Carolina,Derrick Duckworth,SS,70
+718,South Carolina,Damian Woods,DT,70
+718,South Carolina,Markee Anderson,LG,69
+718,South Carolina,Malik Clark,WR,69
+718,South Carolina,Jerami Queen,WR,69
+718,South Carolina,Jaron Willis,MLB,68
+718,South Carolina,Keenan Gaither,RT,67
+718,South Carolina,Troy Pikes,DT,67
+718,South Carolina,Kelvin Hunter,FS,66
+718,South Carolina,Jalewis Solomon,CB,66
+718,South Carolina,Jeff Kline,ROLB,64
+718,South Carolina,Vi Harrison,CB,64
+718,South Carolina,Reuben Womack,DT,62
+718,South Carolina,Blake Franks,LG,62
+718,South Carolina,Andrew Colasurdo,LOLB,62
+718,South Carolina,Alan Wilbur,WR,61
+718,South Carolina,Mason Love,P,60
+718,South Carolina,Peyton Argent,K,60
+718,South Carolina,Aaron Harris Gates,TE,59
+718,South Carolina,Eric O Neill,FB,58
+718,South Carolina,Cole Rasmussen,TE,58
+718,South Carolina,Solomon Coles,FS,54
+718,South Carolina,Brad English,LT,54
+718,South Carolina,Jordon Robinson,ROLB,53
+718,South Carolina,Tyler Vance,MLB,48
+718,South Carolina,Nick Barrett,DT,47
+720,South Florida,Josh Moten,CB,89
+720,South Florida,Carl Chester,WR,86
+720,South Florida,Brodarius Lewis,DT,86
+720,South Florida,Micah Davis,WR,85
+720,South Florida,Aloali I Maui,LG,84
+720,South Florida,Grant Page,WR,84
+720,South Florida,Braylon Braxton,QB,82
+720,South Florida,Broderick Roman,C,82
+720,South Florida,Dominick Hill,SS,82
+720,South Florida,Elijah Metcalf,WR,81
+720,South Florida,Davis Dalton,WR,81
+720,South Florida,Kyirin Heath,TE,80
+720,South Florida,Chuck Montgomery,WR,80
+720,South Florida,Deontae Barber,LOLB,80
+720,South Florida,Isaiah Gibson Sr,DT,79
+720,South Florida,Dorian Kaplan,ROLB,79
+720,South Florida,Tychaun Chapman,WR,78
+720,South Florida,Bryan Traylor,RT,78
+720,South Florida,Ahmere Foster,FS,77
+720,South Florida,Bralon Brown,WR,77
+720,South Florida,Quinzavious Warren,DT,77
+720,South Florida,Brendan Toles,CB,77
+720,South Florida,Reed Jesiolowski,FB,77
+720,South Florida,Rashad Polk,ROLB,77
+720,South Florida,Joseph Harper,MLB,77
+720,South Florida,Hayes Creel,LT,76
+720,South Florida,Jez Janvier,RG,76
+720,South Florida,Chris Jones,MLB,76
+720,South Florida,Greg Nunnery,RT,75
+720,South Florida,Chris Hayes,DT,75
+720,South Florida,Zion Edwards,MLB,75
+720,South Florida,John Burks,SS,74
+720,South Florida,Jonathan Mcgowan,LOLB,74
+720,South Florida,Landry Lyddy,QB,74
+720,South Florida,Landon Cutler,TE,74
+720,South Florida,Gregory Craig,LOLB,74
+720,South Florida,Tyquan Caver,FS,73
+720,South Florida,Cameron Knox,FS,73
+720,South Florida,Lashawn Clay,FS,73
+720,South Florida,Markus Samuel,DT,72
+720,South Florida,Ishmael Ibraheem,CB,72
+720,South Florida,Ian Foster,CB,72
+720,South Florida,Damarious Blake,LT,72
+720,South Florida,Bernard Yates,FS,72
+720,South Florida,Carlos Slayden,RG,72
+720,South Florida,Jacobe Robinson,QB,71
+720,South Florida,Kadinn Morris,TE,71
+720,South Florida,Jeffrey Barden,C,71
+720,South Florida,Marcus Clinton,SS,71
+720,South Florida,Luke Beard,TE,71
+720,South Florida,Sammy Favors,RG,71
+720,South Florida,Jerry Clemons,ROLB,70
+720,South Florida,Luke Rogers,LG,70
+720,South Florida,John White,QB,68
+720,South Florida,Josh Bledsoe,CB,67
+720,South Florida,Cameron Mackey,DT,67
+720,South Florida,Kj Thomas Paige,CB,66
+720,South Florida,Guylijah Theodule,CB,66
+720,South Florida,Corey Myrick,SS,66
+720,South Florida,Brandon Dalton,DT,65
+720,South Florida,Isaiah Hammond,TE,65
+720,South Florida,Larry Edwards,RG,63
+720,South Florida,Rj Whitehead,RT,61
+720,South Florida,Jon Dodson,TE,61
+720,South Florida,Jaylin Carter,WR,60
+720,South Florida,Kaden Morgan,K,58
+720,South Florida,Malakai Murphy,CB,57
+720,South Florida,Charles Tucker,P,56
+720,South Florida,Denzel Gardner,QB,54
+720,South Florida,Shane King,TE,51
+720,South Florida,Wyatt Hart,K,45
+720,South Florida,Michael Esquivel,MLB,44
+719,Southern Miss,Jack Wilty,LG,89
+719,Southern Miss,Thomas Shrader,LT,88
+719,Southern Miss,Connor Mclaughlin,LT,87
+719,Southern Miss,Mike Lofton,C,86
+719,Southern Miss,Zane Herring,RG,86
+719,Southern Miss,Izaiah Guy,CB,86
+719,Southern Miss,Jhalyn Shuler,ROLB,85
+719,Southern Miss,Rocco Nicholl,LOLB,85
+719,Southern Miss,De Shawn Rucker,CB,84
+719,Southern Miss,Chavez Brown,MLB,84
+719,Southern Miss,Mudia Reuben,WR,84
+719,Southern Miss,Byrum Brown,QB,83
+719,Southern Miss,Mac Harris,MLB,83
+719,Southern Miss,Weston Wolff,TE,83
+719,Southern Miss,Derek Bowman,RT,83
+719,Southern Miss,Dre Butler,DT,82
+719,Southern Miss,Tavin Ward,FS,82
+719,Southern Miss,Cole Best,C,81
+719,Southern Miss,Jaelen Stokes,FS,81
+719,Southern Miss,Locklan Hewlett,QB,81
+719,Southern Miss,Deonte Bowie,LG,81
+719,Southern Miss,Jarvis Lee,CB,80
+719,Southern Miss,Jaden Alexis,WR,80
+719,Southern Miss,James Jenkins,RG,80
+719,Southern Miss,Devin Lee,DT,79
+719,Southern Miss,Evan Dangler,FB,79
+719,Southern Miss,Bryce Archie,QB,79
+719,Southern Miss,Cade Roberts,WR,79
+719,Southern Miss,Chas Nimrod,WR,78
+719,Southern Miss,Ben Knox,CB,78
+719,Southern Miss,Kajuan Banks,CB,78
+719,Southern Miss,Adam Forbes,RG,77
+719,Southern Miss,Boogsie Silvera,SS,76
+719,Southern Miss,Jacob Merrifield,DT,76
+719,Southern Miss,Wyatt Sullivan,TE,75
+719,Southern Miss,Fred Gaskin,SS,75
+719,Southern Miss,Cole Skinner,RG,75
+719,Southern Miss,Jonas Duclona,CB,75
+719,Southern Miss,Amer Amer,ROLB,75
+719,Southern Miss,Christian Helms,WR,75
+719,Southern Miss,James Chenault,CB,74
+719,Southern Miss,Keshaun Singleton,WR,73
+719,Southern Miss,Dinellson Exume,DT,73
+719,Southern Miss,Zavier Hamilton,ROLB,73
+719,Southern Miss,Joshua Porter,WR,73
+719,Southern Miss,Khalil Walker,RT,73
+719,Southern Miss,Garrett Cates,TE,73
+719,Southern Miss,Tj Lawrence,LG,73
+719,Southern Miss,Tyler Williams,WR,72
+719,Southern Miss,Rodney Hill,MLB,72
+719,Southern Miss,Braden Carter,RT,72
+719,Southern Miss,Derrick Mccormick,LOLB,72
+719,Southern Miss,Turner Mclaughlin,TE,72
+719,Southern Miss,Cedrick Hawkins,FS,70
+719,Southern Miss,Jeyquan Smith,WR,70
+719,Southern Miss,Jahari Grant,DT,70
+719,Southern Miss,Tyreek Major,LT,70
+719,Southern Miss,Devon Byrd,ROLB,70
+719,Southern Miss,Greg Otten,MLB,70
+719,Southern Miss,Teriyan Morman,C,69
+719,Southern Miss,Jermaine Dalias,FS,68
+719,Southern Miss,Jeremiah Jones,SS,65
+719,Southern Miss,Seantrel Anderson,ROLB,64
+719,Southern Miss,Eli Jones,DT,61
+719,Southern Miss,Nico Gramatica,K,60
+719,Southern Miss,Gavin Jenkins,CB,60
+719,Southern Miss,Emmett Parks,LG,60
+719,Southern Miss,Marcelis Tate,QB,58
+719,Southern Miss,Luke Goater,P,57
+719,Southern Miss,Adam Zouagui,K,57
+719,Southern Miss,Chase Leon,P,56
+721,Stanford,Ricky Galvin,WR,90
+721,Stanford,Collin Wright,CB,88
+721,Stanford,Ben Gulbranson,QB,85
+721,Stanford,Sam Roush,TE,84
+721,Stanford,Jack Leyrer,LG,84
+721,Stanford,Braden Marceau Olayinka,DT,82
+721,Stanford,Wilfredo Aybar,ROLB,82
+721,Stanford,Niki Prongos,RT,82
+721,Stanford,Scotty Edwards,SS,81
+721,Stanford,Jahsiah Galvan,ROLB,81
+721,Stanford,Simione Pale,RG,81
+721,Stanford,Bo Tate,ROLB,81
+721,Stanford,Tevarua Tafiti,LOLB,80
+721,Stanford,Mitch Leigber,FS,80
+721,Stanford,Kahlil House,LT,80
+721,Stanford,Myles Jackson,QB,80
+721,Stanford,Aiden Black,TE,80
+721,Stanford,Brandon Nicholson,CB,79
+721,Stanford,Brendan Doyle,TE,79
+721,Stanford,Zach Buckey,DT,79
+721,Stanford,Fisher Anderson,LT,79
+721,Stanford,Lorenzo Owens,RG,79
+721,Stanford,Dylan Rizk,QB,78
+721,Stanford,Ese Dubre,MLB,77
+721,Stanford,Caden High,WR,77
+721,Stanford,Jay Green,SS,76
+721,Stanford,Benji Blackburn,TE,76
+721,Stanford,Ernest Cooper,ROLB,76
+721,Stanford,James Kutcher,FB,76
+721,Stanford,Jaylen Dai Sumlin,FS,75
+721,Stanford,Ziron Brown,LG,75
+721,Stanford,Allen Thomason,C,75
+721,Stanford,Elijah Brown,QB,74
+721,Stanford,Zach Johnson,MLB,74
+721,Stanford,Jordan Onovughe,WR,74
+721,Stanford,Charlie Symonds,RT,74
+721,Stanford,James Cotton,C,72
+721,Stanford,Cam Richardson,CB,72
+721,Stanford,Marcus Brown,WR,72
+721,Stanford,Dylan Stephenson,LOLB,72
+721,Stanford,Derrik Redd,WR,71
+721,Stanford,Benedict Umeh,DT,71
+721,Stanford,Hunter Barth,MLB,71
+721,Stanford,Hayden Gunter,LT,71
+721,Stanford,Peyton Warford,TE,70
+721,Stanford,Che Ojarikre,SS,70
+721,Stanford,Troy Aldridge,DT,69
+721,Stanford,Emmet Kenney,K,68
+721,Stanford,Matt Rose,MLB,68
+721,Stanford,Jacobi Murray,DT,68
+721,Stanford,Aaron Morris,CB,68
+721,Stanford,Aidan Flintoft,P,67
+721,Stanford,Jahleel Parker,LOLB,67
+721,Stanford,Tre Williams,LOLB,67
+721,Stanford,Charlie Hoitink,RG,67
+721,Stanford,Alejandro Chavez,TE,67
+721,Stanford,Gavin Geweniger,ROLB,66
+721,Stanford,Sam Mattingly,MLB,66
+721,Stanford,Elijah Ali,RT,65
+721,Stanford,Kareem Hall,WR,63
+721,Stanford,Howie Bates,SS,60
+721,Stanford,Lonnie Mcallister,CB,60
+721,Stanford,Sam Neely,CB,59
+721,Stanford,Maxwell Richardson,MLB,59
+721,Stanford,Jose Moses,FB,59
+721,Stanford,Gregory Teague,CB,58
+721,Stanford,Omari Gaines,FS,58
+721,Stanford,Darrius Davis,SS,56
+721,Stanford,Quinton Barden,LG,53
+721,Stanford,Dakota Clark,K,52
+721,Stanford,Darin Johnson,RG,52
+721,Stanford,Aj Seidler,K,51
+721,Stanford,Joe Kendricks,LOLB,46
+722,Syracuse,Justus Ross Simmons,WR,87
+722,Syracuse,Mark Petry,C,86
+722,Syracuse,Kevin Jobity Jr,DT,86
+722,Syracuse,Devin Grant,FS,85
+722,Syracuse,Steve Angeli,QB,85
+722,Syracuse,Derek Mcdonald,MLB,85
+722,Syracuse,Duce Chestnut,SS,84
+722,Syracuse,Umari Hatcher,WR,84
+722,Syracuse,Chris Thomas Jr,DT,84
+722,Syracuse,Dan Villari,TE,83
+722,Syracuse,Da Metrius Weatherspoon,RT,83
+722,Syracuse,Elijah Fuentes Cundiff,DT,83
+722,Syracuse,Johntay Cook Ii,WR,82
+722,Syracuse,Tj Ferguson,LG,82
+722,Syracuse,Darrell Gill Jr,WR,81
+722,Syracuse,Dion Wilson Jr,DT,81
+722,Syracuse,Rashard Perry,DT,81
+722,Syracuse,Marcus Washington Jr,CB,79
+722,Syracuse,George Rooks,DT,79
+722,Syracuse,Davien Kerr,CB,78
+722,Syracuse,Joe Cruz,RG,78
+722,Syracuse,Trevion Mack,LT,78
+722,Syracuse,Anwar Sparrow,ROLB,77
+722,Syracuse,Austin Collins,LG,75
+722,Syracuse,Joshua Miller,LG,75
+722,Syracuse,Naquil Betrand,LT,75
+722,Syracuse,Nate Prater,CB,75
+722,Syracuse,Zach Rice,C,74
+722,Syracuse,Demetres Samuel Jr,CB,74
+722,Syracuse,Fran Brown Jr,MLB,74
+722,Syracuse,David Clement,TE,74
+722,Syracuse,Emanuel Ross,WR,74
+722,Syracuse,Rickie Collins,QB,73
+722,Syracuse,Greg Delaine,CB,73
+722,Syracuse,Berry Buxton Iii,CB,73
+722,Syracuse,Mycah Peterson,LOLB,72
+722,Syracuse,James Heard,MLB,72
+722,Syracuse,Jahide Lesaine Jr,ROLB,72
+722,Syracuse,Tommy Jarrett,LOLB,72
+722,Syracuse,Patrick Alberga,C,72
+722,Syracuse,Chris Peal,CB,71
+722,Syracuse,Davion Kerr,CB,71
+722,Syracuse,Jack Stonehouse,P,70
+722,Syracuse,Braheem Long Jr,CB,70
+722,Syracuse,Kam Pringle,LT,70
+722,Syracuse,Micah Witherspoon,FB,70
+722,Syracuse,Tommy Porter,SS,70
+722,Syracuse,Jamichael Thompkins,RG,70
+722,Syracuse,Zay Craig,FS,69
+722,Syracuse,Tyshawn Russell,WR,69
+722,Syracuse,Fatim Diggs,MLB,69
+722,Syracuse,Travis Brown Miller,RT,69
+722,Syracuse,Jackson Kennedy,K,67
+722,Syracuse,Jalil Martin,CB,67
+722,Syracuse,Darien Williams,WR,66
+722,Syracuse,Cassius Wilcox,LOLB,66
+722,Syracuse,Julian Mcfadden,WR,65
+722,Syracuse,Kaylib Singleton,CB,65
+722,Syracuse,Jakhari Williams,QB,65
+722,Syracuse,Ethan Stangle,TE,65
+722,Syracuse,Cornell Perry,SS,64
+722,Syracuse,Darius Johnson,WR,64
+722,Syracuse,Jayden Mann,RG,64
+722,Syracuse,Jamie Tremble,TE,62
+722,Syracuse,Kahlil Stewart,LG,62
+722,Syracuse,Rich Belin,QB,60
+722,Syracuse,Daunte Bacheyie,TE,60
+722,Syracuse,Nick Bryan,ROLB,60
+722,Syracuse,Zyian Moultrie Goddard,MLB,58
+722,Syracuse,Luke Carney,QB,56
+722,Syracuse,Eric Thomas,DT,56
+722,Syracuse,Skylar Harvey,RT,56
+722,Syracuse,Jadyn Oh,K,47
+723,TCU,Bud Clark,FS,92
+723,TCU,Josh Hoover,QB,87
+723,TCU,Eric Mcalister,WR,87
+723,TCU,Coltin Deery,C,87
+723,TCU,Kaleb Elarms Orr,MLB,86
+723,TCU,Carson Bruno,RG,86
+723,TCU,Elijah Jackson,CB,85
+723,TCU,Cade Bennett,LG,85
+723,TCU,Namdi Obiazor,ROLB,84
+723,TCU,Joseph Manjack Iv,WR,84
+723,TCU,Chase Curtis,TE,84
+723,TCU,Channing Canada,CB,83
+723,TCU,Jordan Dwyer,WR,82
+723,TCU,Avery Helm,CB,82
+723,TCU,Dj Rogers,TE,82
+723,TCU,Ansel Din Mbuh,DT,81
+723,TCU,Jamel Johnson,SS,81
+723,TCU,Ken Seals,QB,80
+723,TCU,Jevon Mciver Jr,CB,80
+723,TCU,Austin Jordan,CB,79
+723,TCU,Remington Strickland,RG,79
+723,TCU,Connor Lingren,DT,79
+723,TCU,Max Carroll,MLB,78
+723,TCU,Ryan Hughes,LT,78
+723,TCU,Gekyle Baker,WR,77
+723,TCU,Ben Taylor Whitfield,RT,77
+723,TCU,Kelten Mickell,DT,76
+723,TCU,Ka Morreun Pimpton,TE,75
+723,TCU,Rasheed Jackson,LT,75
+723,TCU,Major Everhart,WR,75
+723,TCU,Michael Teason,LOLB,75
+723,TCU,Cooper Powers,LG,75
+723,TCU,Markis Deal,DT,74
+723,TCU,Kylin Jackson,FS,73
+723,TCU,Ryan Yaites,SS,73
+723,TCU,Tristan Johnson,DT,73
+723,TCU,Quinton Harris,RT,73
+723,TCU,Hudson Hooper,MLB,73
+723,TCU,Samir Camacho,C,73
+723,TCU,Dylan Kinney,LG,72
+723,TCU,Jordyn Bailey,WR,72
+723,TCU,Kaden Mcfadden,SS,72
+723,TCU,Gannon Gaubert,C,72
+723,TCU,Logan Schram,LT,71
+723,TCU,Creece Brister,RG,71
+723,TCU,Dozie Ezukanma,WR,70
+723,TCU,Micah Strickland,FS,69
+723,TCU,Braylon James,WR,69
+723,TCU,Ed Small,WR,68
+723,TCU,Wesley Harvey,RT,68
+723,TCU,Will Halkyard,TE,68
+723,TCU,Matthew Blaire,FB,67
+723,TCU,Ethan Craw,P,66
+723,TCU,Jordan Lester,FS,65
+723,TCU,Adam Schobel,QB,64
+723,TCU,Lafayette Kaiuway,TE,63
+723,TCU,Perry Cole Jr,DT,63
+723,TCU,Dillon Arkansas,LOLB,63
+723,TCU,Tariq Scantling,LOLB,63
+723,TCU,Ventrelle Hilton,ROLB,62
+723,TCU,Devondre Mcgee,CB,61
+723,TCU,Taj Mccrae,ROLB,60
+723,TCU,Kyle Lemmermann,K,58
+723,TCU,Tobias Steppes,LT,57
+723,TCU,Brock Atwood,ROLB,56
+723,TCU,Sergio Day,SS,56
+723,TCU,Steven Williams Owens,LOLB,56
+723,TCU,Niko Lashley,LOLB,55
+723,TCU,Randy Warlick,ROLB,50
+723,TCU,Nate Mccashland,K,44
+724,Temple,Demerick Morris,DT,86
+724,Temple,Grayson Mains,C,85
+724,Temple,John Adams,WR,84
+724,Temple,Allan Haye,DT,83
+724,Temple,Louis Frye,FS,82
+724,Temple,Javier Morton,SS,81
+724,Temple,Jalen Stewart,MLB,81
+724,Temple,Evan Simon,QB,81
+724,Temple,K J Miles,DT,81
+724,Temple,Luke Watson,LT,80
+724,Temple,Antonio Jones,WR,79
+724,Temple,Kevin Terry,RT,79
+724,Temple,Johnny Kirkland,C,79
+724,Temple,Ian Stewart,WR,78
+724,Temple,Sekou Kromah,DT,78
+724,Temple,Reggie Jones,DT,78
+724,Temple,Eric Stuart,ROLB,77
+724,Temple,Xavier Irvin,WR,77
+724,Temple,Katin Surprenant,MLB,77
+724,Temple,Calvin Cates,DT,77
+724,Temple,Gevani Mccoy,QB,76
+724,Temple,Aaron Beckwith,DT,76
+724,Temple,Jordan Montgomery,LOLB,76
+724,Temple,Linus Lindberg,RT,76
+724,Temple,Conlan Greene,TE,76
+724,Temple,Ben Osueke,CB,75
+724,Temple,Jaylen Castleberry,CB,75
+724,Temple,Jackson Pruitt,RG,75
+724,Temple,Chris Smith,C,75
+724,Temple,Avery Powell,FS,74
+724,Temple,Ty Davis,LOLB,74
+724,Temple,Tyree Alualu,MLB,74
+724,Temple,London Hall,ROLB,73
+724,Temple,Omar Ibrahim,CB,73
+724,Temple,Preston Everhart,WR,73
+724,Temple,Peter Clarke,TE,72
+724,Temple,Anthony Chiccitt,QB,72
+724,Temple,Diego Barajas,RT,72
+724,Temple,Damien Ordonez,ROLB,72
+724,Temple,Eric King,LG,72
+724,Temple,Kevin Smithwick,RG,71
+724,Temple,Bryant Wallace,FB,71
+724,Temple,Zyil Powell,SS,70
+724,Temple,Ihsim Smith Marsette,SS,70
+724,Temple,Ryder Kusch,TE,70
+724,Temple,Mausa Palu,LG,70
+724,Temple,Klay Adams,QB,69
+724,Temple,Jayvant Brown,ROLB,69
+724,Temple,Willy Love,LOLB,69
+724,Temple,Adrian Laing,CB,69
+724,Temple,Brandon Taylor,FS,69
+724,Temple,Rameir Hardy,WR,68
+724,Temple,Daniel Evert,TE,68
+724,Temple,Russell Sykes Iv,DT,68
+724,Temple,Dante Atton,P,66
+724,Temple,Cole Dunn,QB,66
+724,Temple,Tyler Douglas,QB,66
+724,Temple,Tyler Stewart,WR,66
+724,Temple,Jett White,CB,65
+724,Temple,Clint Clements,LG,65
+724,Temple,Devin Goode,FS,64
+724,Temple,Lamarr Johnson Fuller,WR,64
+724,Temple,Zavien Bryant,CB,62
+724,Temple,Wesley Brown,MLB,62
+724,Temple,Earl Kulp,CB,61
+724,Temple,Giakoby Hills,RT,61
+724,Temple,P J Todd,RG,60
+724,Temple,Carl Hardin,K,57
+724,Temple,Jamarcus Pierre,CB,56
+724,Temple,Lucas Glassburn,K,53
+725,Tennessee,Jermod Mccoy,CB,94
+725,Tennessee,Miles Kitselman,TE,90
+725,Tennessee,Axton Gaines,WR,90
+725,Tennessee,Wendell Moe Jr,RG,89
+725,Tennessee,Bryson Eason,DT,88
+725,Tennessee,Rickey Gibson Iii,CB,87
+725,Tennessee,Jeremiah Telander,MLB,87
+725,Tennessee,Arion Carter,ROLB,86
+725,Tennessee,Joey Aguilar,QB,86
+725,Tennessee,Jaxson Moi,DT,86
+725,Tennessee,Chris Brazzell Ii,WR,85
+725,Tennessee,Lance Heard,LT,84
+725,Tennessee,Boo Carter,CB,82
+725,Tennessee,Jalen Mcmurray,CB,82
+725,Tennessee,Colton Hood,CB,81
+725,Tennessee,Shamurad Umarov,LG,81
+725,Tennessee,Andre Turrentine,SS,81
+725,Tennessee,Sam Pendleton,LG,79
+725,Tennessee,Max Anderson,C,77
+725,Tennessee,Jourdan Thomas,FS,76
+725,Tennessee,David Sanders Jr,RT,75
+725,Tennessee,Braylon Staley,WR,75
+725,Tennessee,Jake Merklinger,QB,75
+725,Tennessee,Nathan Robinson,DT,75
+725,Tennessee,Edrees Farooq,FS,75
+725,Tennessee,Trevor Duncan,LT,75
+725,Tennessee,Mike Matthews,WR,74
+725,Tennessee,Jesse Perry,RT,74
+725,Tennessee,Jackson Mathews,SS,74
+725,Tennessee,Amari Jefferson,WR,73
+725,Tennessee,Jeremias Heard,LT,73
+725,Tennessee,Bennett Saturday,WR,73
+725,Tennessee,Ethan Davis,TE,72
+725,Tennessee,Gage Ginther,RG,72
+725,Tennessee,George Macintyre,QB,72
+725,Tennessee,Marcus Goree Jr,CB,71
+725,Tennessee,Zakai Kelly,LOLB,70
+725,Tennessee,Dane Mallette,MLB,70
+725,Tennessee,Dustin Rodgers,C,70
+725,Tennessee,Cole Harrison,TE,70
+725,Tennessee,Daevin Hobbs,DT,69
+725,Tennessee,Andre Stewart,FS,69
+725,Tennessee,Jackson Ross,P,68
+725,Tennessee,Bobbie Walker Norman,ROLB,68
+725,Tennessee,Bennett Brady,TE,68
+725,Tennessee,Jeremy Newton,WR,67
+725,Tennessee,Trace Crabsworth,ROLB,66
+725,Tennessee,William Satterwhite,C,66
+725,Tennessee,Bennett Warren,RT,66
+725,Tennessee,Noah Herrick,DT,66
+725,Tennessee,Brad Strickland,TE,66
+725,Tennessee,Ben Bolton,LOLB,66
+725,Tennessee,Max Gilbert,K,65
+725,Tennessee,Deshaun Garcia,WR,65
+725,Tennessee,Kaleb Beasley,CB,64
+725,Tennessee,Carson Wise,MLB,64
+725,Tennessee,Julio Tammy,DT,63
+725,Tennessee,Khalil Zimmerman,CB,62
+725,Tennessee,Justyn Brock,MLB,62
+725,Tennessee,Stephen Clinton,TE,62
+725,Tennessee,Masai Reddick,RG,58
+725,Tennessee,Edwin Spillman,MLB,56
+725,Tennessee,Charles Bagley,SS,56
+725,Tennessee,Harrison Jackson,RG,56
+725,Tennessee,Tyren Ramsey,FB,56
+725,Tennessee,Lavar Johnson,CB,55
+725,Tennessee,Brian Grant,LG,54
+725,Tennessee,Josh Turbyville,K,48
+726,Texas,Michael Taaffe,FS,98
+726,Texas,Anthony Hill Jr,MLB,95
+726,Texas,Trey Moore,ROLB,95
+726,Texas,Jack Endries,TE,94
+726,Texas,Malik Muhammad,CB,92
+726,Texas,Cole Hutson,C,92
+726,Texas,Dj Campbell,RG,90
+726,Texas,Arch Manning,QB,90
+726,Texas,Liona Lefau,ROLB,87
+726,Texas,Cole Brevard,DT,87
+726,Texas,Deandre Moore Jr,WR,86
+726,Texas,Jaylon Guilbeau,CB,86
+726,Texas,Emmett Mosley V,WR,85
+726,Texas,Hero Kanu,DT,85
+726,Texas,Cliff Honeywell,QB,84
+726,Texas,Trevor Goosby,LT,82
+726,Texas,Brad Spence,MLB,82
+726,Texas,Parker Livingstone,WR,82
+726,Texas,Alex January,DT,80
+726,Texas,Ryan Wingo,WR,79
+726,Texas,Maraad Watson,DT,79
+726,Texas,Spencer Shannon,TE,78
+726,Texas,Jelani Mcdonald,SS,77
+726,Texas,Kaliq Lockett,WR,77
+726,Texas,Brandon Wymore,FB,77
+726,Texas,Trey Owens,QB,76
+726,Texas,Jordan Washington,TE,76
+726,Texas,Derek Williams Jr,FS,75
+726,Texas,Kade Phillips,CB,75
+726,Texas,Jonah Williams,ROLB,75
+726,Texas,Kobe Black,CB,74
+726,Texas,Brandon Baker,RT,74
+726,Texas,Jaydon Chatman,LT,74
+726,Texas,Lavon Johnson,DT,74
+726,Texas,Travis Shaw,DT,73
+726,Texas,Warren Roberson,CB,73
+726,Texas,Ryan Niblett,CB,73
+726,Texas,Connor Stroh,RG,73
+726,Texas,Ty Anthony Smith,ROLB,73
+726,Texas,Zelus Hicks,SS,72
+726,Texas,Andre Cojoe,RT,72
+726,Texas,Connor Robertson,C,72
+726,Texas,Graceson Littleton,CB,72
+726,Texas,Jack Bouwmeester,P,71
+726,Texas,Neto Umeozulu,LG,71
+726,Texas,Jaime Ffrench,WR,71
+726,Texas,Jordon Johnson Rubell,SS,71
+726,Texas,Graham Gillespie,FS,71
+726,Texas,Jackson Christian,LG,71
+726,Texas,Ridge Barker,TE,71
+726,Texas,Mason Shipley,K,70
+726,Texas,Shane Mcoliver,LOLB,70
+726,Texas,Kam Norman,MLB,70
+726,Texas,Brady Sarkisian,ROLB,70
+726,Texas,Nate Kibble,LG,69
+726,Texas,Wardell Mack,CB,68
+726,Texas,Daniel Cruz,C,68
+726,Texas,Justus Terry,DT,67
+726,Texas,Daylan Mccutcheon,WR,67
+726,Texas,Santana Wilson,CB,67
+726,Texas,Aaron Butler,WR,67
+726,Texas,Will Stone,K,66
+726,Texas,Tate Haver,TE,66
+726,Texas,Xavier Filsaime,SS,65
+726,Texas,Vencot Colvin,LOLB,65
+726,Texas,Lance St Louis,TE,65
+726,Texas,Caleb Chester,CB,62
+726,Texas,Emaree Winston,TE,60
+726,Texas,Mason Kelsay,QB,58
+726,Texas,Franklin Walker,LOLB,57
+726,Texas,Jack Woodard,MLB,56
+726,Texas,Jaybron Baldwin,RT,55
+726,Texas,Casey Ellington,LT,54
+739,USC,Makai Lemon,WR,90
+739,USC,Jayden Maiava,QB,90
+739,USC,Ja Kobi Lane,WR,89
+739,USC,Dj Harvey,CB,88
+739,USC,Kamari Ramsey,FS,88
+739,USC,Dj Wingfield,LG,88
+739,USC,Lake Mcree,TE,87
+739,USC,Decarlos Nicholson,CB,85
+739,USC,Prince Strachan,WR,85
+739,USC,Eric Gentry,ROLB,84
+739,USC,Jay Fair,WR,84
+739,USC,Tobias Raymond,RT,84
+739,USC,Sam Huard,QB,84
+739,USC,Kilian O Connor,C,83
+739,USC,Elijah Paige,LT,82
+739,USC,Abraham Jackson,FS,82
+739,USC,Devan Thompkins,DT,82
+739,USC,J Onre Reed,C,82
+739,USC,Jack Susnjar,LG,82
+739,USC,Desman Stephens Ii,MLB,80
+739,USC,Chasen Johnson,CB,79
+739,USC,Prophet Brown,CB,77
+739,USC,Bishop Fitzgerald,SS,77
+739,USC,Walker Lyons,TE,77
+739,USC,Marcelles Williams,CB,76
+739,USC,Jide Abasiri,DT,76
+739,USC,Keeshawn Silver,DT,75
+739,USC,Cade Fox,QB,75
+739,USC,Anthony Beavers Jr,FS,75
+739,USC,Jadyn Walker,MLB,75
+739,USC,Carson Tabaracci,TE,75
+739,USC,Jon Conrad,RT,74
+739,USC,Erwin Taomi,LG,74
+739,USC,Alani Noa,RG,73
+739,USC,Micah Banuelos,LT,73
+739,USC,Justin Tauanuu,RT,72
+739,USC,Kennedy Urlacher,SS,72
+739,USC,Trestin Castro,CB,71
+739,USC,Jalen Fowler,WR,71
+739,USC,Ta Mere Robinson,ROLB,70
+739,USC,Walter Matthews,TE,70
+739,USC,Max Hurst,RT,68
+739,USC,Luke Longway,FS,68
+739,USC,Garrison Madden,MLB,68
+739,USC,Eron Mckenzie,FB,68
+739,USC,Vincent Kemp,LT,67
+739,USC,Kobe Pepe,DT,67
+739,USC,Xavier Jordan,WR,67
+739,USC,Christian Pierce,SS,66
+739,USC,Marquis Gallegos,FS,66
+739,USC,Tahir Savage,RT,66
+739,USC,Willi Wascher,C,66
+739,USC,James Johnson,CB,66
+739,USC,Devin Mcdonough,TE,66
+739,USC,Sam Johnson,P,65
+739,USC,Hank Pepper,TE,65
+739,USC,Jamaal Jarrett,DT,64
+739,USC,Caden Chittenden,K,64
+739,USC,Joey Olsen,TE,64
+739,USC,Zacharyus Williams,WR,64
+739,USC,Makai Saina,RG,63
+739,USC,Jaylen Griffith,SS,62
+739,USC,Isaiah Rubin,CB,62
+739,USC,Braylon Conley,CB,61
+739,USC,Will Weisberg,P,60
+739,USC,Malcolm Wilson Thomas,DT,59
+739,USC,Rachaad Ray,FS,57
+739,USC,Josh Dudley,DT,57
+739,USC,Gabriel Williams,ROLB,53
+739,USC,Mikell Perkins,MLB,50
+739,USC,Cole Jayne,RG,50
+739,USC,Myles Runnels,ROLB,42
+740,Utah,Spencer Fano,RT,94
+740,Utah,Caleb Lomu,LT,90
+740,Utah,Michael Mokofisi,RG,90
+740,Utah,Tao Johnson,FS,89
+740,Utah,Jaren Kump,C,89
+740,Utah,Devon Dampier,QB,87
+740,Utah,Lander Barton,LOLB,87
+740,Utah,Tanoa Togiai,LG,87
+740,Utah,Levani Damuni,MLB,86
+740,Utah,Elijah Davis,CB,85
+740,Utah,Rayshawn Glover,WR,85
+740,Utah,Smith Snowden,CB,84
+740,Utah,Otto Tia,WR,84
+740,Utah,Aliki Vimahi,DT,83
+740,Utah,Tobias Merriweather,WR,83
+740,Utah,Creed Whittemore,WR,83
+740,Utah,Ryan Davis,WR,83
+740,Utah,Johnathan Hall,ROLB,83
+740,Utah,Trey Reynolds,MLB,83
+740,Utah,Jonah Lea Ea,DT,82
+740,Utah,Donovan Saunders,CB,81
+740,Utah,Nate Ritchie,FS,81
+740,Utah,Rabbit Evans,SS,80
+740,Utah,Blake Cotton,CB,79
+740,Utah,Zereoue Williams,LT,78
+740,Utah,Keith Olson,RG,78
+740,Utah,Isaac Wilson,QB,78
+740,Utah,Dallen Bentley,TE,77
+740,Utah,Alex Harrison,C,77
+740,Utah,Luca Caldarella,WR,77
+740,Utah,Dallas Vakalahi,DT,76
+740,Utah,Daniel Escalante,C,76
+740,Utah,Solatoa Moea I,LG,75
+740,Utah,Rock Caldwell,CB,75
+740,Utah,John Henry Daley,DT,74
+740,Utah,Jackson Bennee,SS,73
+740,Utah,Roger Alderman,LG,72
+740,Utah,Daidren Zipperer,WR,72
+740,Utah,J J Runyon,ROLB,71
+740,Utah,Kana I Lopes,MLB,71
+740,Utah,Logan Castor,TE,71
+740,Utah,Myron Green,LT,70
+740,Utah,Isaiah Garcia,RT,69
+740,Utah,Cyrus Polu,ROLB,69
+740,Utah,Hunter Andrews,TE,69
+740,Utah,Paul Puletasi,LOLB,68
+740,Utah,Debrandon Mosley,SS,68
+740,Utah,Paul Martin,TE,68
+740,Utah,Brendan Zurbrugg,QB,67
+740,Utah,Kevin Loa,FB,67
+740,Utah,Christian Thatcher,LOLB,66
+740,Utah,Trenton Wilson,CB,66
+740,Utah,Drew Clemens,TE,66
+740,Utah,Trent Bush,SS,66
+740,Utah,Justin Stevenson,WR,66
+740,Utah,Eddie Tyson,DT,65
+740,Utah,Elijah Thomas,QB,65
+740,Utah,Karson Kaufusi,DT,65
+740,Utah,Jc Hart,CB,64
+740,Utah,Nathan Tilmon,FS,64
+740,Utah,Andrew Satele,DT,63
+740,Utah,Deshaun Ruth,FS,62
+740,Utah,Nate Johnson,QB,60
+740,Utah,Mana Carvalho,WR,57
+740,Utah,Brian Savea,DT,57
+740,Utah,Barry Glendale,RT,55
+740,Utah,Jeremy Nalu,RG,55
+740,Utah,Joey Cheek,K,52
+740,Utah,Dillon Curtis,K,48
+740,Utah,Isaiah Elmer,ROLB,45
+740,Utah,Kalolo Ta Aga,LT,45
+740,Utah,Orion Phillips,P,45
+743,Utah State,Ike Larsen,FS,88
+743,Utah State,Matt Lowell,LOLB,86
+743,Utah State,Naki Fahina,DT,83
+743,Utah State,Josh Sterzer,TE,83
+743,Utah State,Jamal Foster,LT,83
+743,Utah State,Devin Kramer,FS,82
+743,Utah State,Trey Andersen,LT,82
+743,Utah State,John Miller,MLB,81
+743,Utah State,Bronson Olevao Jr,ROLB,81
+743,Utah State,Demick Starling,WR,81
+743,Utah State,Broc Lane,TE,80
+743,Utah State,Tavo Motu Apuaka,RG,80
+743,Utah State,George Maile,LG,80
+743,Utah State,Braden Pegan,WR,80
+743,Utah State,Hyrum Hatch,TE,80
+743,Utah State,Craig Mcdonald,ROLB,79
+743,Utah State,Jake Eichorn,C,79
+743,Utah State,Bryson Taylor,CB,78
+743,Utah State,Corey Thompson Jr,WR,78
+743,Utah State,Brady Boyd,WR,78
+743,Utah State,Jared Pele,RT,78
+743,Utah State,Jacob Conover,QB,78
+743,Utah State,Noah Avinger,CB,77
+743,Utah State,Gabriel Iniguez Jr,DT,77
+743,Utah State,Kahanu Davis,WR,77
+743,Utah State,Jason Brewer,FS,76
+743,Utah State,Tyree Morris,DT,76
+743,Utah State,Omari Okeke,SS,76
+743,Utah State,Noah Flores,CB,76
+743,Utah State,Bryson Barnes,QB,75
+743,Utah State,Bobby Arnold Iii,CB,75
+743,Utah State,Ej Fisk,CB,75
+743,Utah State,Carlos Orr Gillespie,WR,75
+743,Utah State,Jarvis Griffiths,C,75
+743,Utah State,Brevin Hamblin,ROLB,74
+743,Utah State,Kendrick Cooks,SS,73
+743,Utah State,Cj Tiller,QB,73
+743,Utah State,Dylan Tucker,CB,73
+743,Utah State,Adam Pond,LT,72
+743,Utah State,Elia Migao,RG,72
+743,Utah State,D Andre Barnes,FS,72
+743,Utah State,Anthony Garcia,QB,72
+743,Utah State,Matt Lampman,LG,71
+743,Utah State,Kyle Pendleton,LOLB,70
+743,Utah State,K Leyone Iosua,RG,70
+743,Utah State,Cole Keele,DT,70
+743,Utah State,Courage Ugo,CB,69
+743,Utah State,Reed Driscoll,FS,68
+743,Utah State,Brett Mann,LT,68
+743,Utah State,J T Stringer,LG,68
+743,Utah State,Tymere Burton,MLB,68
+743,Utah State,Jimmy Liston,LG,67
+743,Utah State,Jr Sia,RT,67
+743,Utah State,Camden Jury,LT,67
+743,Utah State,Kary Hudson,LT,66
+743,Utah State,Carter Brown,K,65
+743,Utah State,Roman James,FB,65
+743,Utah State,Mike Mccloud,SS,62
+743,Utah State,Mick Burrell,LG,62
+743,Utah State,Kone Aumua Uiagalelei,DT,61
+743,Utah State,Gio Kafentzis,SS,60
+743,Utah State,Jared Anderson,TE,59
+743,Utah State,Dylan Sprague,P,58
+743,Utah State,Max Richart,C,58
+743,Utah State,Sammy Talbott,LG,58
+743,Utah State,Todd Gaffney,TE,57
+743,Utah State,Antonio Shropshire,TE,57
+743,Utah State,Tanner Rinker,K,52
+743,Utah State,Greg Talbott,RT,51
+743,Utah State,Shonn Mullins,MLB,50
+744,UTEP,Xavier Smith,SS,85
+744,UTEP,Joseph Immediato,RG,85
+744,UTEP,Kenny Odom,WR,84
+744,UTEP,Kam Thomas,WR,83
+744,UTEP,Cole Gustafson,DT,82
+744,UTEP,Ivan Escobar,LG,81
+744,UTEP,Skyler Locklear,QB,81
+744,UTEP,Jaden Smith,WR,80
+744,UTEP,Lantz Russell,FS,79
+744,UTEP,Azizi Henry,RT,79
+744,UTEP,Justin Content,CB,79
+744,UTEP,Kd Johnson,DT,78
+744,UTEP,Jaylon Shelton,CB,78
+744,UTEP,Tyler Jones,SS,77
+744,UTEP,Juan Camacho Jr,RT,77
+744,UTEP,Yessman Green,CB,77
+744,UTEP,Ashton Nickelberry,WR,77
+744,UTEP,Stratton Shufelt,MLB,76
+744,UTEP,Solo Barnes,FS,76
+744,UTEP,Kode Lowe,SS,75
+744,UTEP,Jaquan Toney,RG,75
+744,UTEP,Cade Mcconnell,QB,75
+744,UTEP,Neil Campbell,CB,75
+744,UTEP,Donte Thompson,CB,75
+744,UTEP,Joshua Rudolph,ROLB,75
+744,UTEP,Eli Wilber,FS,75
+744,UTEP,Chad Isaac,LOLB,75
+744,UTEP,Jayden Wilson,LOLB,74
+744,UTEP,Udoka Ezeani,LOLB,74
+744,UTEP,Ashton Coker,DT,74
+744,UTEP,Luka Matamoros,LT,74
+744,UTEP,Judah Ezinwa,TE,74
+744,UTEP,Garrett Hawkins,MLB,74
+744,UTEP,Cash Cheeks,TE,72
+744,UTEP,Jaylan Brown,WR,72
+744,UTEP,Jake Riggs,C,72
+744,UTEP,Josh Schuchts,TE,71
+744,UTEP,Wondame Davis Jr,WR,71
+744,UTEP,James Williams,LG,71
+744,UTEP,Dylan Brown Turner,ROLB,70
+744,UTEP,Tyrone Mcduffie Iii,LG,70
+744,UTEP,Noah Stephenson,TE,70
+744,UTEP,Calvin Pollard,SS,70
+744,UTEP,Taylor Perez,WR,70
+744,UTEP,Malachi Nelson,QB,69
+744,UTEP,Jeff Tracy,QB,69
+744,UTEP,Dennis Lafferty,LT,69
+744,UTEP,Rolando Beltran,RG,69
+744,UTEP,Deven Harold,FS,68
+744,UTEP,Mason Ferguson,WR,66
+744,UTEP,Tyler Christie,RT,66
+744,UTEP,Allan Mccarter,C,65
+744,UTEP,Rafeald Campbell,WR,65
+744,UTEP,Preston Parsons,LT,62
+744,UTEP,Craig Wydra,C,62
+744,UTEP,Isaac Rudolph,TE,61
+744,UTEP,Tyler Reyes,FB,61
+744,UTEP,Vashon Brunswick Ii,MLB,61
+744,UTEP,Tj Tillman,CB,60
+744,UTEP,Trace Meadows,LOLB,59
+744,UTEP,Cam Weeks,C,59
+744,UTEP,Joe Bowman,K,58
+744,UTEP,Gabriel Beaver,MLB,58
+744,UTEP,Grant Stewart,FS,58
+744,UTEP,Nicholas Werth,RT,57
+744,UTEP,Rudy Moreland,MLB,57
+744,UTEP,Noah Botsford,P,55
+744,UTEP,Bo Phillips,ROLB,55
+744,UTEP,Josh Hancock,TE,53
+744,UTEP,Shay Smith,QB,52
+744,UTEP,Marcus Torres,WR,52
+744,UTEP,Sean Bush,DT,52
+744,UTEP,Jerry Potts,LG,50
+741,UTSA,Kamar Missouri,LT,92
+741,UTSA,De Corian Clark,WR,88
+741,UTSA,Ben Rios,C,88
+741,UTSA,Trevor Timmons,LG,86
+741,UTSA,Owen Mccown,QB,86
+741,UTSA,Jaylen Garth,RT,85
+741,UTSA,Devin Mccuin,WR,84
+741,UTSA,Venly Tatafu,LG,84
+741,UTSA,Jermarius Lewis,FS,84
+741,UTSA,David Amador Ii,WR,83
+741,UTSA,Willie Mccoy,WR,82
+741,UTSA,Cameron Blaylock,DT,82
+741,UTSA,Syrus Dumas,CB,82
+741,UTSA,Tyan Milton,SS,81
+741,UTSA,Cory Godinet,RG,81
+741,UTSA,Kaian Roberts Day,DT,81
+741,UTSA,Kaden Meier,CB,81
+741,UTSA,Zach Morris,CB,81
+741,UTSA,Houston Thomas,TE,80
+741,UTSA,Vic Shaw,ROLB,80
+741,UTSA,Luke Lapeze,C,80
+741,UTSA,Daquon Parks,FB,80
+741,UTSA,Shad Banks Jr,MLB,79
+741,UTSA,Kendrick Blackshire,MLB,79
+741,UTSA,Davin Martin,CB,78
+741,UTSA,Jonah Miller,LT,76
+741,UTSA,Patrick Overmyer,TE,76
+741,UTSA,Brandon Tucker,ROLB,76
+741,UTSA,Chidera Otutu,DT,76
+741,UTSA,Jarius Walker,SS,76
+741,UTSA,Bryce Grays,LOLB,76
+741,UTSA,Nnanna Anyanwu,ROLB,75
+741,UTSA,Noah Lugo,QB,75
+741,UTSA,Andrew Alvarado,RT,75
+741,UTSA,Jamie Rhett,QB,74
+741,UTSA,Darrell Jones,RT,74
+741,UTSA,Demetris Allen,LG,74
+741,UTSA,Devron Williams Jr,LG,74
+741,UTSA,Austin Phillips,TE,74
+741,UTSA,Elliott Brow,WR,74
+741,UTSA,Owen Pewee,LOLB,73
+741,UTSA,Dan Dishman,TE,73
+741,UTSA,Jimmy Wyrick,FS,73
+741,UTSA,Jameian Buxton,DT,73
+741,UTSA,Camron Cooper,ROLB,73
+741,UTSA,Dj Allen,WR,72
+741,UTSA,Marcellus Wilkerson,LOLB,72
+741,UTSA,Jaelen Smith,WR,72
+741,UTSA,Dorian Rowe,FS,72
+741,UTSA,Brandon Jacob,FS,71
+741,UTSA,Deandre Marshall,RG,71
+741,UTSA,Rj Lester,CB,71
+741,UTSA,Cam Upshaw Jr,SS,71
+741,UTSA,Armoni Rue,CB,71
+741,UTSA,Elijah Newell,SS,70
+741,UTSA,Ian Jackson,MLB,70
+741,UTSA,Davion Hurth,RG,69
+741,UTSA,Mekhi Anderson,WR,68
+741,UTSA,Dematrius Davis Jr,QB,67
+741,UTSA,Briley Brown,C,67
+741,UTSA,Jakevian Rodgers,CB,67
+741,UTSA,Brandon Tennison,QB,66
+741,UTSA,Cade Collenback,TE,66
+741,UTSA,Ty Rupe,TE,65
+741,UTSA,James Walley Jr,MLB,65
+741,UTSA,Franklin Wilson,SS,64
+741,UTSA,Nathan Wallace,WR,64
+741,UTSA,Isaiah Butler Tanner,TE,62
+741,UTSA,Kingston Jones,WR,60
+741,UTSA,Breck Chambers,P,59
+741,UTSA,A Marion Breland,LT,58
+741,UTSA,Caile Hogan,P,56
+741,UTSA,Michael Petro,P,46
+742,Vanderbilt,Eli Stowers,TE,93
+742,Vanderbilt,Jordan White,C,90
+742,Vanderbilt,Diego Pavia,QB,88
+742,Vanderbilt,Bryan Longwell,ROLB,88
+742,Vanderbilt,Isaia Glass,LT,88
+742,Vanderbilt,Martel Hight,CB,87
+742,Vanderbilt,Randon Fontenette,SS,87
+742,Vanderbilt,Junior Sherrill,WR,87
+742,Vanderbilt,Trent Hudson,WR,87
+742,Vanderbilt,Chase Mitchell,RG,87
+742,Vanderbilt,Mason Nelson,DT,87
+742,Vanderbilt,Marlon Jones Jr,CB,86
+742,Vanderbilt,Sterling Porcher,LG,86
+742,Vanderbilt,Richie Hoskins,WR,86
+742,Vanderbilt,Yilanan Ouattara,DT,85
+742,Vanderbilt,Zaylin Wood,DT,85
+742,Vanderbilt,Joshua Singh,DT,84
+742,Vanderbilt,Langston Patterson,MLB,83
+742,Vanderbilt,Nick Rinaldi,MLB,83
+742,Vanderbilt,Gage Pitchford,RG,83
+742,Vanderbilt,Charlie Clark,RT,83
+742,Vanderbilt,David Siegel,RT,83
+742,Vanderbilt,Marlen Sewell,SS,82
+742,Vanderbilt,Jace Gleason,RT,82
+742,Vanderbilt,Orion Irving,LT,81
+742,Vanderbilt,Kevo Wesley,LG,80
+742,Vanderbilt,Kolbey Taylor,CB,80
+742,Vanderbilt,Gabe Fisher,FB,80
+742,Vanderbilt,Cj Heard,SS,79
+742,Vanderbilt,Misael Sandoval,LT,79
+742,Vanderbilt,Prince Kollie,ROLB,79
+742,Vanderbilt,Cade Mcconnell,C,78
+742,Vanderbilt,Trudell Berry,CB,78
+742,Vanderbilt,Jaylin Lackey,CB,77
+742,Vanderbilt,Bradley Mann,DT,77
+742,Vanderbilt,Cole Spence,TE,76
+742,Vanderbilt,Lionel Reddick,LOLB,76
+742,Vanderbilt,Jordan Matthews,CB,75
+742,Vanderbilt,Bryce Cowan,MLB,75
+742,Vanderbilt,Aaron Bryant,DT,75
+742,Vanderbilt,Glenn Seabrooks Iii,DT,75
+742,Vanderbilt,Gunner Givens,RG,75
+742,Vanderbilt,Everett Donaghy,QB,75
+742,Vanderbilt,Chance Fitzgerald,WR,74
+742,Vanderbilt,Keegan Wechsler,C,74
+742,Vanderbilt,Durham Harris,TE,74
+742,Vanderbilt,Jalen Gilbert,FS,74
+742,Vanderbilt,Walter Bartell,LG,74
+742,Vanderbilt,Jeremiah Dillon,WR,73
+742,Vanderbilt,Vanzale Hinton,CB,72
+742,Vanderbilt,Drew Dickey,QB,72
+742,Vanderbilt,Tristen Brown,WR,72
+742,Vanderbilt,Brock Taylor,K,70
+742,Vanderbilt,Blaze Berlowitz,QB,70
+742,Vanderbilt,Cj Williams,LT,70
+742,Vanderbilt,Dontae Carter,FS,69
+742,Vanderbilt,Nick Haberer,P,67
+742,Vanderbilt,Branden Silas,LOLB,67
+742,Vanderbilt,Jason Ash,LT,66
+742,Vanderbilt,Jorrell Riddick,SS,66
+742,Vanderbilt,Joseph Mcvay,WR,66
+742,Vanderbilt,Austin Howard,ROLB,65
+742,Vanderbilt,Jeremy St Hilaire,QB,64
+742,Vanderbilt,Mason Rohmiller,K,64
+742,Vanderbilt,Josh Cowan,LOLB,64
+742,Vanderbilt,Brycen Coleman,TE,62
+742,Vanderbilt,D Juan Hooker,FS,62
+742,Vanderbilt,Terry Nwabuisi Ezeala,DT,56
+742,Vanderbilt,Tate Hamby,FS,56
+742,Vanderbilt,Courtland Williams,CB,56
+742,Vanderbilt,Jamichael Poole,DT,55
+742,Vanderbilt,Conor Weasler,P,49
+742,Vanderbilt,Angelo Bishop,MLB,48
+745,Virginia,Chandler Morris,QB,88
+745,Virginia,Noah Josey,LG,88
+745,Virginia,Kam Robinson,MLB,88
+745,Virginia,Jam Jackson,CB,88
+745,Virginia,Jahmal Edrine,WR,87
+745,Virginia,Wallace Unamba,RG,87
+745,Virginia,Brady Wilson,C,86
+745,Virginia,Jahmeer Carter,DT,86
+745,Virginia,David Wohlabaugh Jr,RT,86
+745,Virginia,Devin Neal,FS,85
+745,Virginia,Jayden Thomas,WR,85
+745,Virginia,Cam Ross,WR,85
+745,Virginia,Mckale Boley,LT,85
+745,Virginia,James Jackson,ROLB,85
+745,Virginia,Monroe Mills,RT,84
+745,Virginia,Antonio Clary,SS,84
+745,Virginia,Kevin Wigenton Ii,RG,84
+745,Virginia,Sage Ennis,TE,84
+745,Virginia,Connor Edwards,FB,84
+745,Virginia,Donavon Platt,CB,83
+745,Virginia,Drake Metcalf,C,83
+745,Virginia,Trell Harris,WR,83
+745,Virginia,Dakota Twitty,TE,83
+745,Virginia,Kenan Johnson,CB,82
+745,Virginia,Da Marcus Crosby Ii,SS,82
+745,Virginia,Makilan Thomas,RT,82
+745,Virginia,Jack Witmer,RT,82
+745,Virginia,Jason Hammond,DT,81
+745,Virginia,Anthony Britton,DT,80
+745,Virginia,Trey Mcdonald,MLB,80
+745,Virginia,Bryce Robinson,TE,80
+745,Virginia,Jordan Robinson,CB,79
+745,Virginia,Andre Greene Jr,WR,78
+745,Virginia,Hunter Osborne,DT,78
+745,Virginia,Jacob Holmes,DT,78
+745,Virginia,David Byron,QB,78
+745,Virginia,Tyshawn Wyatt,LT,78
+745,Virginia,Christian Charles,SS,77
+745,Virginia,Kameron Courtney,WR,77
+745,Virginia,Marco Craig,LOLB,77
+745,Virginia,Ethan Sipe,LT,77
+745,Virginia,Dre Walker,CB,76
+745,Virginia,Ethan Minter,FS,76
+745,Virginia,Ja Son Prevard,CB,76
+745,Virginia,Stevie Bracey,MLB,75
+745,Virginia,Maddox Marcellus,ROLB,75
+745,Virginia,Caleb Hardy,SS,75
+745,Virginia,Cole Surber,LG,75
+745,Virginia,Corbin Patton,LT,74
+745,Virginia,Karson Gay,TE,74
+745,Virginia,Dawson Alters,C,74
+745,Virginia,Grant Ellinger,LG,74
+745,Virginia,Matthew Peck,LT,74
+745,Virginia,Emmanuel Karnley,CB,73
+745,Virginia,Daniel Kaelin,QB,73
+745,Virginia,Josiah Persinger,CB,71
+745,Virginia,Justin Zames,TE,70
+745,Virginia,Cole Geer,QB,70
+745,Virginia,Ja Maric Morris,CB,68
+745,Virginia,Suderian Harrison,WR,68
+745,Virginia,Maurice Cunningham,DT,68
+745,Virginia,Jameel Mcallister,LOLB,67
+745,Virginia,Allen Hanna,FB,67
+745,Virginia,Will Bettridge,K,66
+745,Virginia,Daniel Sparks,P,66
+745,Virginia,Myles Brown,MLB,66
+745,Virginia,Ben York,RT,65
+745,Virginia,Landon Danley,SS,59
+745,Virginia,Keke Adams,FS,59
+745,Virginia,Grayson Reid,RG,58
+745,Virginia,Logan Kotter,LOLB,55
+746,Virginia Tech,Tomas Rimac,LG,91
+746,Virginia Tech,Donavon Greene,WR,88
+746,Virginia Tech,Caleb Woodson,ROLB,86
+746,Virginia Tech,Christian Ellis,SS,85
+746,Virginia Tech,Benji Gosnell,TE,85
+746,Virginia Tech,Caleb Brown,CB,84
+746,Virginia Tech,Jaden Muskrat,RG,84
+746,Virginia Tech,Kelvin Gilliam Jr,DT,83
+746,Virginia Tech,Dante Lovett,CB,83
+746,Virginia Tech,Elhadj Fall,DT,83
+746,Virginia Tech,Jaden Keller,MLB,83
+746,Virginia Tech,Isaiah Brown Murray,CB,82
+746,Virginia Tech,Montavious Cunningham,RT,82
+746,Virginia Tech,Isaiah Cash,SS,81
+746,Virginia Tech,Kyron Drones,QB,80
+746,Virginia Tech,Layth Ghannam,LT,80
+746,Virginia Tech,Brody Meadows,RG,79
+746,Virginia Tech,Arias Nash,DT,79
+746,Virginia Tech,Garret Rangel,QB,79
+746,Virginia Tech,Antwone Santiago,ROLB,79
+746,Virginia Tech,Immanuel Hickman,DT,78
+746,Virginia Tech,Lucas Austin,RT,78
+746,Virginia Tech,Kyle Altuner,C,78
+746,Virginia Tech,Jordan Bass,ROLB,77
+746,Virginia Tech,Quentin Reddish,FS,77
+746,Virginia Tech,Ayden Greene,WR,77
+746,Virginia Tech,Kemari Copeland,DT,77
+746,Virginia Tech,Tyler Childress,SS,77
+746,Virginia Tech,Thomas Williams,CB,77
+746,Virginia Tech,Johnny Garrett,LT,76
+746,Virginia Tech,Kaleb Spencer,MLB,76
+746,Virginia Tech,Cameron Seldon,WR,75
+746,Virginia Tech,Jahzari Priester,DT,75
+746,Virginia Tech,Joseph Reddish,CB,75
+746,Virginia Tech,Henry Spencer,FB,75
+746,Virginia Tech,Jahmari Deloatch,CB,73
+746,Virginia Tech,Harrison Saint Germain,TE,73
+746,Virginia Tech,Krystian Williams,CB,73
+746,Virginia Tech,Michael Short,MLB,73
+746,Virginia Tech,Grant Karczewski,LG,73
+746,Virginia Tech,Brody Jones,ROLB,73
+746,Virginia Tech,Tucker Holloway,WR,72
+746,Virginia Tech,Chanz Wiggins,WR,72
+746,Virginia Tech,Ja Ricous Hairston,TE,72
+746,Virginia Tech,Devin Alves,FS,71
+746,Virginia Tech,Takye Heath,WR,71
+746,Virginia Tech,Hannes Hammer,LT,71
+746,Virginia Tech,Sherrod Covil Jr,SS,70
+746,Virginia Tech,Emmett Laws,DT,70
+746,Virginia Tech,Drew Doyle,TE,70
+746,Virginia Tech,Tyson Flowers,FS,69
+746,Virginia Tech,Tommy Ricard,C,69
+746,Virginia Tech,Elijah Haughawout,C,69
+746,Virginia Tech,John Love,K,68
+746,Virginia Tech,William Watson Iii,QB,68
+746,Virginia Tech,Nick Veltsistas,P,67
+746,Virginia Tech,Carter Stallard,LG,67
+746,Virginia Tech,Aidan Lynch,RT,67
+746,Virginia Tech,Will Johnson,MLB,65
+746,Virginia Tech,Nathaniel Wright,RG,65
+746,Virginia Tech,Kyle Lowe,K,63
+746,Virginia Tech,Keylen Adams,WR,63
+746,Virginia Tech,George Ballance,MLB,62
+746,Virginia Tech,Gavin Crawford,RG,61
+746,Virginia Tech,Ricky Stiles,FB,61
+746,Virginia Tech,Colby Mcclain,ROLB,61
+746,Virginia Tech,Aj Brand,QB,59
+746,Virginia Tech,Gabe Williams,LOLB,59
+746,Virginia Tech,Christian Epling,TE,56
+746,Virginia Tech,Brendan Mclean,FS,53
+746,Virginia Tech,Tate Kendall,TE,51
+747,Wake Forest,Fa Alili Fa Amoe,RT,87
+747,Wake Forest,Nick Andersen,FS,86
+747,Wake Forest,Melvin Siani,LT,85
+747,Wake Forest,Zach Lohavichan,DT,85
+747,Wake Forest,Devin Kylany,C,84
+747,Wake Forest,Jacob Dennison,LT,84
+747,Wake Forest,Wyatt Crespi,DT,84
+747,Wake Forest,Derrell Johnson Ii,LG,84
+747,Wake Forest,Dylan Hazen,MLB,83
+747,Wake Forest,Davaughn Patterson,SS,83
+747,Wake Forest,Harry Lodge,TE,83
+747,Wake Forest,Quincy Bryant,ROLB,82
+747,Wake Forest,Jayden Loving,DT,82
+747,Wake Forest,Sterling Berkhalter,WR,82
+747,Wake Forest,Mateen Ibirogba,DT,82
+747,Wake Forest,Zamari Stevenson,CB,81
+747,Wake Forest,Jaydon Collins,LT,81
+747,Wake Forest,George Sell,RG,80
+747,Wake Forest,Rushaun Tongue,SS,79
+747,Wake Forest,Lardarius Webb Jr,CB,78
+747,Wake Forest,Robby Ashford,QB,78
+747,Wake Forest,Jaxon Mull,CB,78
+747,Wake Forest,Ashaad Williams,CB,78
+747,Wake Forest,Aiden Hall,MLB,78
+747,Wake Forest,Dallas Afalava,DT,78
+747,Wake Forest,Micah Mays Jr,WR,77
+747,Wake Forest,Rodrick Tialavea,LG,77
+747,Wake Forest,George Steih,RT,77
+747,Wake Forest,Deshawn Purdie,QB,76
+747,Wake Forest,Karon Prunty,CB,76
+747,Wake Forest,Reginald Vick Jr,WR,76
+747,Wake Forest,Sawyer Racanelli,WR,76
+747,Wake Forest,Jeremiah Melvin,WR,76
+747,Wake Forest,Carlos Hernandez,WR,75
+747,Wake Forest,Sascha Garcia,CB,75
+747,Wake Forest,Kamrean Johnson,TE,75
+747,Wake Forest,William Tackie Jr,CB,75
+747,Wake Forest,Quentin Morton,FS,75
+747,Wake Forest,Michael Frogge,TE,74
+747,Wake Forest,Devin Mcrae,C,73
+747,Wake Forest,Philip Bennett,LT,73
+747,Wake Forest,Tramon Robinson,FB,73
+747,Wake Forest,Uber Ajongo,LT,72
+747,Wake Forest,Travon West,CB,72
+747,Wake Forest,Hank Lucas,C,72
+747,Wake Forest,Chris Barnes,WR,70
+747,Wake Forest,Ja Marion Kennedy,RG,70
+747,Wake Forest,Thurman Jordan,RT,68
+747,Wake Forest,Zachary Zinger,TE,68
+747,Wake Forest,Matthew Dennis,K,67
+747,Wake Forest,Kadear Dembele,DT,67
+747,Wake Forest,Braylon Johnson,FS,66
+747,Wake Forest,Daniel Conover,RT,66
+747,Wake Forest,Clinton Richard,RT,65
+747,Wake Forest,Joel Lowenberg,LOLB,65
+747,Wake Forest,Myles Turpin,FS,64
+747,Wake Forest,Dakota Church,P,62
+747,Wake Forest,Jaylon Edmond,CB,62
+747,Wake Forest,Frank Cusano,ROLB,62
+747,Wake Forest,Darius Jones,MLB,62
+747,Wake Forest,Will Cobb,TE,62
+747,Wake Forest,Jaishaun Offutt,LG,61
+747,Wake Forest,Dominic Deluca,TE,60
+747,Wake Forest,Elijiah Oehlke,QB,58
+747,Wake Forest,Jacob Cosby Mosley,SS,58
+747,Wake Forest,Caleb Carlson,K,55
+747,Wake Forest,Steele Pizzella,QB,52
+747,Wake Forest,Whittman Whaley,MLB,49
+747,Wake Forest,Nick Sawyer,LT,45
+748,Washington,Denzel Boston,WR,91
+748,Washington,Tacario Davis,CB,91
+748,Washington,Drew Azzopardi,RT,89
+748,Washington,Jacob Manu,MLB,88
+748,Washington,Ephesians Prysock,CB,87
+748,Washington,Zach Durfee,ROLB,87
+748,Washington,Quentin Moore,TE,86
+748,Washington,Xe Ree Alexander,MLB,86
+748,Washington,Taariq Al Uqdah,MLB,85
+748,Washington,Carver Willis,LT,85
+748,Washington,Geirean Hatchett,RG,84
+748,Washington,Logan Sagapolu,DT,84
+748,Washington,Omari Evans,WR,83
+748,Washington,Cj Christian,SS,83
+748,Washington,Hayden Moore,LOLB,83
+748,Washington,Demond Williams Jr,QB,82
+748,Washington,Landen Hatchett,C,81
+748,Washington,Kai Horton,QB,81
+748,Washington,Deshawn Lynch,LOLB,81
+748,Washington,Alex Mclaughlin,SS,80
+748,Washington,Simote Pepa,DT,80
+748,Washington,Maximus Mccree,RT,80
+748,Washington,Dyson Mccutcheon,CB,79
+748,Washington,Russell Davis Ii,LOLB,79
+748,Washington,Jacob Lane,LOLB,79
+748,Washington,Anthony Ward,MLB,78
+748,Washington,Makell Esteen,FS,77
+748,Washington,Decker Degraaf,TE,77
+748,Washington,Griffin Miller,ROLB,77
+748,Washington,Kevin Green Jr,WR,76
+748,Washington,Omar Khan,DT,76
+748,Washington,Ryan Otton,TE,75
+748,Washington,Vincent Holmes,FS,75
+748,Washington,Soane Faasolo,LT,75
+748,Washington,Zachary Henning,C,75
+748,Washington,Rashid Williams,WR,74
+748,Washington,Rahshawn Clark,FS,74
+748,Washington,Elishah Jackett,RT,74
+748,Washington,Zaydrius Rainey Sale,MLB,73
+748,Washington,Audric Harris,WR,73
+748,Washington,Champ Taulealea,RG,71
+748,Washington,Matthew Leo Ioane,QB,71
+748,Washington,Jonathan Epperson Jr,LOLB,71
+748,Washington,Chris Lawson,WR,69
+748,Washington,John Mills,LT,69
+748,Washington,Charles Ellerson,ROLB,68
+748,Washington,Raiden Vines Bright,WR,68
+748,Washington,Grady Gross,K,67
+748,Washington,Marcus Harris,WR,67
+748,Washington,Ryan Kean,TE,67
+748,Washington,Vincent Wheeler,CB,66
+748,Washington,Dash Beierly,QB,66
+748,Washington,Jack Shaffer,RT,66
+748,Washington,Leroy Bryant,CB,65
+748,Washington,Jake Flores,C,65
+748,Washington,Rahim Wright Ii,CB,64
+748,Washington,Jayden Harts,LG,63
+748,Washington,Kade Eldridge,TE,63
+748,Washington,Dominic Macon,DT,63
+748,Washington,Tae Littlejohn,RG,62
+748,Washington,Tristan Warner,SS,61
+748,Washington,Paki Finau,LG,60
+748,Washington,Paul Mencke Jr,SS,60
+748,Washington,Richard Leota,FB,60
+748,Washington,James Murphy Day,LT,59
+748,Washington,Troy Petz,P,58
+748,Washington,Asa Maae,FS,58
+748,Washington,Ethan Moczulski,K,57
+748,Washington,Deven Bryant,MLB,56
+748,Washington,Treston Mcmillan,QB,50
+748,Washington,Luke Dunne,P,48
+755,Team 755,Omar Aigbedion,RG,91
+755,Team 755,Josh Cameron,WR,89
+755,Team 755,Keaton Thomas,LOLB,89
+755,Team 755,Sidney Fugar,LT,89
+755,Team 755,Sawyer Robertson,QB,88
+755,Team 755,Travion Barnes,MLB,87
+755,Team 755,Kole Wilson,WR,87
+755,Team 755,Jackie Marshall,DT,87
+755,Team 755,Cooper Lanz,DT,86
+755,Team 755,Kobe Prentice,WR,85
+755,Team 755,Louis Brown Iv,WR,85
+755,Team 755,Coleton Price,C,85
+755,Team 755,Kaden Sieracki,RT,85
+755,Team 755,Caden Jenkins,CB,84
+755,Team 755,Devin Turner,FS,83
+755,Team 755,Tevin Williams Iii,CB,82
+755,Team 755,Ryan Lengyel,LG,82
+755,Team 755,Kendrick Simpkins,SS,81
+755,Team 755,Michael Trigg,TE,80
+755,Team 755,Phoenix Jackson,ROLB,80
+755,Team 755,Tonga Lolohea,DT,80
+755,Team 755,Dj Coleman,SS,79
+755,Team 755,Adonis Friloux,DT,78
+755,Team 755,Sean Thompkins,LT,77
+755,Team 755,Micah Gifford,SS,77
+755,Team 755,Cameron Mcrae,RT,77
+755,Team 755,Devonte Tezino,DT,76
+755,Team 755,Samu Taumanupepe,DT,76
+755,Team 755,Dk Kalu,DT,76
+755,Team 755,Matthew Klopfenstein,TE,76
+755,Team 755,Parker Vanness,QB,76
+755,Team 755,Wes Tucker,RG,76
+755,Team 755,Devyn Bobby,SS,75
+755,Team 755,Carl Williams Iv,FS,75
+755,Team 755,Joe Crocker,RG,75
+755,Team 755,Diontae Robinson,WR,74
+755,Team 755,Tyler Turner,FS,73
+755,Team 755,Jeremy Evans,MLB,73
+755,Team 755,Kris Wokomah,SS,73
+755,Team 755,Jacob Redding,FS,73
+755,Team 755,Cameren Jenkins,SS,73
+755,Team 755,Jadon Porter,WR,73
+755,Team 755,Mason Dossett,WR,73
+755,Team 755,Reggie Bush Ii,CB,72
+755,Team 755,Will Bateman,LG,71
+755,Team 755,Josh Paulding,LG,71
+755,Team 755,Koltin Sieracki,C,71
+755,Team 755,Calvin Simpson Hunt,CB,70
+755,Team 755,Colton Thomasson,RT,70
+755,Team 755,Palmer Williams,P,69
+755,Team 755,Jamarcus Ryder,FS,69
+755,Team 755,Placide Djungu Sungu,SS,69
+755,Team 755,Cody Mladenka,TE,69
+755,Team 755,Kyler Beaty,CB,68
+755,Team 755,Hawkins Polley,TE,68
+755,Team 755,Walker White,QB,64
+755,Team 755,Drake Knobloch,TE,63
+755,Team 755,Tyreek Word,CB,62
+755,Team 755,Greg Berman,K,60
+755,Team 755,Michael Allen,SS,60
+755,Team 755,Hayden Cresswell,ROLB,59
+755,Team 755,Sean Woodall,FS,59
+755,Team 755,Nate Bennett,QB,58
+755,Team 755,Leo Almanza,CB,58
+755,Team 755,Levar Thornton Jr,CB,57
+755,Team 755,Kyland Reed,MLB,57
+755,Team 755,Bo Schrader,LOLB,56
+755,Team 755,Andrew Mast,K,55
+755,Team 755,Isaiah Robinson,LT,49
+755,Team 755,Austin Moore,MLB,46
+634,Baylor,Braxton Fely,DT,91
+634,Baylor,Kage Casey,LT,90
+634,Baylor,Matt Lauter,TE,89
+634,Baylor,Maddux Madsen,QB,88
+634,Baylor,Latrell Caples,WR,88
+634,Baylor,Marco Notarainni,MLB,88
+634,Baylor,A Marion Mccoy,CB,87
+634,Baylor,Hall Schmidt,RT,87
+634,Baylor,Ty Benefield,FS,86
+634,Baylor,Jeremiah Earby,CB,85
+634,Baylor,Mason Randolph,C,83
+634,Baylor,Dion Washington,DT,83
+634,Baylor,Austin Bolt,WR,82
+634,Baylor,Roger Carreon,RG,81
+634,Baylor,Davon Banks,CB,81
+634,Baylor,Tyler Keinath,LG,80
+634,Baylor,Chase Penry,WR,80
+634,Baylor,Jaden Mickey,CB,79
+634,Baylor,David Latu,DT,78
+634,Baylor,Carson Rasmussen,LG,78
+634,Baylor,Austin Terry,TE,77
+634,Baylor,Demetrius Freeney,CB,76
+634,Baylor,Ja Bree Bickham,WR,76
+634,Baylor,Michael Madrie,DT,76
+634,Baylor,Daylon Metoyer,RT,75
+634,Baylor,Jake Ripp,MLB,75
+634,Baylor,Mana Tuioti,MLB,75
+634,Baylor,Dominik Calhoun,CB,75
+634,Baylor,Jaylen Webb,CB,75
+634,Baylor,Cordell Rich,SS,74
+634,Baylor,Zion Washington,SS,74
+634,Baylor,Boen Phelps,FS,74
+634,Baylor,Marquez Anderson,WR,74
+634,Baylor,Sherrod Smith,CB,74
+634,Baylor,Chris Rozman,RG,74
+634,Baylor,Matt Wagner,TE,73
+634,Baylor,Jason Steele,C,73
+634,Baylor,Mason Hutton,TE,73
+634,Baylor,Jake Steele,RG,72
+634,Baylor,Jaylen Alston,LOLB,72
+634,Baylor,L J Grant,FS,72
+634,Baylor,Samuel Brooks,FS,72
+634,Baylor,Jerron James,LT,72
+634,Baylor,Cameron Bates,WR,71
+634,Baylor,Ben Ford,WR,71
+634,Baylor,Cedric Vines,LG,71
+634,Baylor,Jacob Tracy,LT,70
+634,Baylor,Pierre Washington,LOLB,69
+634,Baylor,Chase Martin,ROLB,69
+634,Baylor,Lopez Sanusi,DT,69
+634,Baylor,Miles Walker,LG,68
+634,Baylor,Travis Anderson,SS,68
+634,Baylor,Kaden Anderson,TE,68
+634,Baylor,Torrell Robinson,FS,68
+634,Baylor,Zach Holmes,C,67
+634,Baylor,Max Cutforth,QB,67
+634,Baylor,Kyle Cox,RT,66
+634,Baylor,Eyitayo Omotinugbon,LG,66
+634,Baylor,Kyle Spangler,FB,65
+634,Baylor,Colton Boomer,K,64
+634,Baylor,Ramsey Snell,LOLB,63
+634,Baylor,Trevor Mckenna,LT,62
+634,Baylor,Franklyn Johnson Jr,CB,60
+634,Baylor,Treyvon Tolmaire,CB,60
+634,Baylor,Clayton Boswell,TE,59
+634,Baylor,Kaleb Annett,QB,59
+634,Baylor,Keanu Mailoto,DT,57
+634,Baylor,Pat Taggert,P,54
+634,Baylor,Jarrett Reeser,K,52
+634,Baylor,Clay Martineau,ROLB,47
+635,Boise State,Jude Bowry,LT,89
+635,Boise State,Kp Price,SS,87
+635,Boise State,Logan Taylor,LG,85
+635,Boise State,Max Tucker,CB,85
+635,Boise State,Amari Jackson,CB,85
+635,Boise State,Grayson James,QB,85
+635,Boise State,Lewis Bond,WR,84
+635,Boise State,Daveon Crouch,ROLB,84
+635,Boise State,Carter Davis,FS,84
+635,Boise State,Kevin Cline,RT,84
+635,Boise State,Jeremiah Franklin,TE,83
+635,Boise State,Dwayne Allick,RG,83
+635,Boise State,Reed Harris,WR,82
+635,Boise State,Owen Stoudmire,DT,82
+635,Boise State,Jaqwaylin Merritt,WR,81
+635,Boise State,Jadon Lafontant,LG,80
+635,Boise State,Omar Thornton,SS,79
+635,Boise State,Zeke Moore,TE,78
+635,Boise State,Dylan Lonergan,QB,78
+635,Boise State,Cole Warner,QB,78
+635,Boise State,Owen Mcgowan,MLB,78
+635,Boise State,Jack Funke,RT,78
+635,Boise State,Jaylen Blackwell,LOLB,77
+635,Boise State,Jaedn Skeete,WR,77
+635,Boise State,Connor Short,C,77
+635,Boise State,Ashton Mcshane,CB,77
+635,Boise State,Nate Johnson,WR,77
+635,Boise State,Johnathan Montague Jr,WR,77
+635,Boise State,Ty Lockwood,TE,76
+635,Boise State,Kwan Williams,DT,76
+635,Boise State,Amir Johnson,RG,76
+635,Boise State,Michael Crounse,RG,76
+635,Boise State,Chuck Nnaeto,DT,75
+635,Boise State,Jerrid Washington,DT,75
+635,Boise State,Cameron Martinez,SS,74
+635,Boise State,Davante Kemper,FS,74
+635,Boise State,Ty Clemons,DT,73
+635,Boise State,Isaiah Farris,CB,73
+635,Boise State,Syair Torrence,CB,72
+635,Boise State,Ismael Zamor,WR,72
+635,Boise State,Ryan Mickow,LT,71
+635,Boise State,Chauncey Worthy,RG,71
+635,Boise State,Nedrick Boldin Jr,WR,70
+635,Boise State,Ezekiel Branch,LOLB,70
+635,Boise State,Palaie Faoa,MLB,70
+635,Boise State,Tyler Barlow,TE,70
+635,Boise State,Omarion Davis,FS,69
+635,Boise State,Judah Pruitt,C,69
+635,Boise State,Kendrick Alexander,DT,67
+635,Boise State,Eryx Daugherty,LG,67
+635,Boise State,Quincy Winston,FS,66
+635,Boise State,Marvin Cason,FS,66
+635,Boise State,Mark Jordan Brown,C,65
+635,Boise State,Danny Edgehille,TE,65
+635,Boise State,Micah Winter,P,64
+635,Boise State,Nick Bayless,MLB,64
+635,Boise State,Cayleb Mccray,FB,64
+635,Boise State,Byron Joyner,CB,63
+635,Boise State,Liam Connor,K,60
+635,Boise State,Demarcus Stephens,DT,60
+635,Boise State,Rodney Leach,DT,60
+635,Boise State,Chris Marable Jr,DT,59
+635,Boise State,Kemori Dixon,FS,59
+635,Boise State,Daquan Hodges,ROLB,59
+635,Boise State,Terrance Beckett,FB,59
+635,Boise State,Billy Van Pelt,MLB,49
+635,Boise State,Pape Sy,RT,46
+636,Boston College,Drew Pyne,QB,84
+636,Boston College,Andrew Kilfoyl,LG,84
+636,Boston College,Jake Burns,C,84
+636,Boston College,Finn Hogan,WR,81
+636,Boston College,Jacob Harris,TE,81
+636,Boston College,Rj Garcia Ii,WR,80
+636,Boston College,Victor Vazquez,CB,80
+636,Boston College,Alex Padgett,RG,79
+636,Boston College,Nate Pabst,RT,79
+636,Boston College,Tunde Fatukasi,LT,79
+636,Boston College,Evan Branch Haynes,DT,79
+636,Boston College,Arlis Boardingham,TE,78
+636,Boston College,Trey Johnson,WR,77
+636,Boston College,Darius Lorfils,SS,76
+636,Boston College,Brennan Ridley,WR,76
+636,Boston College,Gideon Lampron,ROLB,76
+636,Boston College,Chris Williams,ROLB,76
+636,Boston College,Jojo Johnson,CB,75
+636,Boston College,Donny Stephens,MLB,75
+636,Boston College,Jaden Parsons,SS,75
+636,Boston College,Jared Merk,WR,75
+636,Boston College,George Carlson,TE,75
+636,Boston College,Jace Hicks,CB,74
+636,Boston College,Justin Owens,DT,74
+636,Boston College,Winn Sharp,WR,74
+636,Boston College,Cade Zimmerly,LG,73
+636,Boston College,Allen Middleton,WR,73
+636,Boston College,Jace Henry,CB,73
+636,Boston College,Gordon Binns,FS,73
+636,Boston College,Alex Harris,LT,73
+636,Boston College,Kal El Pascal,CB,72
+636,Boston College,Andrew Williams,CB,72
+636,Boston College,Dayln White,DT,72
+636,Boston College,David Afogho,ROLB,72
+636,Boston College,Randal Austin,FS,71
+636,Boston College,Malik Moses,DT,71
+636,Boston College,Jabari Mitchell,MLB,71
+636,Boston College,Lucian Anderson Iii,QB,70
+636,Boston College,Austin Clay,WR,70
+636,Boston College,Jay Quan Bostic,FS,70
+636,Boston College,D Kyah Banks,SS,70
+636,Boston College,Baron May,QB,68
+636,Boston College,Tj Nelson,SS,68
+636,Boston College,Adrian Curtis,RT,68
+636,Boston College,Randy Davis,FB,67
+636,Boston College,Kiyaunta Parks,CB,66
+636,Boston College,Brody Bolyn,C,66
+636,Boston College,Ezra Coleman,TE,66
+636,Boston College,Caleb Goodloe,WR,66
+636,Boston College,John Henderson,P,65
+636,Boston College,Andrew Hines Iii,LOLB,65
+636,Boston College,Ed Patterson,TE,65
+636,Boston College,Cynceir Mcneal,WR,65
+636,Boston College,Will Benson,DT,64
+636,Boston College,Dorian Pringle,MLB,64
+636,Boston College,Larry Yates,SS,64
+636,Boston College,Donte Young,QB,63
+636,Boston College,Joshua Patton,LG,63
+636,Boston College,Matthew Mitchell,MLB,62
+636,Boston College,Gavin Harris,CB,62
+636,Boston College,James Thomas Jr,RG,62
+636,Boston College,Dilon Tallie,WR,60
+636,Boston College,Eric Baber,FB,60
+636,Boston College,Travis Kenner,K,58
+636,Boston College,Pat Stephenson,LOLB,58
+636,Boston College,Joe O Leary,C,57
+636,Boston College,Jackson Kleather,P,55
+636,Boston College,Ian Van Der Merwe,DT,55
+636,Boston College,Deshaun Lanier,WR,54
+636,Boston College,Zach Long,K,49
+636,Boston College,Ethan Warner,K,40
+637,Bowling Green,Red Murdock,MLB,90
+637,Bowling Green,Trevor Brock,LG,87
+637,Bowling Green,Henry Tabansi,LT,85
+637,Bowling Green,Nik Mcmillan,WR,85
+637,Bowling Green,Marquis Cooper,CB,85
+637,Bowling Green,Victor Snow,WR,84
+637,Bowling Green,George Wolo,DT,84
+637,Bowling Green,Charles Mccartherens,CB,84
+637,Bowling Green,Tyler Doty,RG,83
+637,Bowling Green,Solomon Brown,FS,83
+637,Bowling Green,Dion Crawford,ROLB,83
+637,Bowling Green,Jalen Mcnair,CB,82
+637,Bowling Green,Andrew Schnackenberg,TE,82
+637,Bowling Green,Jacob Merritt,RT,81
+637,Bowling Green,Cornell Evans,DT,79
+637,Bowling Green,Jake Timm,C,79
+637,Bowling Green,Ta Quan Roberson,QB,78
+637,Bowling Green,Gabriel Arena,LT,78
+637,Bowling Green,Tristan Souza,DT,77
+637,Bowling Green,Jackson Bellamy,RG,76
+637,Bowling Green,Oliver Bridges,CB,75
+637,Bowling Green,Eddie Pleasant Iii,CB,75
+637,Bowling Green,Dwayne Early Jr,WR,75
+637,Bowling Green,George Hill,MLB,75
+637,Bowling Green,Alex Heininger,RG,75
+637,Bowling Green,Bradley Ilunga Bisselele,ROLB,75
+637,Bowling Green,Thomas Barr,C,75
+637,Bowling Green,Jonathan Capo,SS,74
+637,Bowling Green,Gunnar Gray,QB,74
+637,Bowling Green,Mitch Viviano,TE,74
+637,Bowling Green,Jackson Small,CB,74
+637,Bowling Green,Christopher Lamb,RT,74
+637,Bowling Green,Chance Morrow,WR,73
+637,Bowling Green,Jonathan Rousseau,SS,73
+637,Bowling Green,Evan King,TE,72
+637,Bowling Green,James Carrington Iii,RT,72
+637,Bowling Green,Sal Brooks,QB,72
+637,Bowling Green,Patrick Clacks Iii,WR,72
+637,Bowling Green,Val Kondratenko,LG,72
+637,Bowling Green,Taylor Blake,QB,71
+637,Bowling Green,Miles Greer,SS,71
+637,Bowling Green,Paul Clark,LG,71
+637,Bowling Green,Mitchell Gonser,MLB,70
+637,Bowling Green,Junior Poyser,DT,70
+637,Bowling Green,Kobi Blackwell,CB,69
+637,Bowling Green,Ryan Daly,TE,69
+637,Bowling Green,Ahmaan Thomas,LT,69
+637,Bowling Green,Gio De Leon,ROLB,68
+637,Bowling Green,John Keough,FS,68
+637,Bowling Green,Jeremiah Watkins,WR,68
+637,Bowling Green,Jerrod Gentry,FS,68
+637,Bowling Green,Tyrone Davis,RT,68
+637,Bowling Green,Qua Sanders,WR,68
+637,Bowling Green,Mathew Hilty,MLB,68
+637,Bowling Green,Chayce Chadwick,C,68
+637,Bowling Green,Carson Selee,TE,68
+637,Bowling Green,Liam Hamilton,C,68
+637,Bowling Green,Saveon Brown,ROLB,67
+637,Bowling Green,Connor Henderson,ROLB,66
+637,Bowling Green,Ronnell Davis,FS,66
+637,Bowling Green,Devin Morgan,DT,65
+637,Bowling Green,Keontez Bradley,CB,64
+637,Bowling Green,Xavier Leonard,SS,63
+637,Bowling Green,Nick Phillips,FB,62
+637,Bowling Green,Will Clark,MLB,61
+637,Bowling Green,Tyrell Simmons Jr,WR,61
+637,Bowling Green,Jack Howes,K,60
+637,Bowling Green,Keenan Fairley,LT,59
+637,Bowling Green,Jason Wright,QB,58
+637,Bowling Green,Matthew Glen,LG,58
+637,Bowling Green,Dylan Drennan,P,57
+637,Bowling Green,Nick Reed,K,44
+638,Buffalo,Chase Roberts,WR,90
+638,Buffalo,Jack Kelly,ROLB,89
+638,Buffalo,Jake Retzlaff,QB,88
+638,Buffalo,Isaiah Glasker,LOLB,88
+638,Buffalo,Weylin Lapuaho,LG,88
+638,Buffalo,Trevin Ostler,LT,88
+638,Buffalo,Tanner Wall,FS,87
+638,Buffalo,Bruce Mitchell,C,87
+638,Buffalo,Mory Bamba,CB,87
+638,Buffalo,Tiger Bachmeier,WR,86
+638,Buffalo,Keanu Tanuvasa,DT,85
+638,Buffalo,Carsen Ryan,TE,84
+638,Buffalo,Raider Damuni,SS,84
+638,Buffalo,Austin Leausa,RT,84
+638,Buffalo,Justin Kirkland,DT,83
+638,Buffalo,Sonny Makasini,C,83
+638,Buffalo,Ace Kaufusi,ROLB,83
+638,Buffalo,John Taumoepeau,DT,82
+638,Buffalo,Siale Esera,MLB,81
+638,Buffalo,Andrew Gentry,RT,80
+638,Buffalo,Patrick Anderson,QB,80
+638,Buffalo,Isaiah Jatta,LT,80
+638,Buffalo,Talan Alfrey,SS,79
+638,Buffalo,Preston Rex,FS,79
+638,Buffalo,Cody Hagen,WR,78
+638,Buffalo,Jojo Phillips,WR,78
+638,Buffalo,Jake Griffin,LT,77
+638,Buffalo,Wes Culliver,FS,77
+638,Buffalo,Faletau Satuala,SS,76
+638,Buffalo,Maika Kaufusi,LOLB,76
+638,Buffalo,Derron Davis,FS,76
+638,Buffalo,Parker Kingston,WR,75
+638,Buffalo,Evan Johnson,CB,74
+638,Buffalo,Treyson Bourguet,QB,74
+638,Buffalo,Miles Hall,MLB,73
+638,Buffalo,Joe Brown,RG,73
+638,Buffalo,Kaden Chidester,LT,73
+638,Buffalo,Jayden Dunlap,CB,73
+638,Buffalo,Will Ferrin,K,72
+638,Buffalo,Marcus Mckenzie,CB,72
+638,Buffalo,Tommy Prassas,FS,72
+638,Buffalo,Keegan Nowak,TE,72
+638,Buffalo,Max Alford,ROLB,71
+638,Buffalo,Clay Russell,FB,71
+638,Buffalo,Ethan Erickson,TE,69
+638,Buffalo,Tei Nacua,WR,69
+638,Buffalo,Ikinasio Tupou,LG,69
+638,Buffalo,Aaron Reede,DT,68
+638,Buffalo,Sani Tuala,DT,68
+638,Buffalo,Trevor Dunn,MLB,67
+638,Buffalo,Garrison Grimes,TE,67
+638,Buffalo,Therrian Alexander Iii,CB,66
+638,Buffalo,Anfernee Shivers,LOLB,65
+638,Buffalo,Jonathan Kabeya,CB,65
+638,Buffalo,Darren Downs,RT,65
+638,Buffalo,Nick Orr,P,64
+638,Buffalo,Sam Vander Haar,P,62
+638,Buffalo,Jared Thurston,C,62
+638,Buffalo,Alvin Puefua,DT,62
+638,Buffalo,Justin Burnett,ROLB,62
+638,Buffalo,Stephen Wakefield,QB,61
+638,Buffalo,Phil Logan,RG,61
+638,Buffalo,Lamason Waller Iii,WR,60
+638,Buffalo,Justin Carr Vincent,MLB,60
+638,Buffalo,Dorian Patterson,QB,58
+638,Buffalo,Pierre Phillips,TE,58
+638,Buffalo,Devin Hough,FB,57
+638,Buffalo,Deion Spriggs,RT,53
+638,Buffalo,Matthias Dunn,K,45
+639,BYU,Sioape Vatikani,LG,92
+639,BYU,Aidan Keanaaina,DT,88
+639,BYU,Cade Uluave,MLB,87
+639,BYU,Ryan Mcculloch,ROLB,87
+639,BYU,Trond Grizzell,WR,86
+639,BYU,Hezekiah Masses,CB,85
+639,BYU,Harrison Taggart,MLB,85
+639,BYU,Brent Austin,CB,85
+639,BYU,Landon Morris,TE,84
+639,BYU,Jacob De Jesus,WR,83
+639,BYU,Tyson Ruffins,C,82
+639,BYU,Jayden Wayne,ROLB,81
+639,BYU,Stanley Saole Mckenzie,DT,80
+639,BYU,Bastian Swinney,C,80
+639,BYU,Nick Morrow,LT,79
+639,BYU,Jordan King,WR,79
+639,BYU,Devin Brown,QB,78
+639,BYU,Jordan Spasojevic Moko,LG,78
+639,BYU,Dru Polidore Jr,SS,78
+639,BYU,Frederick Williams Iii,RT,78
+639,BYU,Curlee Thomas Iv,DT,77
+639,BYU,Mark Hamper,WR,77
+639,BYU,Ja Ir Smith,CB,77
+639,BYU,Jeffrey Johnson,TE,76
+639,BYU,Tristan Dunn,FS,75
+639,BYU,Cam Sidney,CB,75
+639,BYU,Lajuan Owens,LT,75
+639,BYU,Ewan Arechaederra,TE,75
+639,BYU,Braden Miller,RG,75
+639,BYU,Mason Mini,TE,75
+639,BYU,Jaiven Plummer,WR,75
+639,BYU,Leon Bell,RT,75
+639,BYU,Travis Mcleod,LOLB,75
+639,BYU,Dazmin James,WR,74
+639,BYU,Ej Caminong,QB,74
+639,BYU,Jordan Sanford,FS,73
+639,BYU,Buom Jock,ROLB,73
+639,BYU,Clifton Armstrong,RT,73
+639,BYU,Justin Hasenhuetl,LG,72
+639,BYU,Ben Marshall,TE,72
+639,BYU,Khamani Hudson,CB,72
+639,BYU,Odera Okaka,LOLB,72
+639,BYU,Lamar Robinson,RG,71
+639,BYU,Kyion Grayes,WR,70
+639,BYU,Akili Calhoun,RG,70
+639,BYU,Serigne Tounkara,LOLB,70
+639,BYU,Jae On Young,CB,69
+639,BYU,Abram Murray,K,69
+639,BYU,Brook Honore Jr,P,69
+639,BYU,Kaden Cook,CB,68
+639,BYU,Eze Osondu,MLB,68
+639,BYU,Jaron Keawe Sagapolutele,QB,67
+639,BYU,Quimari Shemwell,CB,67
+639,BYU,Jasiah Wagoner,CB,65
+639,BYU,Meyer Swinney,TE,65
+639,BYU,Isaiah Crosby,FS,65
+639,BYU,Aaron Hampton,MLB,65
+639,BYU,Josh Bordelon,C,65
+639,BYU,Dorian Heyward,SS,65
+639,BYU,Aiden Manutai,SS,64
+639,BYU,Tyler Knape,RG,64
+639,BYU,Dominic Ingrassia,QB,63
+639,BYU,Luke Ferrelli,MLB,63
+639,BYU,Cordale Price,FB,63
+639,BYU,Demetrius Robinson,DT,62
+639,BYU,James Finnegan,ROLB,62
+639,BYU,Dominick Weaver,FB,62
+639,BYU,Trevor Rogers,WR,61
+639,BYU,Syris Corley,RT,61
+639,BYU,Michael Kern,P,56
+639,BYU,Aiden Newbill,LT,55
+640,California,Kalen Carroll,CB,86
+640,California,Jordan Kwiatkowski,MLB,85
+640,California,Brady Ploucha,RG,85
+640,California,Lawai A Brown,MLB,84
+640,California,Jaion Jackson,CB,83
+640,California,Joe Labas,QB,83
+640,California,Stephan Bracey Jr,WR,82
+640,California,Jacob Booth,RG,81
+640,California,Caleb Spann,SS,80
+640,California,Dakota Cochran,ROLB,80
+640,California,Fernando Sanchez Iii,LOLB,80
+640,California,Elijah Gordon,FS,80
+640,California,Elijah Rikard,FS,79
+640,California,Travis Wolf,QB,79
+640,California,Jordyn Williams,WR,78
+640,California,Tyson Davis,WR,77
+640,California,Aakeem Snell,CB,77
+640,California,Decorion Temple,TE,76
+640,California,Brenden Deasfernandes,FS,75
+640,California,Langston Lewis,WR,75
+640,California,Maddix Blackwell,CB,75
+640,California,Jayshaun Coffman,DT,74
+640,California,Dylan Fisher,DT,74
+640,California,Ryan Blum,C,74
+640,California,Nolan Anderson,FS,74
+640,California,Angel Flores,QB,73
+640,California,Rory Callahan,TE,73
+640,California,Tayte Vanderleest,WR,73
+640,California,Apisa Poumele,C,73
+640,California,Earl Langford,ROLB,73
+640,California,Martin Koivisto,RT,72
+640,California,Ed Conoran,SS,72
+640,California,Jacob Russell,LT,72
+640,California,Morgan Taggart,RG,72
+640,California,Marcus Badgett,CB,72
+640,California,Jordan Kelly,WR,72
+640,California,Josiah Booker,WR,72
+640,California,Kyle Krebs,CB,72
+640,California,Rusty Vanwetzinga,FB,71
+640,California,Mckeegan Ferguson,ROLB,71
+640,California,Jonathan Decker,DT,71
+640,California,Nathan Vantimmeren,TE,70
+640,California,Jacob Kaminski,TE,69
+640,California,Khari Johnson,MLB,69
+640,California,Xavier White,LOLB,69
+640,California,Tim Tomlinson,RG,69
+640,California,Victor Earl,ROLB,69
+640,California,Mark Allen Gay,SS,68
+640,California,Ben Pratt,TE,66
+640,California,Evan Carpenter,K,65
+640,California,Mick Demott,QB,65
+640,California,Quavion Bird,DT,65
+640,California,Cade Graham,K,64
+640,California,Marcus Beamon,QB,64
+640,California,Jadyn Glasser,QB,64
+640,California,Bryce Rowe,SS,64
+640,California,Jeremiah Alston Jackson,SS,63
+640,California,Zac Chapeau,K,62
+640,California,John Burke,LT,62
+640,California,Declan Duley,P,61
+640,California,Will Mooney,FS,61
+640,California,Elijah Grant,LG,61
+640,California,Andre Thomas,MLB,61
+640,California,Tai Newkirk,WR,61
+640,California,Tremaine Carnegie,RG,60
+640,California,Matthew Nehf,LG,59
+640,California,Dane Sickler,RT,56
+640,California,Dasan Smith,LT,55
+640,California,Dylan Hertzberg,P,52
+640,California,Luis Martinez,RT,52
+640,California,Skylar Lindo,C,50
+641,Central Michigan,Justin Olson,WR,88
+641,Central Michigan,Thailand Baldwin,CB,86
+641,Central Michigan,Jonny King,C,85
+641,Central Michigan,Isaiah Bullerdick,C,83
+641,Central Michigan,Treyveon Mcgee,SS,81
+641,Central Michigan,Mo Clipper Jr,LG,81
+641,Central Michigan,Jamarrion Solomon,DT,81
+641,Central Michigan,Jesse Ramil,LT,80
+641,Central Michigan,Ja Qurious Conley,CB,80
+641,Central Michigan,Joey Bearns Iii,FB,80
+641,Central Michigan,Andrew Adair,LG,80
+641,Central Michigan,Collin Gill,FS,79
+641,Central Michigan,Rod Green,LG,79
+641,Central Michigan,Taz Williams,DT,79
+641,Central Michigan,Jayden Mcgowan,WR,78
+641,Central Michigan,Reid Williford,MLB,78
+641,Central Michigan,Grayson Loftis,QB,78
+641,Central Michigan,Cj Clinkscales,CB,78
+641,Central Michigan,Tyler Gibson,RT,78
+641,Central Michigan,Parker Startz,MLB,77
+641,Central Michigan,Xavier Simmons,ROLB,77
+641,Central Michigan,Jonathon Okate,LOLB,77
+641,Central Michigan,Derrick Edwards,CB,77
+641,Central Michigan,Grant Laskey,TE,77
+641,Central Michigan,Shay Taylor,MLB,76
+641,Central Michigan,Gavin Willis,ROLB,75
+641,Central Michigan,Xavier Miles,DT,75
+641,Central Michigan,Dwight Bootle Ii,CB,75
+641,Central Michigan,Breon Noel,SS,75
+641,Central Michigan,James Thompkins,FS,75
+641,Central Michigan,E Jai Mason,WR,75
+641,Central Michigan,Nate Spillman,WR,75
+641,Central Michigan,Gus Mcgee,TE,74
+641,Central Michigan,Zach Wilcke,QB,74
+641,Central Michigan,Lane Mcdonald,SS,74
+641,Central Michigan,Ayo Tifase,DT,74
+641,Central Michigan,Conner Harrell,QB,73
+641,Central Michigan,Javen Nicholas,WR,73
+641,Central Michigan,Mason Bowers,LT,73
+641,Central Michigan,Dallas Shirley,RG,72
+641,Central Michigan,Darius Wallace,MLB,72
+641,Central Michigan,Boston Brinkley,C,72
+641,Central Michigan,Randy Franklin,FS,72
+641,Central Michigan,Andrew Cunningham,RG,72
+641,Central Michigan,Adam Hopkins,WR,71
+641,Central Michigan,Travis Arnold,P,70
+641,Central Michigan,Dominick Kelley,LG,70
+641,Central Michigan,Devin Davis,RG,70
+641,Central Michigan,Omarion Davis,LG,70
+641,Central Michigan,Antonio Cotman Jr,CB,69
+641,Central Michigan,Cary Grant,FS,69
+641,Central Michigan,Evan Austin,WR,69
+641,Central Michigan,Miles Burris,WR,69
+641,Central Michigan,Darius Clarke,LT,67
+641,Central Michigan,Stellan Bowman,ROLB,67
+641,Central Michigan,Deuce Rose,CB,66
+641,Central Michigan,Johnny Jacobs,CB,65
+641,Central Michigan,Eli Samples,RT,65
+641,Central Michigan,Heath Holt,RG,64
+641,Central Michigan,Vee Jay Ellis,WR,63
+641,Central Michigan,Leon House,TE,62
+641,Central Michigan,Jefferson Lambert,DT,61
+641,Central Michigan,Dy Lon Womack,CB,61
+641,Central Michigan,Umar Rockhead,LT,61
+641,Central Michigan,Bronson Long,P,59
+641,Central Michigan,Kyle Richard,RT,57
+641,Central Michigan,Cornell Allen,SS,56
+641,Central Michigan,Colby Garfield,TE,51
+641,Central Michigan,Ross Paulsen,K,50
+642,Charlotte,Dontay Corleone,DT,92
+642,Charlotte,Jake Golday,LOLB,88
+642,Charlotte,Brendan Sorsby,QB,88
+642,Charlotte,Joe Royer,TE,87
+642,Charlotte,Matthew Mcdoom,CB,87
+642,Charlotte,Antwan Peek Jr,SS,85
+642,Charlotte,Jiquan Sanks,FS,85
+642,Charlotte,Jalen Hunt,DT,85
+642,Charlotte,Taran Tyo,RG,84
+642,Charlotte,Deondre Buford,LG,84
+642,Charlotte,Gavin Gerhardt,C,83
+642,Charlotte,Cyrus Allen,WR,83
+642,Charlotte,Ormanie Arnold,CB,83
+642,Charlotte,Jack Dingle,ROLB,83
+642,Charlotte,Xavier Lozowicki,LT,82
+642,Charlotte,Jonathan Thompson,MLB,82
+642,Charlotte,Jeff Caldwell,WR,81
+642,Charlotte,Xavier Williams,FS,81
+642,Charlotte,Cameron Roetherford,DT,81
+642,Charlotte,Judea Milon,LT,80
+642,Charlotte,Ethan Green,RT,78
+642,Charlotte,Christian Harrison,CB,77
+642,Charlotte,Simeon Coleman,MLB,77
+642,Charlotte,Weston Simmons,TE,76
+642,Charlotte,Nolan Latulippe,RT,76
+642,Charlotte,Caleb Goodie,WR,75
+642,Charlotte,Logan Wilson,SS,75
+642,Charlotte,Samaj Jones,QB,75
+642,Charlotte,Tayden Barnes,FS,75
+642,Charlotte,Joe Cotton,LT,75
+642,Charlotte,Barry Jackson Jr,WR,74
+642,Charlotte,Xavier Washburn,ROLB,73
+642,Charlotte,Grant Edgington,RG,72
+642,Charlotte,Michael Wheatley Vance,ROLB,71
+642,Charlotte,Angelo Westbrook,LOLB,71
+642,Charlotte,Max Fletcher,P,70
+642,Charlotte,Kye Stokes,SS,70
+642,Charlotte,Noah Jennings,WR,70
+642,Charlotte,Indy Murray,LG,70
+642,Charlotte,Montay Weedon,LOLB,70
+642,Charlotte,Anthony Flint,TE,69
+642,Charlotte,Brian Simms Iii,ROLB,69
+642,Charlotte,Andy Franzel,FB,68
+642,Charlotte,Evan Tengesdahl,C,68
+642,Charlotte,Aiden Pastoriza,RG,68
+642,Charlotte,Darnell Lamb,DT,67
+642,Charlotte,Cray Paich,LT,67
+642,Charlotte,Zay Johnson,CB,67
+642,Charlotte,Terrell Holcomb,MLB,66
+642,Charlotte,Stephen Rusnak,K,65
+642,Charlotte,Ka Maurri Smith,TE,65
+642,Charlotte,Zach Taylor,LG,64
+642,Charlotte,Patrick Williams,CB,64
+642,Charlotte,Mason Newman,ROLB,64
+642,Charlotte,Marqavious Saboor,FS,64
+642,Charlotte,Jake Wheelock,C,64
+642,Charlotte,Dakarai Anderson,WR,64
+642,Charlotte,Zebulin Kinsey,QB,63
+642,Charlotte,Brady Lichtenberg,QB,62
+642,Charlotte,Devyn Zahursky,TE,62
+642,Charlotte,Daniel James,CB,58
+642,Charlotte,Willie Goodwyn,CB,58
+642,Charlotte,Marcus Mcgregor,C,58
+642,Charlotte,Max Lemasters,K,57
+642,Charlotte,Trevon Gola Callard,FS,55
+642,Charlotte,Gavin Grover,TE,55
+642,Charlotte,Vonterrio Smith,WR,53
+642,Charlotte,Zac Clarke,RT,50
+643,Cincinnati,Peter Woods,DT,94
+643,Cincinnati,Cade Klubnik,QB,92
+643,Cincinnati,Blake Miller,RT,92
+643,Cincinnati,Avieon Terrell,CB,92
+643,Cincinnati,Walker Parks,RG,92
+643,Cincinnati,Antonio Williams,WR,90
+643,Cincinnati,Wade Woodaz,MLB,90
+643,Cincinnati,Cole Turner,WR,87
+643,Cincinnati,Khalil Barnes,FS,85
+643,Cincinnati,Tristan Leigh,LT,85
+643,Cincinnati,Kobe Mccloud,ROLB,85
+643,Cincinnati,Bryant Wesco Jr,WR,84
+643,Cincinnati,Tyler Brown,WR,84
+643,Cincinnati,Jeadyn Lukus,CB,83
+643,Cincinnati,Ryan Linthicum,C,83
+643,Cincinnati,Demonte Capehart,DT,82
+643,Cincinnati,Sammy Brown,ROLB,81
+643,Cincinnati,Kylon Griffin,SS,81
+643,Cincinnati,Tristan Smith,WR,81
+643,Cincinnati,Tyler Venables,FS,80
+643,Cincinnati,T J Moore,WR,79
+643,Cincinnati,Olsen Patt Henry,TE,79
+643,Cincinnati,Collin Sadler,RG,79
+643,Cincinnati,Stephiylan Green,DT,78
+643,Cincinnati,Jeremiah Alexander,MLB,78
+643,Cincinnati,Ashton Hampton,CB,77
+643,Cincinnati,Ricardo Jones,FS,76
+643,Cincinnati,Harris Sewell,LG,76
+643,Cincinnati,Christopher Vizzina,QB,75
+643,Cincinnati,Shelton Lewis,CB,75
+643,Cincinnati,Rob Billings,SS,75
+643,Cincinnati,Philip Florenzo,TE,75
+643,Cincinnati,Amare Adams,DT,74
+643,Cincinnati,Jamal Anderson,LOLB,73
+643,Cincinnati,Brayden Jacobs,RT,73
+643,Cincinnati,Marcus Jackson,SS,73
+643,Cincinnati,Trent Pearman,QB,73
+643,Cincinnati,Ronan Hanafin,WR,72
+643,Cincinnati,Chapman Pendergrass,C,72
+643,Cincinnati,Caden Story,DT,71
+643,Cincinnati,Kylen Webb,SS,71
+643,Cincinnati,Elyjah Thurmon,LT,71
+643,Cincinnati,Dee Crayton,MLB,71
+643,Cincinnati,Josh Sapp,TE,71
+643,Cincinnati,Ian Reed,LT,70
+643,Cincinnati,Vic Burley,DT,69
+643,Cincinnati,Dietrick Pennington,LG,69
+643,Cincinnati,Corian Gipson,CB,69
+643,Cincinnati,Tray Farmer,LOLB,69
+643,Cincinnati,Joe Wilkinson,FS,69
+643,Cincinnati,Logan Brooking,TE,68
+643,Cincinnati,Watson Young,LG,68
+643,Cincinnati,Myles Oliver,CB,67
+643,Cincinnati,Mason Wade,RT,67
+643,Cincinnati,Justin Henry,FB,67
+643,Cincinnati,Christian Bentancur,TE,66
+643,Cincinnati,Branden Strozier,CB,66
+643,Cincinnati,Hevin Brown Shuler,DT,66
+643,Cincinnati,Mario O Neill,LT,65
+643,Cincinnati,C J Kubah Taylor,MLB,65
+643,Cincinnati,Nolan Hauser,K,64
+643,Cincinnati,Ronan O Connell,RG,62
+643,Cincinnati,Misun Kelley,CB,61
+643,Cincinnati,Jakarrion Kenan,SS,61
+643,Cincinnati,Robert Gunn Iii,K,60
+643,Cincinnati,Memphis Grimm,C,59
+643,Cincinnati,Nick Snell,TE,58
+643,Cincinnati,Shayne Elliott,LT,57
+643,Cincinnati,Jack Smith,P,56
+643,Cincinnati,Drew Woodaz,ROLB,54
+643,Cincinnati,Chris Denson,QB,52
+643,Cincinnati,Michael Jacobs,LG,52
+645,Coastal Carolina,Jordan Seaton,LT,92
+645,Coastal Carolina,Xavier Hill,RT,90
+645,Coastal Carolina,Dj Mckinney,CB,89
+645,Coastal Carolina,Preston Hodge,SS,89
+645,Coastal Carolina,Kaidon Salter,QB,88
+645,Coastal Carolina,Tyrecus Davis,CB,87
+645,Coastal Carolina,Phillip Houston,RT,87
+645,Coastal Carolina,Cooper Lovelace,RT,87
+645,Coastal Carolina,Jaheim Oatis,DT,86
+645,Coastal Carolina,Tyler Brown,LG,86
+645,Coastal Carolina,Zy Crisler,LG,86
+645,Coastal Carolina,Carter Stoutmire,FS,85
+645,Coastal Carolina,Martavius French,MLB,85
+645,Coastal Carolina,Jack Hestera,WR,85
+645,Coastal Carolina,Kareem Harden,RG,85
+645,Coastal Carolina,Zarian Mcgill,C,85
+645,Coastal Carolina,Tavian Coleman,DT,84
+645,Coastal Carolina,Ben Finneseth,SS,84
+645,Coastal Carolina,Omarion Miller,WR,82
+645,Coastal Carolina,Taurean Carter Ii,DT,82
+645,Coastal Carolina,Adam Blackburn,LT,82
+645,Coastal Carolina,Joseph Williams,WR,81
+645,Coastal Carolina,Drelon Miller,WR,80
+645,Coastal Carolina,Gavriel Lightfoot,DT,80
+645,Coastal Carolina,Tawfiq Thomas,DT,80
+645,Coastal Carolina,Ivan Yates,CB,80
+645,Coastal Carolina,Reginald Hughes,ROLB,79
+645,Coastal Carolina,Jeremiah Brown,MLB,77
+645,Coastal Carolina,Levi Drayton,QB,77
+645,Coastal Carolina,Zach Atkins,TE,76
+645,Coastal Carolina,Hykeem Williams,WR,76
+645,Coastal Carolina,Anquin Barnes Jr,DT,76
+645,Coastal Carolina,Andre Roye Jr,RT,76
+645,Coastal Carolina,Brady Kopetz,TE,76
+645,Coastal Carolina,Tawfiq Byard,SS,75
+645,Coastal Carolina,Sav Ell Smalls,TE,75
+645,Coastal Carolina,Ryan Staub,QB,75
+645,Coastal Carolina,Terrell Timmons Jr,WR,75
+645,Coastal Carolina,Amari Mcneill,DT,74
+645,Coastal Carolina,Quanell Farrakhan Jr,WR,74
+645,Coastal Carolina,Aki Ogunbiyi,RG,73
+645,Coastal Carolina,Larry Johnson Iii,LT,73
+645,Coastal Carolina,Noah King,FS,73
+645,Coastal Carolina,Makari Vickers,CB,73
+645,Coastal Carolina,Kevin Flanagan,FS,73
+645,Coastal Carolina,Rj Johnson,CB,71
+645,Coastal Carolina,Isaiah Hardge,WR,71
+645,Coastal Carolina,Terrance Love,SS,70
+645,Coastal Carolina,John Slaughter,SS,70
+645,Coastal Carolina,Gage Goldberg,ROLB,70
+645,Coastal Carolina,Kam Mikell,WR,69
+645,Coastal Carolina,Braden Keith,CB,69
+645,Coastal Carolina,Kameron Hawkins,TE,69
+645,Coastal Carolina,Julian Lewis,QB,68
+645,Coastal Carolina,Alejandro Mata,K,68
+645,Coastal Carolina,Mantrez Walker,ROLB,67
+645,Coastal Carolina,Nathaniel Watson,CB,66
+645,Coastal Carolina,Christian Hudson,DT,65
+645,Coastal Carolina,Chris Brooks Stott,ROLB,64
+645,Coastal Carolina,Quentin Gibson,WR,64
+645,Coastal Carolina,Gabe Landers,TE,63
+645,Coastal Carolina,Jontez Holland,TE,63
+645,Coastal Carolina,Chauncey Gooden,RG,62
+645,Coastal Carolina,Buck Buchanan,K,62
+645,Coastal Carolina,Bo Lapenna,LOLB,61
+645,Coastal Carolina,Eli Tongue,FB,61
+645,Coastal Carolina,Jonathan Neill,TE,59
+645,Coastal Carolina,Corbin Laisure,TE,59
+645,Coastal Carolina,Damon Greaves,P,58
+645,Coastal Carolina,Kylan Salter,MLB,57
+645,Coastal Carolina,Daniel Gerlach,P,54
+645,Coastal Carolina,Yahya Attia,LG,49
+647,Colorado State,Fintan Brose,RT,86
+647,Colorado State,Max Patterson,WR,82
+647,Colorado State,Kt Seay,FS,81
+647,Colorado State,Steven Demboski,C,81
+647,Colorado State,Nicholas Laboy,WR,81
+647,Colorado State,Dillon Trainer,ROLB,80
+647,Colorado State,Gavin Moul,MLB,80
+647,Colorado State,Keyshawn Hunter,DT,80
+647,Colorado State,Anwar O Neal,LT,78
+647,Colorado State,Hasson Manning Jr,FS,77
+647,Colorado State,Zach Marker,QB,77
+647,Colorado State,Ja Carree Kelly,WR,77
+647,Colorado State,Thomas Chernasky,LT,77
+647,Colorado State,Jake Thaw,WR,76
+647,Colorado State,Cole Snyder,RT,76
+647,Colorado State,Montez Cowing,LOLB,76
+647,Colorado State,Julius Puryear,ROLB,76
+647,Colorado State,Keontae Jenkins,CB,75
+647,Colorado State,Elijah Sessoms,TE,75
+647,Colorado State,Trace Scott,DT,75
+647,Colorado State,Sean Wilson,WR,74
+647,Colorado State,Blake Matthews,LOLB,74
+647,Colorado State,Connor Witthoft,TE,74
+647,Colorado State,Patrick Methlie,C,74
+647,Colorado State,Carmine Lupi,RT,74
+647,Colorado State,Marje Mulumba,MLB,74
+647,Colorado State,Dominick Brogna,DT,74
+647,Colorado State,Nick Karika,DT,74
+647,Colorado State,Wahkeem Roman,LG,73
+647,Colorado State,Patrick Shupp,LG,73
+647,Colorado State,Nate Spak,FS,73
+647,Colorado State,Mysonne Pollard,SS,73
+647,Colorado State,Brock Glass,P,73
+647,Colorado State,Azir Lee,CB,73
+647,Colorado State,Alexander Cobbs,ROLB,73
+647,Colorado State,Jake Bredell,TE,72
+647,Colorado State,Kshawn Cox Jr,CB,72
+647,Colorado State,Dillon Worley,SS,72
+647,Colorado State,Aj Graham,FS,72
+647,Colorado State,Anthony Crenshaw Jr,LOLB,72
+647,Colorado State,Anthony Caccese,RG,72
+647,Colorado State,Noah Vitko,TE,72
+647,Colorado State,Meikhi Cuttino,MLB,72
+647,Colorado State,Chris Collot,MLB,72
+647,Colorado State,Donovan Lewis,WR,71
+647,Colorado State,Luke Brown,WR,71
+647,Colorado State,Alex Adebayo,SS,71
+647,Colorado State,Tre Lloyd,QB,71
+647,Colorado State,Ethan Saunders,DT,71
+647,Colorado State,Colin Gallagher,MLB,71
+647,Colorado State,Jaime Ramos,RG,70
+647,Colorado State,Mekhi Carmon,LOLB,70
+647,Colorado State,Kingsley Royal,SS,69
+647,Colorado State,Kahlil Ali,CB,69
+647,Colorado State,Noah Rosahac,LT,69
+647,Colorado State,Nyair Domnie,CB,69
+647,Colorado State,Makai Alexander,ROLB,69
+647,Colorado State,Matt Mckinley,WR,68
+647,Colorado State,Blake Brown,QB,67
+647,Colorado State,Braden Streeter,QB,66
+647,Colorado State,Thomas Amankwaa,WR,66
+647,Colorado State,Nate Reed,K,65
+647,Colorado State,Josh Cupitt,P,65
+647,Colorado State,Nick Tyree,WR,65
+647,Colorado State,Jason Mcburrows,CB,65
+647,Colorado State,Deon Dotson,C,65
+647,Colorado State,Skyler Sholder,K,62
+647,Colorado State,Nick Colson,LG,61
+647,Colorado State,Jay Luggo,RT,60
+647,Colorado State,Ej Archield Jr,QB,55
+647,Colorado State,T T Wynn,WR,54
+647,Colorado State,Cade Wentworth,LG,53
+647,Colorado State,Calvin Thomas,WR,52
+26,Delaware,Chandler Rivers,CB,93
+26,Delaware,Brian Parker Ii,RT,92
+26,Delaware,Terry Moore,SS,92
+26,Delaware,Darian Mensah,QB,89
+26,Delaware,Caleb Weaver,FS,89
+26,Delaware,Bruno Fina,LT,87
+26,Delaware,Matt Craycraft,C,85
+26,Delaware,Tre Freeman,ROLB,85
+26,Delaware,Justin Pickett,RG,83
+26,Delaware,Sahmir Hagans,WR,83
+26,Delaware,Landen King,TE,82
+26,Delaware,Caleb Dorris,LT,82
+26,Delaware,Que Sean Brown,WR,81
+26,Delaware,Nick Morris Jr,MLB,81
+26,Delaware,Aaron Hall,DT,81
+26,Delaware,Eric Schon,LG,81
+26,Delaware,Dashawn Stone,FS,81
+26,Delaware,Kimari Robinson,CB,79
+26,Delaware,Micah Sahakian,LG,79
+26,Delaware,Andrel Anthony,WR,78
+26,Delaware,Jaiden Francois,LOLB,78
+26,Delaware,Jeremiah Hasley,TE,78
+26,Delaware,Cooper Barkate,WR,78
+26,Delaware,Jake Taylor,TE,77
+26,Delaware,Josiah Green,DT,77
+26,Delaware,Henry Belin Iv,QB,75
+26,Delaware,Leon Griffin Iii,FS,75
+26,Delaware,Brett Elliott,TE,75
+26,Delaware,Bradley Smith,LG,73
+26,Delaware,George Wright,SS,73
+26,Delaware,Vontae Floyd,CB,73
+26,Delaware,Bradley Gompers,ROLB,73
+26,Delaware,Travis Bates,FS,72
+26,Delaware,Gemyel Allen,RG,72
+26,Delaware,Derrick Brown Jr,LOLB,72
+26,Delaware,Tony Boggs,LG,72
+26,Delaware,Roman Fina,LT,72
+26,Delaware,Jamin Brown,RG,71
+26,Delaware,Jordan Larsen,LG,71
+26,Delaware,Luke Mergott,MLB,71
+26,Delaware,Jayden Moore,WR,70
+26,Delaware,Vance Bolyard,TE,69
+26,Delaware,Curtis Cooper,TE,69
+26,Delaware,Reagan Mccranie,C,68
+26,Delaware,Jamien Little,WR,67
+26,Delaware,Jeremiah Newell,LOLB,67
+26,Delaware,Kenzy Paul,LOLB,67
+26,Delaware,Preston Watson,DT,67
+26,Delaware,Jack Yates,TE,67
+26,Delaware,Kade Reynoldson,P,66
+26,Delaware,Dan Mahan,QB,66
+26,Delaware,Chance Griffin,FB,65
+26,Delaware,Todd Pelino,K,64
+26,Delaware,Kendall Johnson,ROLB,63
+26,Delaware,Maliki Wright,SS,63
+26,Delaware,Chase Tyler,WR,63
+26,Delaware,Moussa Kane,CB,62
+26,Delaware,Kyren Condoll,CB,62
+26,Delaware,Julius Columbus,DT,61
+26,Delaware,Memorable Factor,MLB,61
+26,Delaware,Mario Wofford,FB,60
+26,Delaware,Landan Callahan,CB,59
+26,Delaware,Ma Khi Jones,CB,59
+26,Delaware,Desmond Aladuge,DT,58
+26,Delaware,Ryan Degyansky,P,58
+26,Delaware,Jack Small,RT,57
+26,Delaware,Brayden Moore,K,57
+26,Delaware,Terry Simmons Jr,DT,52
+26,Delaware,Aaron Buckhalter,RT,49
+26,Delaware,David Anderson,DT,49
+26,Delaware,Cosme Salas,K,46
+648,Duke,Anthony Smith,WR,85
+648,Duke,Rasheed Reason,CB,84
+648,Duke,Jordy Lowery,CB,83
+648,Duke,Emmanuel Poku,LT,83
+648,Duke,Katin Houser,QB,82
+648,Duke,Dameon Wilson,MLB,82
+648,Duke,Jayson Tarpeh,LT,81
+648,Duke,Payton Mangrum,WR,81
+648,Duke,Darius Bell,LG,80
+648,Duke,Malik Leverett,WR,80
+648,Duke,Ja Marley Riddle,FS,79
+648,Duke,Jacob Sacra,RG,79
+648,Duke,Jimarion Mccrimon,RT,79
+648,Duke,Jaquaize Pettaway,WR,78
+648,Duke,Panda Askew,C,78
+648,Duke,Teagan Wilk,SS,77
+648,Duke,Mike Wright,QB,77
+648,Duke,Tymir Brown,CB,77
+648,Duke,Jonathan Jean,SS,77
+648,Duke,Brock Spalding,WR,77
+648,Duke,Zion Wilson,DT,77
+648,Duke,Jackson Barker,MLB,77
+648,Duke,Kelan Robinson,WR,77
+648,Duke,Karson Jones,RT,77
+648,Duke,Julien Davis,ROLB,77
+648,Duke,Yannick Smith,WR,76
+648,Duke,Kyle Long,LG,76
+648,Duke,Desirrio Riles,TE,75
+648,Duke,Cooper Trnavsky,RT,75
+648,Duke,Xavier Mciver,DT,74
+648,Duke,Nick Childress,CB,73
+648,Duke,Cayman Reynolds,TE,73
+648,Duke,Tripp Smith,TE,73
+648,Duke,Marleo Neolien,LT,72
+648,Duke,Cole Hodge,QB,72
+648,Duke,Key Crowell,CB,72
+648,Duke,Dj Johnson Jr,ROLB,72
+648,Duke,Kaleb Morrow,TE,72
+648,Duke,Jonathan Stokes,C,72
+648,Duke,Trey Hardison,RG,71
+648,Duke,Rion Roseborough,DT,71
+648,Duke,Triston O Brien,TE,70
+648,Duke,Ayden Duncanson,SS,70
+648,Duke,Jonathan Akins,CB,70
+648,Duke,Kamaurri Mckinley,CB,69
+648,Duke,Demarius Hines,SS,69
+648,Duke,Justin Benton,DT,68
+648,Duke,Tyler Johnson,WR,68
+648,Duke,Preston Carr,DT,68
+648,Duke,J P Richmond,FB,68
+648,Duke,Andrew Conrad,K,67
+648,Duke,Chaston Ditta,QB,67
+648,Duke,Dillon Lorick,WR,67
+648,Duke,Kevon Merrell,ROLB,67
+648,Duke,O Marion Lewis,FS,66
+648,Duke,Johnny Williams,WR,64
+648,Duke,Raheim Jeter,QB,64
+648,Duke,Bryce Weaver,RT,64
+648,Duke,Jayvontay Conner,TE,63
+648,Duke,Connor Hodge,WR,63
+648,Duke,Noah Perez,K,62
+648,Duke,Alani Day,FS,62
+648,Duke,Michael Joiner Lambert,P,61
+648,Duke,James Moore,K,59
+648,Duke,Durante Speer,FS,58
+648,Duke,Duncan Toon,RG,56
+648,Duke,Derrion Horsley,CB,56
+648,Duke,Carlos Canidate,LT,56
+648,Duke,Harvey Hood,MLB,55
+648,Duke,Jameer Strong,RG,55
+648,Duke,Kendric Davis,MLB,48
+648,Duke,Paul Lee,P,47
+649,East Carolina,Mickey Rewolinski,LG,87
+649,East Carolina,Nicholas Gallegos,C,86
+649,East Carolina,Nick Harris,TE,85
+649,East Carolina,Porter Rooks,WR,84
+649,East Carolina,Terry Lockett Jr,WR,82
+649,East Carolina,Josh Anderson,RT,82
+649,East Carolina,Jamarien Wheeler,WR,81
+649,East Carolina,Mack Indestad,LT,81
+649,East Carolina,Jamie Wentworth,RT,80
+649,East Carolina,Owen Snively,RG,79
+649,East Carolina,Noah Kim,QB,78
+649,East Carolina,Cameron Edge,QB,78
+649,East Carolina,Joshua Scott,CB,78
+649,East Carolina,Dramarian Mcnulty,CB,77
+649,East Carolina,Spencer Webb,RG,77
+649,East Carolina,Bryce Eliuk,MLB,77
+649,East Carolina,Zach Mowchan,ROLB,77
+649,East Carolina,Zyell Griffin,WR,77
+649,East Carolina,Chris Mayo,LT,77
+649,East Carolina,Tyrell Martin,DT,76
+649,East Carolina,Camar Jones,QB,76
+649,East Carolina,Isaac Smith,WR,75
+649,East Carolina,Donovan Green,DT,74
+649,East Carolina,Marco Patierno,MLB,74
+649,East Carolina,Jesse Vasquez,CB,74
+649,East Carolina,Jeremiah Salem,QB,74
+649,East Carolina,Kendall Clark,WR,74
+649,East Carolina,Dennis Strey Jr,RT,74
+649,East Carolina,Jordan Toney,CB,73
+649,East Carolina,Tanner Lemaster,TE,73
+649,East Carolina,James Monds Iii,CB,73
+649,East Carolina,Jaivian Norman,CB,73
+649,East Carolina,Kadin Bailey,MLB,72
+649,East Carolina,Jason Marshall,SS,72
+649,East Carolina,Ray Hester,FS,71
+649,East Carolina,Robert Robinson,LG,71
+649,East Carolina,Jace Stuckey,QB,70
+649,East Carolina,Caleb Dobbs,CB,70
+649,East Carolina,Micah Grant,RT,70
+649,East Carolina,Izaiah Jackson,FB,70
+649,East Carolina,Warren Stevens Tayou,DT,69
+649,East Carolina,Makhi Gilbert,DT,69
+649,East Carolina,Andrew Steger,LG,69
+649,East Carolina,Barry Manning,SS,68
+649,East Carolina,Bryce Llewellyn,SS,68
+649,East Carolina,Matthew July,QB,68
+649,East Carolina,Kamal Jones Tolbert,FS,68
+649,East Carolina,Darron Likely,FS,67
+649,East Carolina,D Riq Davis,LG,67
+649,East Carolina,Terrance Saunders,C,66
+649,East Carolina,Daniel Warnsman,LG,66
+649,East Carolina,Everett Small,LT,66
+649,East Carolina,Mitchell Tomasek,P,65
+649,East Carolina,Noah Lee,TE,65
+649,East Carolina,Everett Hunter,TE,63
+649,East Carolina,Dalin Wilkins,WR,63
+649,East Carolina,Nathan Dibert,K,60
+649,East Carolina,Ali Abdul Barr,ROLB,60
+649,East Carolina,Jack Storey,C,59
+649,East Carolina,Avery Redd,LOLB,59
+649,East Carolina,Michael Gurley,CB,58
+649,East Carolina,Jerquay Benson,FS,58
+649,East Carolina,Mitchell Dietzel,TE,57
+649,East Carolina,Joseph Taylor,RG,53
+649,East Carolina,Houston Berry,DT,53
+649,East Carolina,Cameron Kiser,P,51
+649,East Carolina,Kenneth Jackson,MLB,49
+649,East Carolina,Marvell Eggleston,MLB,49
+649,East Carolina,Rudy Kessinger,K,47
+650,Eastern Michigan,Zaire Flournoy,RG,86
+650,Eastern Michigan,Brian Blades Ii,CB,85
+650,Eastern Michigan,Julius Pierce,LT,82
+650,Eastern Michigan,Jaheim Buchanon,RT,82
+650,Eastern Michigan,Johnny Chaney Jr,MLB,82
+650,Eastern Michigan,Alex Perry,WR,82
+650,Eastern Michigan,Dominick Mays,FS,82
+650,Eastern Michigan,Ross Fournet,WR,82
+650,Eastern Michigan,Juju Lewis,WR,80
+650,Eastern Michigan,Keyone Jenkins,QB,79
+650,Eastern Michigan,Steven Shannon,DT,79
+650,Eastern Michigan,Daniel Michel,LT,79
+650,Eastern Michigan,Dallas Payne,TE,78
+650,Eastern Michigan,Quaylen Hill,DT,76
+650,Eastern Michigan,Tar Varish Dawson,WR,76
+650,Eastern Michigan,Erik Diehl,LG,76
+650,Eastern Michigan,Victor Evans Iii,CB,75
+650,Eastern Michigan,Bobby Salla Jr,FS,75
+650,Eastern Michigan,C Quan Jnopierre,WR,75
+650,Eastern Michigan,Jackson Schultze,LG,75
+650,Eastern Michigan,Sean Burke,TE,75
+650,Eastern Michigan,Clinton Mahoni,DT,75
+650,Eastern Michigan,Germaine Carter,DT,75
+650,Eastern Michigan,Jackson Verdugo,TE,74
+650,Eastern Michigan,Mykeal Rabess,RT,74
+650,Eastern Michigan,Tyson Carter,WR,74
+650,Eastern Michigan,Antonio Patterson,SS,73
+650,Eastern Michigan,Chayden Peery,QB,73
+650,Eastern Michigan,Percy Courtney Jr,ROLB,73
+650,Eastern Michigan,Jeremy Smith,LT,73
+650,Eastern Michigan,Matias Garcia,LG,73
+650,Eastern Michigan,Demetrius Hill,SS,72
+650,Eastern Michigan,Jai Ayviauynn Celestine,CB,72
+650,Eastern Michigan,Keshawn Brewer,FS,72
+650,Eastern Michigan,Jojo Stone,WR,72
+650,Eastern Michigan,Justin Wood,TE,72
+650,Eastern Michigan,Mister Clark,CB,71
+650,Eastern Michigan,Shamir Sterlin,SS,71
+650,Eastern Michigan,Miguel Cedeno,LT,70
+650,Eastern Michigan,Cris Russo,MLB,70
+650,Eastern Michigan,Cassius Davis,FB,70
+650,Eastern Michigan,Jaleel Davis,LT,69
+650,Eastern Michigan,Websley Etienne,FS,68
+650,Eastern Michigan,Chad Staley,RT,68
+650,Eastern Michigan,Su Agunloye,DT,67
+650,Eastern Michigan,L Cier Luter,DT,66
+650,Eastern Michigan,Preston Thompson,CB,66
+650,Eastern Michigan,Bryan Moore,QB,64
+650,Eastern Michigan,Antonio Tripp Jr,RG,63
+650,Eastern Michigan,Dwight Nunoo,MLB,63
+650,Eastern Michigan,Mike Veldman,RT,63
+650,Eastern Michigan,Toddrick Brewton,LOLB,63
+650,Eastern Michigan,Alex Franklin,RT,63
+650,Eastern Michigan,Quincy Harrison,LG,63
+650,Eastern Michigan,Ashton Levells,SS,62
+650,Eastern Michigan,Tyler Proctor,QB,61
+650,Eastern Michigan,Kyle Mcneal,WR,61
+650,Eastern Michigan,Sadonnie Gay,SS,61
+650,Eastern Michigan,Robert Czeremcha,K,60
+650,Eastern Michigan,Takaylen Muex,RG,60
+650,Eastern Michigan,Alejandro Prado,K,58
+650,Eastern Michigan,Trey Wilhoit,P,58
+650,Eastern Michigan,Jon Rodriguez,RG,56
+650,Eastern Michigan,Kenny Williams,WR,56
+650,Eastern Michigan,Josiah Taylor,MLB,55
+650,Eastern Michigan,Braiden Staten,TE,54
+650,Eastern Michigan,Tyderick Brown,CB,54
+650,Eastern Michigan,Bobbie Darman,CB,54
+650,Eastern Michigan,Knajee Saffold,C,53
+650,Eastern Michigan,Clayton Dees,QB,51
+652,FIU,Jake Slaughter,C,92
+652,FIU,Dj Lagway,QB,90
+652,FIU,Caleb Banks,DT,90
+652,FIU,Austin Barber,LT,90
+652,FIU,Eugene Wilson Iii,WR,89
+652,FIU,Asa Turner,FS,88
+652,FIU,Kahleil Jackson,WR,86
+652,FIU,Jordan Castell,SS,85
+652,FIU,Knijeah Harris,LG,84
+652,FIU,Damieon George Jr,RG,84
+652,FIU,Hayden Hansen,TE,84
+652,FIU,Bryce Lovett,RT,84
+652,FIU,Devon Manuel,RT,84
+652,FIU,J Michael Sturdivant,WR,83
+652,FIU,Micheal Caraway Jr,CB,83
+652,FIU,Devin Moore,CB,82
+652,FIU,Grayson Howard,MLB,82
+652,FIU,Dijon Johnson,CB,82
+652,FIU,Harrison Bailey,QB,81
+652,FIU,Roderick Kearney,C,80
+652,FIU,Myles Graham,ROLB,80
+652,FIU,Brendan Bett,DT,80
+652,FIU,Mark Pitts,RT,77
+652,FIU,Bryce Thornton,FS,76
+652,FIU,Brien Taylor Jr,DT,76
+652,FIU,Jason Zandamela,C,75
+652,FIU,Michai Boireau,DT,75
+652,FIU,Cormani Mcclain,CB,75
+652,FIU,Sharif Denson,CB,75
+652,FIU,Clay Millen,QB,75
+652,FIU,Jamari Lyons,DT,74
+652,FIU,Dallas Wilson,WR,74
+652,FIU,Aaron Chiles,ROLB,74
+652,FIU,Amir Jackson,TE,74
+652,FIU,Caleb Rillos,TE,74
+652,FIU,Ben Hanks Jr,CB,73
+652,FIU,Naeshaun Montgomery,WR,73
+652,FIU,Noel Portnjagin,LG,73
+652,FIU,Tommy Doman,P,72
+652,FIU,Marteze Lee,SS,72
+652,FIU,Colton Norton,K,72
+652,FIU,Kamryn Waites,RG,72
+652,FIU,Tony Livingston,TE,71
+652,FIU,Tank Hawkins,WR,71
+652,FIU,Alfonzo Allen Jr,SS,71
+652,FIU,Trey Smack,K,70
+652,FIU,Torrance Harvey,FB,70
+652,FIU,Tramell Jones Jr,QB,69
+652,FIU,Tj Abrams,WR,69
+652,FIU,Ty Jackson,MLB,68
+652,FIU,Fletcher Westphal,LT,67
+652,FIU,Caden Jones,LT,67
+652,FIU,Kwame Collins,RT,65
+652,FIU,Marcus Rowe,CB,65
+652,FIU,Josiah Davis,SS,65
+652,FIU,Aidan Warner,QB,65
+652,FIU,Rocco Underwood,TE,65
+652,FIU,Marcus Mascoll,LG,64
+652,FIU,Aidan Mizell,WR,63
+652,FIU,Aaron Gates,FS,63
+652,FIU,William Combs,FS,63
+652,FIU,Kyle Hardee,TE,63
+652,FIU,Vernell Brown Iii,WR,62
+652,FIU,Cameron Kossmann,TE,62
+652,FIU,Adam Louden,P,62
+652,FIU,Jaden Robinson,MLB,60
+652,FIU,Jamroc Grimsley,CB,60
+652,FIU,Najee Williams,DT,57
+652,FIU,Steven Cuffey,K,56
+652,FIU,Drew Mcfrank,RT,53
+652,FIU,Paul Terry,LT,51
+652,FIU,Layne Swafford,LOLB,51
+653,Florida,Easton Messer,WR,84
+653,Florida,Caden Veltkamp,QB,83
+653,Florida,Jr Wilson,WR,82
+653,Florida,Qae Shon Sapp,C,81
+653,Florida,Woody Jean,RG,81
+653,Florida,Zach Gibson,QB,80
+653,Florida,Tyler Shields,SS,80
+653,Florida,Joseph Young,WR,80
+653,Florida,Mauricio Hinds,RT,80
+653,Florida,Madden Sanker,LG,79
+653,Florida,Naejuan Barber,DT,79
+653,Florida,Dominique Henry,WR,78
+653,Florida,Terez Reid,CB,78
+653,Florida,Alex Atcavage,RG,77
+653,Florida,Derrick Rogers Jr,CB,77
+653,Florida,Wendol Philord,SS,77
+653,Florida,Kiemar Richardson,DT,77
+653,Florida,Jayshon Platt,WR,76
+653,Florida,Isaac Henley,QB,76
+653,Florida,Bryce Langston,DT,76
+653,Florida,Leon Hart Jr,ROLB,76
+653,Florida,Zyere Horton,MLB,76
+653,Florida,Shovon Jackson,CB,76
+653,Florida,Tyler Stolsky,MLB,75
+653,Florida,Cj Doggette,DT,75
+653,Florida,Daughtry Richardson,RT,75
+653,Florida,Mike Wright Iii,FS,75
+653,Florida,Cameron Goggins,CB,75
+653,Florida,Kahlil Brantley,TE,74
+653,Florida,Jabari Smith,WR,74
+653,Florida,Ovie Dubre,RG,73
+653,Florida,Vincent Forney,LT,73
+653,Florida,Dillion Williams,SS,72
+653,Florida,Lawrence Johnson,CB,72
+653,Florida,Nimari Brantley,DT,72
+653,Florida,Enyce Sledge,DT,71
+653,Florida,Chris Tooley Iii,CB,71
+653,Florida,Kasen Weisman,QB,71
+653,Florida,George Traylor,RG,71
+653,Florida,Keon Rohe,RT,71
+653,Florida,Vincent Fiacable,LG,70
+653,Florida,Kyle Boylston,FS,70
+653,Florida,Darnell Wolf,C,68
+653,Florida,Carson Osmus,RT,68
+653,Florida,Jackson Lee,TE,68
+653,Florida,Asaad Waseem,WR,67
+653,Florida,Jarvis Johnson,LOLB,67
+653,Florida,Char Quez Lee,ROLB,66
+653,Florida,Martavious Collins,TE,66
+653,Florida,Logan Lupo,P,65
+653,Florida,Antonio Robinson Jr,CB,65
+653,Florida,Ja Kavion Nonar,RT,65
+653,Florida,Robert Lee,ROLB,65
+653,Florida,Hector Chavez,MLB,65
+653,Florida,Garrison Smith,K,64
+653,Florida,Gary Nelson,TE,64
+653,Florida,Braden Cunningham,C,64
+653,Florida,Tracy Bennett,SS,64
+653,Florida,Chandler Stewart,RT,64
+653,Florida,Justin Zimmerman,TE,63
+653,Florida,Xavier Bryan,RG,63
+653,Florida,Paul Trent,LT,62
+653,Florida,Jadrian Poindexter,WR,61
+653,Florida,Carson Cruver,QB,61
+653,Florida,Shaun Mooney,TE,60
+653,Florida,Jeremiah Perkins,FB,59
+653,Florida,Clyde Ellington,LT,58
+653,Florida,Cris Dukes,P,57
+653,Florida,Jade Card,WR,52
+651,Florida Atlantic,Gennings Dunker,RT,91
+651,Florida Atlantic,Aaron Graves,DT,91
+651,Florida Atlantic,Beau Stephens,LG,91
+651,Florida Atlantic,Logan Jones,C,90
+651,Florida Atlantic,Xavier Nwankpa,FS,90
+651,Florida Atlantic,Kale Krogh,RG,88
+651,Florida Atlantic,Mark Gronowski,QB,87
+651,Florida Atlantic,Jacob Gill,WR,85
+651,Florida Atlantic,Karson Sharar,ROLB,85
+651,Florida Atlantic,Deshaun Lee,CB,84
+651,Florida Atlantic,Tj Hall,CB,83
+651,Florida Atlantic,Addison Ostrenga,TE,82
+651,Florida Atlantic,Jeremiah Pittman,DT,82
+651,Florida Atlantic,Jaden Harrell,MLB,82
+651,Florida Atlantic,Michael Myslinski,RG,82
+651,Florida Atlantic,Kaden Wetjen,WR,80
+651,Florida Atlantic,Jonah Pace,DT,80
+651,Florida Atlantic,Hayden Large,FB,80
+651,Florida Atlantic,Sam Phillips,WR,80
+651,Florida Atlantic,Jared Dalton,C,80
+651,Florida Atlantic,Jarriett Buie,WR,80
+651,Florida Atlantic,Kade Pieper,RG,79
+651,Florida Atlantic,Seth Anderson,WR,79
+651,Florida Atlantic,Will Hubert,DT,79
+651,Florida Atlantic,Reece Vander Zee,WR,78
+651,Florida Atlantic,Jayden Montgomery,MLB,77
+651,Florida Atlantic,Lukas Mcfarland,TE,77
+651,Florida Atlantic,Drew Wilder,RG,76
+651,Florida Atlantic,Kj Parker,WR,76
+651,Florida Atlantic,Trevor Lauck,LT,75
+651,Florida Atlantic,Cannon Leonard,RT,75
+651,Florida Atlantic,Justin Darby,MLB,75
+651,Florida Atlantic,Koen Entringer,SS,74
+651,Florida Atlantic,Hank Brown,QB,74
+651,Florida Atlantic,Jaxon Rexroth,LOLB,74
+651,Florida Atlantic,Drew Stevens,K,73
+651,Florida Atlantic,Zach Ortwerth,TE,73
+651,Florida Atlantic,Landyn Van Kekerix,ROLB,73
+651,Florida Atlantic,Rashad Godfrey Jr,CB,72
+651,Florida Atlantic,Zach Twedt,ROLB,72
+651,Florida Atlantic,Jeremy Hecklinski,QB,71
+651,Florida Atlantic,Ike Speltz,TE,71
+651,Florida Atlantic,Evan Coffey,TE,71
+651,Florida Atlantic,Rhys Dakin,P,70
+651,Florida Atlantic,Kael Kolarik,FS,70
+651,Florida Atlantic,Derek Weisskopf,LOLB,70
+651,Florida Atlantic,Zach Lutmer,SS,70
+651,Florida Atlantic,Nolan Delong,LOLB,70
+651,Florida Atlantic,Bodey Mccaslin,RT,68
+651,Florida Atlantic,Preston Ries,LOLB,68
+651,Florida Atlantic,Sean Herman,RT,67
+651,Florida Atlantic,Kylan Brantley,WR,67
+651,Florida Atlantic,Jaylen Watson,CB,66
+651,Florida Atlantic,Jack Dotzler,LT,65
+651,Florida Atlantic,Will Nolan,RT,65
+651,Florida Atlantic,Cody Fox,RG,65
+651,Florida Atlantic,Teegan Davis,CB,64
+651,Florida Atlantic,Watts Mcbride,SS,64
+651,Florida Atlantic,Isaac Ricks,TE,63
+651,Florida Atlantic,Daneal Jackson,FS,63
+651,Florida Atlantic,Tanner Brown,LT,62
+651,Florida Atlantic,Dayton Howard,WR,62
+651,Florida Atlantic,Josh Janowski,LG,62
+651,Florida Atlantic,Javonte Hyatt,FS,61
+651,Florida Atlantic,Jalen Bowie,CB,61
+651,Florida Atlantic,Roddy Orr,ROLB,61
+651,Florida Atlantic,James Melton,DT,60
+651,Florida Atlantic,Tywan Chase,CB,59
+651,Florida Atlantic,Ryan Baird,DT,58
+651,Florida Atlantic,Dereck Dotson,QB,57
+651,Florida Atlantic,Leighton Jones,LG,55
+651,Florida Atlantic,Zion Armstead,CB,54
+651,Florida Atlantic,Jalen Keys,WR,53
+651,Florida Atlantic,Ty Nissen,P,46
+664,Iowa,Jeremiah Cooper,FS,91
+664,Iowa,Tyler Miller,RT,91
+664,Iowa,Jontez Williams,CB,90
+664,Iowa,Domonique Orange,DT,90
+664,Iowa,Brendan Black,RG,90
+664,Iowa,Rocco Becht,QB,88
+664,Iowa,Chase Sowell,WR,88
+664,Iowa,James Neal,LT,88
+664,Iowa,Dylan Barrett,C,87
+664,Iowa,Trevor Buhr,LG,86
+664,Iowa,Daniel Jackson,WR,86
+664,Iowa,Caleb Bacon,LOLB,85
+664,Iowa,Xavier Townsend,WR,85
+664,Iowa,Jim Bonifas,C,85
+664,Iowa,Tyler Maro,RT,84
+664,Iowa,Gabe Burkle,TE,83
+664,Iowa,Benjamin Brahmer,TE,82
+664,Iowa,Will Mclaughlin,ROLB,82
+664,Iowa,Kooper Ebel,ROLB,81
+664,Iowa,Ta Shawn James,SS,81
+664,Iowa,Deylin Hasert,LG,80
+664,Iowa,Cael Brezina,MLB,79
+664,Iowa,Dontrell Holt,C,79
+664,Iowa,Tre Bell,CB,78
+664,Iowa,Drew Clausen,TE,78
+664,Iowa,Gabe Greenlee,LT,78
+664,Iowa,Eli Green,WR,77
+664,Iowa,Jamison Patton,FS,77
+664,Iowa,Zachary Lovett,MLB,77
+664,Iowa,Lincoln Marion,DT,77
+664,Iowa,Markell Chapman,DT,76
+664,Iowa,Carson Brown,WR,76
+664,Iowa,Brett Eskildsen,WR,76
+664,Iowa,Khijohnn Cummings Coleman,CB,76
+664,Iowa,Alijah Carnell,DT,76
+664,Iowa,Beni Ngoyi,CB,75
+664,Iowa,Zaimir Hawk,DT,75
+664,Iowa,Connor Moberly,QB,75
+664,Iowa,Tyler Moore,TE,74
+664,Iowa,Austin Barrett,RT,74
+664,Iowa,Mason Miller,MLB,74
+664,Iowa,Rylan Barnes,LOLB,73
+664,Iowa,Marcus Neal,SS,73
+664,Iowa,Brendan Salter,FB,72
+664,Iowa,Garret Rutledge,LT,71
+664,Iowa,Will Tompkins,RT,70
+664,Iowa,Beau Goodwin,LOLB,68
+664,Iowa,Carson Willich,LOLB,67
+664,Iowa,David Coffey,CB,67
+664,Iowa,Dyllan Malone,WR,67
+664,Iowa,Kuol Kuol,LT,66
+664,Iowa,Jacari Fant,SS,66
+664,Iowa,Jhordan Guyton,LG,66
+664,Iowa,Tyler Perkins,P,65
+664,Iowa,Ka Mori Moore,DT,65
+664,Iowa,Joshua Patterson,SS,65
+664,Iowa,Keaton Roskop,TE,65
+664,Iowa,John Klosterman,ROLB,64
+664,Iowa,Quentin Taylor Jr,CB,64
+664,Iowa,Kyle Konrardy,K,62
+664,Iowa,Alex Manske,QB,62
+664,Iowa,Jace T Gilbert,P,62
+664,Iowa,Daron Downs,FS,62
+664,Iowa,Jamarco Desir,LT,62
+664,Iowa,Dominic Overby,WR,61
+664,Iowa,Drew Surges,SS,60
+664,Iowa,Landon Garfield,RG,57
+664,Iowa,Carson Van Dinter,FS,55
+664,Iowa,Sione Perkins,RT,54
+664,Iowa,Cam Smith,FS,52
+664,Iowa,Kendrick Kelly,ROLB,50
+665,Iowa State,Brock Rechsteiner,WR,86
+665,Iowa State,Michael Pettway,WR,84
+665,Iowa State,Morven Joseph,ROLB,83
+665,Iowa State,Tyrin Taylor,CB,82
+665,Iowa State,Toby Reeder,WR,82
+665,Iowa State,Khurtiss Perry,DT,81
+665,Iowa State,Gavin Wimsatt,QB,80
+665,Iowa State,Trevor Woods,SS,80
+665,Iowa State,Rod Elston,FS,79
+665,Iowa State,Larry Preston,CB,79
+665,Iowa State,Kd Small,RT,79
+665,Iowa State,Pearson Baldwin,TE,78
+665,Iowa State,Talan Carter,DT,77
+665,Iowa State,Caleb Coombs,WR,77
+665,Iowa State,Jaleel Vincent Jr,SS,77
+665,Iowa State,Jaire Bryant,DT,77
+665,Iowa State,Jaedon Hill,LT,77
+665,Iowa State,Dean Tillman,DT,76
+665,Iowa State,Harrison Hamsley,TE,75
+665,Iowa State,Jacob Cruz,MLB,75
+665,Iowa State,Jacarvis Alexandre,CB,75
+665,Iowa State,Dj Vinson,WR,75
+665,Iowa State,Cai Mayowa,FS,75
+665,Iowa State,Cameron Griffin,LG,74
+665,Iowa State,Gabe Glover,WR,74
+665,Iowa State,Cade Cunningham,QB,73
+665,Iowa State,Jamal Siler,RG,73
+665,Iowa State,Luke Gilbert,TE,73
+665,Iowa State,Travis Franklin Jr,CB,73
+665,Iowa State,Tre Quon Fegans,CB,72
+665,Iowa State,Andre Berryhill,DT,72
+665,Iowa State,Jaheim Jenkins,CB,72
+665,Iowa State,Amare Grayson,RG,71
+665,Iowa State,Marc Woods,FS,71
+665,Iowa State,Chase Alexander,SS,71
+665,Iowa State,Cole Roberson,C,70
+665,Iowa State,Jack Moran,QB,70
+665,Iowa State,Xander Robbins,LOLB,69
+665,Iowa State,Dajwon Deloach,LOLB,69
+665,Iowa State,Colton Pitchford,WR,69
+665,Iowa State,Walker O Steen,LOLB,68
+665,Iowa State,Khari Bendolph,MLB,68
+665,Iowa State,Aj Watkins,FS,67
+665,Iowa State,Alex Moore,TE,67
+665,Iowa State,Clint Goris,QB,66
+665,Iowa State,Collin Westfelt,TE,66
+665,Iowa State,Garrison Rippa,K,65
+665,Iowa State,Nate Smith,LT,65
+665,Iowa State,Franklin Baret Jr,WR,65
+665,Iowa State,Jeremiah Colbert,WR,65
+665,Iowa State,Kyle Monroe,C,64
+665,Iowa State,Jameson Scissum,QB,64
+665,Iowa State,Will Huber,WR,64
+665,Iowa State,Caden Creel,QB,63
+665,Iowa State,Temarion Foster,CB,61
+665,Iowa State,Ryland Bragg,RT,60
+665,Iowa State,Everett Polk,TE,59
+665,Iowa State,Walker Phelps,RT,59
+665,Iowa State,Micah Mccarroll,CB,59
+665,Iowa State,Abdul Johnson,ROLB,58
+665,Iowa State,Cade Backe,P,58
+665,Iowa State,Daylan Martin,LG,57
+665,Iowa State,Jaylon Westberry,DT,57
+665,Iowa State,Vincent Henderson Jr,FS,57
+665,Iowa State,Tj Mcduffie,LT,57
+665,Iowa State,Lance Johnson,LG,55
+665,Iowa State,Anthony Mallory,MLB,54
+665,Iowa State,Aidan Thompson,MLB,46
+665,Iowa State,Ulysses Dixon,CB,45
+666,Jacksonville State,Pat Mcmurtrie,RT,92
+666,Jacksonville State,Carter Sweazie,LG,87
+666,Jacksonville State,Alonza Barnett Iii,QB,86
+666,Jacksonville State,Trent Hendrick,MLB,86
+666,Jacksonville State,Jacob Thomas,SS,85
+666,Jacksonville State,Matthew Sluka,QB,85
+666,Jacksonville State,Isaiah Alston,WR,85
+666,Jacksonville State,Nick Degennaro,WR,84
+666,Jacksonville State,Josh Toner,LG,82
+666,Jacksonville State,Chantz Harley,CB,82
+666,Jacksonville State,Terry Lockett Jr,DT,82
+666,Jacksonville State,Dj Barksdale,CB,81
+666,Jacksonville State,Immanuel Bush,DT,80
+666,Jacksonville State,Gannon Weathersby,ROLB,80
+666,Jacksonville State,Ken Willis,SS,79
+666,Jacksonville State,Kye Holmes,FS,79
+666,Jacksonville State,Brandon Fique,ROLB,79
+666,Jacksonville State,Brett Davis,C,79
+666,Jacksonville State,Logan Kyle,TE,77
+666,Jacksonville State,Landon Ellis,WR,77
+666,Jacksonville State,Justin Eaglin,CB,77
+666,Jacksonville State,Jaylan Sanchez,WR,76
+666,Jacksonville State,Riley Robell,RG,76
+666,Jacksonville State,Mychal Mcmullin,DT,76
+666,Jacksonville State,Zach Greenberg,C,76
+666,Jacksonville State,Camden Coleman,QB,75
+666,Jacksonville State,Kells Bush,DT,75
+666,Jacksonville State,Kyree Barber,WR,75
+666,Jacksonville State,Elijah Culp,CB,74
+666,Jacksonville State,Landon Bolden,FS,73
+666,Jacksonville State,Derrick Barr,LT,73
+666,Jacksonville State,Jayden Studio,LOLB,72
+666,Jacksonville State,Mekhi Rodgers,CB,72
+666,Jacksonville State,Dj Cotton Jr,DT,72
+666,Jacksonville State,Joseph Simmons,LT,72
+666,Jacksonville State,Bryce Kramer,P,71
+666,Jacksonville State,Braeden Wisloski,WR,71
+666,Jacksonville State,Josiah Kennard,TE,70
+666,Jacksonville State,Brian Hnat,TE,70
+666,Jacksonville State,Dylan Williams,WR,70
+666,Jacksonville State,Jamaree Seldon,FS,70
+666,Jacksonville State,Tj Mcgill,SS,69
+666,Jacksonville State,Deacon Rawls,RG,68
+666,Jacksonville State,Jc Evans,QB,67
+666,Jacksonville State,Kj Flowe,CB,67
+666,Jacksonville State,Clayton Edison,TE,67
+666,Jacksonville State,Josh Phifer,TE,67
+666,Jacksonville State,Griffin Hart,RT,67
+666,Jacksonville State,Lacota Dippre,TE,66
+666,Jacksonville State,Mike Stroburg,FB,66
+666,Jacksonville State,Ben May,ROLB,66
+666,Jacksonville State,Evan Bushong,RG,66
+666,Jacksonville State,Chase Regan,SS,65
+666,Jacksonville State,Keilan Pickens,WR,65
+666,Jacksonville State,Trashon Dye,MLB,64
+666,Jacksonville State,Logan Ketcham,TE,64
+666,Jacksonville State,Alton Hobbs,CB,63
+666,Jacksonville State,Jakobe Campbell,LT,63
+666,Jacksonville State,Cristiano Rosa,K,61
+666,Jacksonville State,Jd Rayner,LT,61
+666,Jacksonville State,Pierre Miller,DT,61
+666,Jacksonville State,Trent Wilson,LG,60
+666,Jacksonville State,Roddrey Mcwilliams,CB,60
+666,Jacksonville State,Immanuel Ezeogu,LOLB,60
+666,Jacksonville State,Milt Ferguson,CB,60
+666,Jacksonville State,Patrick Miller,FS,60
+666,Jacksonville State,Joshua Douglas,QB,57
+666,Jacksonville State,Parker Cunningham,C,57
+666,Jacksonville State,Morgan Suarez,K,55
+666,Jacksonville State,Jacobie Smith,SS,55
+666,Jacksonville State,Kai Callen,CB,55
+666,Jacksonville State,Louis Brown Coleman,LOLB,50
+667,James Madison,Bryce Foster,C,89
+667,James Madison,Jalon Daniels,QB,87
+667,James Madison,Nolan Gorczyca,RT,87
+667,James Madison,Kobe Baynes,RG,86
+667,James Madison,Enrique Cruz Jr,RT,86
+667,James Madison,Joseph Sipp Jr,MLB,86
+667,James Madison,Trey Lathan,LOLB,85
+667,James Madison,Gage Keys,DT,84
+667,James Madison,Dj Graham Ii,CB,83
+667,James Madison,Tommy Dunn Jr,DT,83
+667,James Madison,Deshawn Hanika,TE,83
+667,James Madison,Tyler Mercer,C,83
+667,James Madison,D J Withers,DT,82
+667,James Madison,Devin Dye,FS,81
+667,James Madison,Emmanuel Henderson Jr,WR,80
+667,James Madison,Boden Groen,TE,80
+667,James Madison,Jalen Todd,CB,79
+667,James Madison,Cam Pickett,WR,79
+667,James Madison,Levi Wentz,WR,78
+667,James Madison,Calvin Clements,LT,78
+667,James Madison,Tavake Tuikolovatu,LG,78
+667,James Madison,Syeed Gibbs,CB,78
+667,James Madison,Lyrik Rawls,SS,77
+667,James Madison,Kenean Caldwell,DT,77
+667,James Madison,Taylor Davis,FS,77
+667,James Madison,Deandre Harper,RT,77
+667,James Madison,Doug Emilien,WR,77
+667,James Madison,Blake Herold,DT,76
+667,James Madison,Jameel Croft Jr,CB,76
+667,James Madison,James Livingston,LG,75
+667,James Madison,Leyton Cure,TE,75
+667,James Madison,Emory Duggar,TE,74
+667,James Madison,Amir Herring,RG,74
+667,James Madison,Jayson Gilliom,ROLB,74
+667,James Madison,Hollis Moeller,TE,74
+667,James Madison,Jalen Dye,SS,74
+667,James Madison,P J Gaither,FB,74
+667,James Madison,Jack Tanner,LT,74
+667,James Madison,Cole Ballard,QB,73
+667,James Madison,Laith Marjan,K,69
+667,James Madison,Laquan Robinson,SS,69
+667,James Madison,Jon Jon Kamara,ROLB,69
+667,James Madison,Jahlil Hurley,CB,68
+667,James Madison,Marcus Calvin,DT,68
+667,James Madison,Malachi Curvey,LOLB,68
+667,James Madison,David Abajian,RT,67
+667,James Madison,Mekarri Johnson,FS,67
+667,James Madison,David Mccomb,QB,66
+667,James Madison,Myron Bunker,WR,66
+667,James Madison,Finn Lappin,P,65
+667,James Madison,Lesean Smith,SS,65
+667,James Madison,Bryson Hayes,WR,64
+667,James Madison,Kene Anene,LG,64
+667,James Madison,Blaine Nunn,RT,64
+667,James Madison,Logan Brantley,LOLB,64
+667,James Madison,Mason Ellis,FS,63
+667,James Madison,Keaton Kubecka,WR,63
+667,James Madison,Jackson Cook,WR,62
+667,James Madison,Brandin Clary,ROLB,62
+667,James Madison,Aundre Gibson,CB,62
+667,James Madison,Carter Lavrusky,LT,62
+667,James Madison,Damani Maxson,SS,61
+667,James Madison,Austin Alexander,CB,60
+667,James Madison,Jaden Hamm,TE,60
+667,James Madison,Jacoby Davis,CB,57
+667,James Madison,Alex Ball,LG,57
+667,James Madison,Isaiah Marshall,QB,55
+667,James Madison,Grayden Addison,P,55
+667,James Madison,Jacorey Stewart,MLB,46
+667,James Madison,Caleb Redd,MLB,44
+668,Kansas,Desmond Purnell,LOLB,93
+668,Kansas,Austin Romaine,MLB,92
+668,Kansas,Avery Johnson,QB,89
+668,Kansas,Jayce Brown,WR,88
+668,Kansas,Uso Seumalo,DT,88
+668,Kansas,Damian Ilalio,DT,87
+668,Kansas,Taylor Poitier,RG,87
+668,Kansas,Vj Payne,SS,86
+668,Kansas,Sam Hecht,C,86
+668,Kansas,Garrett Oakley,TE,85
+668,Kansas,Jb Nelson,LG,85
+668,Kansas,Jerand Bradley,WR,84
+668,Kansas,Andrew Leingang,RG,84
+668,Kansas,Will Swanson,TE,84
+668,Kansas,Gunner Maldonado,FS,83
+668,Kansas,Drake Bequeaith,RG,83
+668,Kansas,Caleb Medford,WR,83
+668,Kansas,Jaron Tibbs,WR,82
+668,Kansas,Justice James,CB,82
+668,Kansas,Beau Palmer,MLB,82
+668,Kansas,Amarion Fortenberry,CB,79
+668,Kansas,John Pastore,LT,79
+668,Kansas,Terrence Enos Jr,LT,78
+668,Kansas,George Fitzpatrick,RT,78
+668,Kansas,Rex Van Wyhe,ROLB,78
+668,Kansas,Brayden Loftin,TE,78
+668,Kansas,Amos Talalele,LG,78
+668,Kansas,Alex Key,LG,76
+668,Kansas,Linkon Cure,TE,75
+668,Kansas,Colby Mccalister,SS,75
+668,Kansas,Jacob Knuth,QB,75
+668,Kansas,Jack Fabris,SS,75
+668,Kansas,Sterling Lockett,WR,75
+668,Kansas,Michael Capria,C,75
+668,Kansas,Kyle Rakers,C,75
+668,Kansas,Asher Tomaszewski,DT,74
+668,Kansas,Jacques Spradley Demps,WR,74
+668,Kansas,Ja Mez Graham,FS,73
+668,Kansas,Mason Olguin,TE,73
+668,Kansas,Kaedin Massey,RT,72
+668,Kansas,Will Granger,MLB,72
+668,Kansas,Devin Vass,LT,72
+668,Kansas,Gabe Powers,ROLB,71
+668,Kansas,Jayden Rowe,CB,71
+668,Kansas,Jon Nance,C,71
+668,Kansas,Gus Hawkins,RT,70
+668,Kansas,Neal Kennedy,QB,70
+668,Kansas,Ryan Hogan,FB,69
+668,Kansas,Ryan Howard,LT,69
+668,Kansas,Asa Newsom,LOLB,68
+668,Kansas,Donovan Mcintosh,CB,68
+668,Kansas,Wesley Fair,SS,68
+668,Kansas,Cameron Booth,TE,68
+668,Kansas,Royster Blake,SS,66
+668,Kansas,Mekhi Lee,DT,66
+668,Kansas,Callen Barta,FS,66
+668,Kansas,Zack Vaughn,LT,66
+668,Kansas,Kevin Higgs,ROLB,62
+668,Kansas,Lorenzo Waiters,SS,60
+668,Kansas,J J Mcgregor,LOLB,59
+668,Kansas,Jameer Johnson,C,58
+668,Kansas,Drew Moore,DT,57
+668,Kansas,Kendyll Davis,CB,56
+668,Kansas,Joshua Chenault,MLB,56
+668,Kansas,Blake Barnett,QB,55
+668,Kansas,Dayo Hampton,ROLB,55
+668,Kansas,Zach Wittenberg,ROLB,55
+668,Kansas,Boone Morris,LOLB,54
+668,Kansas,Simon Mcclannan,P,53
+668,Kansas,Jayshawn Ross,LOLB,53
+668,Kansas,Basil Montrose,MLB,49
+668,Kansas,Leyton Simmering,K,49
+669,Kansas State,Adam Watkins,DT,85
+669,Kansas State,Jerico Washington Jr,CB,84
+669,Kansas State,Connor Finer,WR,84
+669,Kansas State,Jadarious Lee,RT,84
+669,Kansas State,Donelius Johnson,MLB,83
+669,Kansas State,Elijah Zollicoffer,LG,83
+669,Kansas State,Trey Butts,RT,83
+669,Kansas State,Garland Benyard,MLB,80
+669,Kansas State,Christian Moss,WR,80
+669,Kansas State,Rowan Darnell,TE,80
+669,Kansas State,Milon Jones,SS,79
+669,Kansas State,Jt Pennington,LG,79
+669,Kansas State,Caleb Offord,CB,79
+669,Kansas State,Tyler Hallum,CB,78
+669,Kansas State,Gerard Bullock Jr,TE,77
+669,Kansas State,Tykeem Wallace,WR,77
+669,Kansas State,Mike Jones,DT,77
+669,Kansas State,Chrisdasson Saint Jean,RT,77
+669,Kansas State,Gabriel Benyard,WR,76
+669,Kansas State,Dexter Williams Ii,QB,76
+669,Kansas State,Antonio Stevens,SS,76
+669,Kansas State,Tylon Dunlap,DT,76
+669,Kansas State,Davis Bryson,WR,76
+669,Kansas State,Jaiden Grimes,DT,76
+669,Kansas State,Isaac Paul,FS,75
+669,Kansas State,Brandon Best,RG,75
+669,Kansas State,Jamar Rucks,LOLB,75
+669,Kansas State,Havik Pettigrew,RG,75
+669,Kansas State,Javon Rogers,WR,74
+669,Kansas State,Baron Hopson,MLB,74
+669,Kansas State,Kaleb May,LT,74
+669,Kansas State,Donovan Westmoreland,ROLB,74
+669,Kansas State,Isaiah Williams,TE,74
+669,Kansas State,Semaj Parker,TE,73
+669,Kansas State,Alexander Ford,FS,73
+669,Kansas State,Nikola Milovac,RT,73
+669,Kansas State,Josiah Chenault,C,73
+669,Kansas State,Seaburn Hines,LG,73
+669,Kansas State,Navelle Dean,WR,73
+669,Kansas State,Nick Sawyer,CB,73
+669,Kansas State,Jordan Jackson,WR,72
+669,Kansas State,Chase Stevens,C,72
+669,Kansas State,Aj Miller,DT,72
+669,Kansas State,Rene Miller,RT,71
+669,Kansas State,Ethan Tookes,CB,71
+669,Kansas State,Zamario Woodgett,LT,71
+669,Kansas State,Cameron Williams,LG,70
+669,Kansas State,Matthew Choules,P,70
+669,Kansas State,Jaden Kelly,ROLB,70
+669,Kansas State,Juandarion Silas,LOLB,70
+669,Kansas State,Benton Dunn,C,70
+669,Kansas State,Isaiah Thomas,SS,69
+669,Kansas State,Jaiden Kimble,ROLB,69
+669,Kansas State,Devin Ross,CB,69
+669,Kansas State,Que Billingsley,FS,68
+669,Kansas State,Tywon Christopher,ROLB,68
+669,Kansas State,Ali Joyner,WR,68
+669,Kansas State,Amir Scarver,MLB,67
+669,Kansas State,Markell Redding,SS,66
+669,Kansas State,Dean Roman,RG,66
+669,Kansas State,Darryl Irving,LT,66
+669,Kansas State,Joshua Huiet,P,65
+669,Kansas State,Ben Blanton,TE,64
+669,Kansas State,Amari Odom,QB,62
+669,Kansas State,Jack Bernstein,TE,62
+669,Kansas State,Skyler Williams,QB,54
+669,Kansas State,Jackson Cooper,DT,54
+669,Kansas State,Dylan Hannon,DT,53
+669,Kansas State,Haston Crawford,LG,51
+669,Kansas State,Britton Williams,K,49
+669,Kansas State,Erik Calvillo,K,44
+26517,Kennesaw State,Garrett Masterson,LG,83
+26517,Kennesaw State,Percy Holmes,LOLB,80
+26517,Kennesaw State,Jon Labelle,LT,80
+26517,Kennesaw State,Canaan Williams,ROLB,79
+26517,Kennesaw State,Tevin Tucker,FS,79
+26517,Kennesaw State,Junior Diallo,LT,78
+26517,Kennesaw State,Christian Berry,TE,78
+26517,Kennesaw State,Sebastian Brown,WR,77
+26517,Kennesaw State,Da Realyst Clark,WR,77
+26517,Kennesaw State,Joel Boamah,CB,76
+26517,Kennesaw State,Nylan Brown,ROLB,76
+26517,Kennesaw State,Semaj Cross,LOLB,76
+26517,Kennesaw State,Tommy Arnold,TE,76
+26517,Kennesaw State,Josue Cordoba,DT,76
+26517,Kennesaw State,Gio Perry,WR,76
+26517,Kennesaw State,Travis Meredith,DT,76
+26517,Kennesaw State,Cj Young,SS,75
+26517,Kennesaw State,Dashawn Martin,WR,75
+26517,Kennesaw State,Kevin Rich,MLB,75
+26517,Kennesaw State,Jay Jay Etheridge,WR,75
+26517,Kennesaw State,Sayed Abuhamdeh,MLB,75
+26517,Kennesaw State,Dimitri Irwin,FS,74
+26517,Kennesaw State,Jaire Rawlison,CB,74
+26517,Kennesaw State,Ardell Banks,WR,74
+26517,Kennesaw State,Dustyn Morell,RG,73
+26517,Kennesaw State,Hunter Hopperton,TE,73
+26517,Kennesaw State,Dewayne Gissendanner,CB,73
+26517,Kennesaw State,Terrell Miller,CB,73
+26517,Kennesaw State,Seth Nelson,DT,73
+26517,Kennesaw State,Angelo Stockstill,CB,72
+26517,Kennesaw State,Cecil Wilson,LT,72
+26517,Kennesaw State,Wayne Harris,WR,71
+26517,Kennesaw State,Martell Buchanan,LOLB,71
+26517,Kennesaw State,Gus Goodell,TE,71
+26517,Kennesaw State,Jaxon Dunn,RG,70
+26517,Kennesaw State,Tyler Bivens,CB,70
+26517,Kennesaw State,Terrance Bailey,FB,70
+26517,Kennesaw State,Mason Maddox,DT,69
+26517,Kennesaw State,Mohammed Hazime,TE,69
+26517,Kennesaw State,Jake Michaels,LT,69
+26517,Kennesaw State,Dakota Taylor,TE,69
+26517,Kennesaw State,Dontrell Bennett,WR,69
+26517,Kennesaw State,Ali Fisher,WR,68
+26517,Kennesaw State,Brodyn Bishop,SS,68
+26517,Kennesaw State,Jahzae Kimbrough,WR,68
+26517,Kennesaw State,Joshua Valles,C,67
+26517,Kennesaw State,Owen Griffin,RT,65
+26517,Kennesaw State,Jonathan Aldridge,LG,65
+26517,Kennesaw State,Aiden Burgess,DT,65
+26517,Kennesaw State,Justin Sherels,WR,65
+26517,Kennesaw State,Dash Dorsey,WR,65
+26517,Kennesaw State,Will Hryszko,K,64
+26517,Kennesaw State,Wyatt Falk,QB,63
+26517,Kennesaw State,Ruel Tomlinson,QB,63
+26517,Kennesaw State,Marco Brackins,MLB,63
+26517,Kennesaw State,Derrick Jackson Iii,CB,63
+26517,Kennesaw State,Paskal Jackson Amos,WR,63
+26517,Kennesaw State,Clinton Robinson,SS,62
+26517,Kennesaw State,Jaylyn Butler,SS,62
+26517,Kennesaw State,Zeek Cason,DT,61
+26517,Kennesaw State,Joel Cordoba,CB,61
+26517,Kennesaw State,Darian Blachewicz,DT,61
+26517,Kennesaw State,Arthur Jordan,MLB,60
+26517,Kennesaw State,Quintin Donald,ROLB,58
+26517,Kennesaw State,Gabriel Davenport,TE,57
+26517,Kennesaw State,Dru Deshields,QB,56
+26517,Kennesaw State,Tommy Newcomb,K,55
+26517,Kennesaw State,Jeff Mahoney,C,55
+26517,Kennesaw State,Teaunn Hunter,WR,54
+26517,Kennesaw State,Darryl Cole,QB,53
+26517,Kennesaw State,Bret Rollins,RT,52
+26517,Kennesaw State,Ian Ritchie,K,50
+26517,Kennesaw State,Charlie Durkin,P,47
+670,Kent State,Joshua Braun,LG,91
+670,Kent State,Alex Wollschlaeger,RT,91
+670,Kent State,Shiyazh Pete,LT,88
+670,Kent State,David Gusta,DT,86
+670,Kent State,Jonquis Hardaway,CB,86
+670,Kent State,Kendrick Law,WR,86
+670,Kent State,Ja Mori Maclin,WR,86
+670,Kent State,Josh Kattus,TE,86
+670,Kent State,Fred Farrier Ii,WR,86
+670,Kent State,Zach Calzada,QB,85
+670,Kent State,Troy Stellato,WR,84
+670,Kent State,Jordan Lovett,FS,83
+670,Kent State,J J Hester,WR,83
+670,Kent State,Kameron Olds,LOLB,83
+670,Kent State,Josaih Hayes,DT,82
+670,Kent State,Jager Burton,C,82
+670,Kent State,Jalen Farmer,RG,82
+670,Kent State,Alex Afari Jr,MLB,81
+670,Kent State,Landyn Watson,MLB,81
+670,Kent State,Daveren Rayner,ROLB,79
+670,Kent State,Tavion Gadson,DT,78
+670,Kent State,Beau Allen,QB,78
+670,Kent State,Cameron Jones,LT,78
+670,Kent State,Ty Bryant,SS,77
+670,Kent State,Henry Boyer,TE,77
+670,Kent State,Sam Greene,LOLB,77
+670,Kent State,Ashton Cozart,WR,77
+670,Kent State,Malachi Wood,RT,77
+670,Kent State,Rob Fogler,LT,77
+670,Kent State,Jantzen Dunn,CB,76
+670,Kent State,Elijah Brown,TE,76
+670,Kent State,Evan Wibberley,C,75
+670,Kent State,Austin Ramsey,DT,74
+670,Kent State,Willie Rodriguez,TE,74
+670,Kent State,Laurence Zimmerman,WR,74
+670,Kent State,Quay Sheed Scott,CB,73
+670,Kent State,Grant Godfrey,ROLB,72
+670,Kent State,Hayes Johnson,LT,72
+670,Kent State,Alex Mclaughlin,TE,72
+670,Kent State,Reed Sperry,FB,72
+670,Kent State,Kent Goff,TE,72
+670,Kent State,Ali Robinson Gage,CB,71
+670,Kent State,Mychael Smart,TE,71
+670,Kent State,Hardley Gilmore Iv,WR,70
+670,Kent State,Aidan Laros,P,69
+670,Kent State,Darrin Strey,RT,69
+670,Kent State,Brennen Ward,QB,69
+670,Kent State,Jackson Schulz,SS,69
+670,Kent State,Kalen Edwards,DT,68
+670,Kent State,Cutter Boley,QB,68
+670,Kent State,Aba Selm,RG,68
+670,Kent State,Kevis Thomas,CB,67
+670,Kent State,Lorenzo Cowan,LOLB,67
+670,Kent State,Nasir Addison,CB,66
+670,Kent State,Dyllon Williams,SS,66
+670,Kent State,Jaden Smith,FS,66
+670,Kent State,Antwan Smith,ROLB,66
+670,Kent State,Quintavion Norman,ROLB,65
+670,Kent State,Cam Dooley,FS,64
+670,Kent State,Shane Barnwell,LT,64
+670,Kent State,David Washington Jr,WR,64
+670,Kent State,Devin Smith,MLB,64
+670,Kent State,D J Maddox,SS,63
+670,Kent State,Terhyon Nichols,CB,62
+670,Kent State,Sebastian Thompson,FS,62
+670,Kent State,Noah Harding,LG,59
+670,Kent State,Jonathon Gates,CB,59
+670,Kent State,Jacob Kauwe,K,58
+670,Kent State,Ervin Barrett,QB,57
+670,Kent State,J J Levin,LOLB,57
+670,Kent State,Ryan Blackburn Gorman,LT,47
+671,Kentucky,Aaron Fenimore,C,88
+671,Kentucky,Bryce Dixon,DT,86
+671,Kentucky,Joseph Carter,MLB,85
+671,Kentucky,Brylan Green,SS,85
+671,Kentucky,Elijah Canion,WR,84
+671,Kentucky,Jacob Jenkins,TE,84
+671,Kentucky,Amarian Williams,CB,84
+671,Kentucky,Dexter Ricks Jr,CB,83
+671,Kentucky,Austin Henderson,TE,83
+671,Kentucky,Tyson Mobley,WR,83
+671,Kentucky,Jack Tucker,LT,83
+671,Kentucky,A Khori Jones,CB,82
+671,Kentucky,Reese Smith,WR,81
+671,Kentucky,Ethan Vasko,QB,81
+671,Kentucky,Trey Bedosky,RT,81
+671,Kentucky,Darius Copeland,WR,81
+671,Kentucky,Mike Jarvis,DT,81
+671,Kentucky,Markus Clark,DT,80
+671,Kentucky,Hunter Porterfield,LT,80
+671,Kentucky,Bo Burklow,TE,80
+671,Kentucky,Casey Cain,WR,79
+671,Kentucky,Elijah Auguste,FS,79
+671,Kentucky,Eli Hall,DT,78
+671,Kentucky,Erwil Anthony Jr,LT,78
+671,Kentucky,Christian Bodnar,FS,77
+671,Kentucky,Donte Lee Jr,WR,77
+671,Kentucky,Ethan Crisp,LOLB,77
+671,Kentucky,Harrison Hayes,RG,77
+671,Kentucky,Andrew Johnson,LG,76
+671,Kentucky,Eldric Griffin,FS,75
+671,Kentucky,Derrell Farrar,ROLB,75
+671,Kentucky,Dj Jackson,DT,75
+671,Kentucky,Deuce Spurlock Ii,ROLB,75
+671,Kentucky,Aidan Vaughan,ROLB,75
+671,Kentucky,Jamari Person,WR,75
+671,Kentucky,Brandon Edozie,LT,75
+671,Kentucky,Christian Williams,RT,74
+671,Kentucky,Micah Pollard,MLB,74
+671,Kentucky,Jonathan Hammonds,TE,74
+671,Kentucky,Dillano Glaud,MLB,74
+671,Kentucky,Bryce Randolph,WR,74
+671,Kentucky,Will Morant,DT,74
+671,Kentucky,Jalon Rock,FS,73
+671,Kentucky,Jacob Lecates,RT,73
+671,Kentucky,Elijah Hopkins,CB,71
+671,Kentucky,Ryan Burger,QB,71
+671,Kentucky,Dudley Dillard,FS,71
+671,Kentucky,Eli Sisson,TE,71
+671,Kentucky,Ethan Houck,QB,69
+671,Kentucky,Jamal Miles,CB,69
+671,Kentucky,Cal Grubbs,C,69
+671,Kentucky,Austin Anderson,RT,69
+671,Kentucky,James Chapman,RG,67
+671,Kentucky,Blake Heckmann,LG,67
+671,Kentucky,Kaidon Whidby,LOLB,66
+671,Kentucky,Seneca Moore,MLB,65
+671,Kentucky,Gabe Smith,LG,64
+671,Kentucky,Devin Henderson,SS,63
+671,Kentucky,Max Morgan,P,62
+671,Kentucky,Champ Montgomery,FB,62
+671,Kentucky,Sedrick Sparks,QB,61
+671,Kentucky,Phillip Carradine,TE,61
+671,Kentucky,Ryan Manis,TE,61
+671,Kentucky,Nick Brown,K,59
+671,Kentucky,Jiquavious Marshall,CB,59
+671,Kentucky,Caleb Willis,K,57
+671,Kentucky,Ronald Moore Jr,FS,55
+671,Kentucky,Bret Yoder,C,53
+671,Kentucky,R J Miles,FS,53
+671,Kentucky,Michael Merdinger,QB,52
+671,Kentucky,Sam Crossan,P,52
+671,Kentucky,Brayden Beck,K,46
+672,Liberty,George Jackson,RT,87
+672,Liberty,Jax Harrington,RG,85
+672,Liberty,Jaden Dugger,ROLB,85
+672,Liberty,Tyree Skipper,FS,84
+672,Liberty,Terrence Williams,ROLB,84
+672,Liberty,Robert Williams,WR,83
+672,Liberty,Bryant Williams,LT,82
+672,Liberty,Caleb Kibodi,MLB,82
+672,Liberty,Kailep Edwards,MLB,82
+672,Liberty,Mackey Maillho,RT,82
+672,Liberty,Cameron Whitfield,LOLB,80
+672,Liberty,Kaden Moreau,LG,80
+672,Liberty,Walker Howard,QB,80
+672,Liberty,Charles Robertson,WR,80
+672,Liberty,Noah Kirkwood,LG,80
+672,Liberty,Jaydon Johnson,WR,79
+672,Liberty,Caden Jensen,TE,78
+672,Liberty,Jalen Clark,FS,78
+672,Liberty,John Bragg,LT,78
+672,Liberty,Cooper Fordham,C,77
+672,Liberty,Lorenzell Dubose,CB,77
+672,Liberty,Ashley Williams,LOLB,77
+672,Liberty,Jake St Andre,MLB,77
+672,Liberty,Curley Reed Iii,CB,76
+672,Liberty,Jaelen Crider,DT,75
+672,Liberty,Daniel Beale,QB,75
+672,Liberty,Key Savalyn Barnes,SS,75
+672,Liberty,Shelton Sampson Jr,WR,74
+672,Liberty,Dale Martin,WR,74
+672,Liberty,Khristian Mackintrush,TE,74
+672,Liberty,Kody Jackson,SS,74
+672,Liberty,Kadarius Miller,DT,73
+672,Liberty,Trae Tomlinson,CB,73
+672,Liberty,Quandre Coates,TE,72
+672,Liberty,Trey Miller,TE,72
+672,Liberty,Jaron Dawkins,CB,72
+672,Liberty,Brock Chappell,TE,72
+672,Liberty,Maurion Eleam,CB,72
+672,Liberty,Ethan Veal,ROLB,72
+672,Liberty,Kedarius Wade,WR,72
+672,Liberty,Jake Roberts,QB,71
+672,Liberty,J Marion Gooch,RT,70
+672,Liberty,Trey Fite,LOLB,70
+672,Liberty,Micah Johnson,MLB,70
+672,Liberty,Hunter Sims,TE,70
+672,Liberty,Xzavier Brown,RG,69
+672,Liberty,Zay Alexander,LT,69
+672,Liberty,Steven Ranel,FS,68
+672,Liberty,Blake Harris,RG,68
+672,Liberty,Jeremiah Moses,CB,67
+672,Liberty,Ja Corian Norris,FS,67
+672,Liberty,Rahji Dennis,WR,67
+672,Liberty,Na Tori Brown,LOLB,66
+672,Liberty,Matthew Broussard,LG,66
+672,Liberty,Carter Milliron,TE,66
+672,Liberty,Avery Demery,CB,65
+672,Liberty,Nathan Torney,P,64
+672,Liberty,Justyn Lauderdale,CB,63
+672,Liberty,Ricky June,WR,63
+672,Liberty,Dalvin Coates,CB,62
+672,Liberty,Jayden Mcallister,C,61
+672,Liberty,Korbin Ashmore,DT,61
+672,Liberty,Lunch Winfield,QB,60
+672,Liberty,Brent Gordon,SS,60
+672,Liberty,Jaiden Smith,WR,58
+672,Liberty,Carl Webb,FB,57
+672,Liberty,Ryland Badet,LT,57
+672,Liberty,Tony Sterner,K,54
+672,Liberty,Baylynn Williams,C,53
+672,Liberty,Russell Babineaux,WR,52
+672,Liberty,Logan Klotz,K,45
+673,Louisiana,Carl Glass Jr,ROLB,87
+673,Louisiana,Tyler Griffin,WR,86
+673,Louisiana,Jake Godfrey,WR,85
+673,Louisiana,Carl Fauntroy,FS,84
+673,Louisiana,Elijah Fisher,LG,83
+673,Louisiana,David Godsey Jr,CB,83
+673,Louisiana,Tyrese Hopkins,MLB,83
+673,Louisiana,Javon Campbell,WR,83
+673,Louisiana,Jay Mickle,RG,82
+673,Louisiana,D Arco Perkins Mcallister,CB,82
+673,Louisiana,Paul Cobb,MLB,82
+673,Louisiana,Daniel Knudsen,MLB,80
+673,Louisiana,Aidan Armenta,QB,78
+673,Louisiana,Dontavius Burrows,MLB,78
+673,Louisiana,Markeegan Gray,LOLB,78
+673,Louisiana,Kelbee Holmes,ROLB,78
+673,Louisiana,Nate Sullivan Jr,TE,77
+673,Louisiana,Tristan Shorter,LOLB,77
+673,Louisiana,Hunter Herring,QB,77
+673,Louisiana,Que Mcbroom,RT,77
+673,Louisiana,Oj Berry,TE,77
+673,Louisiana,Andre Mack,SS,76
+673,Louisiana,Noah Flemmings,MLB,76
+673,Louisiana,Sergio Simpson,LT,76
+673,Louisiana,Antavious Woody,LG,75
+673,Louisiana,Brandon Buckhaulter,WR,75
+673,Louisiana,Kristopher Robinson,FS,75
+673,Louisiana,Amir Mcgruder,WR,75
+673,Louisiana,Lynard Harris,SS,74
+673,Louisiana,Reese Mooney,QB,74
+673,Louisiana,Levontae Jacobs,DT,74
+673,Louisiana,Dylan Howell,DT,73
+673,Louisiana,Rylan Green,TE,73
+673,Louisiana,Caleb Groce,WR,73
+673,Louisiana,Brett Drillette,MLB,73
+673,Louisiana,Korian Wilson,CB,72
+673,Louisiana,Julian Nixon,TE,72
+673,Louisiana,B J Gaffney,LT,72
+673,Louisiana,Stephen Saywahn,LOLB,72
+673,Louisiana,Jyren Ester,CB,72
+673,Louisiana,Drew Hutchinson,C,72
+673,Louisiana,Jaden Hamlin,DT,71
+673,Louisiana,Nolan Wilson,TE,71
+673,Louisiana,Amarion Ware,DT,71
+673,Louisiana,Seidrion Langston,ROLB,71
+673,Louisiana,Nic Trujillo,WR,70
+673,Louisiana,Navarion Benson,CB,70
+673,Louisiana,Tremaine Ware,WR,70
+673,Louisiana,Reese Steele,LG,70
+673,Louisiana,Davin Anderson,DT,70
+673,Louisiana,Roscoe Tucker,LT,69
+673,Louisiana,Joe Bazley,WR,69
+673,Louisiana,Kamrin Canterbury,CB,68
+673,Louisiana,Adameon Botley,LT,68
+673,Louisiana,Stephen Evans,WR,68
+673,Louisiana,Max Larson,K,67
+673,Louisiana,Quentis Griffin Jr,RT,67
+673,Louisiana,Bryson Kimbrough,QB,66
+673,Louisiana,Don Baumhower,QB,62
+673,Louisiana,Kamryn Moats,SS,61
+673,Louisiana,Trevis Blades,CB,60
+673,Louisiana,Rashaud Mccormick,CB,59
+673,Louisiana,Ethan Bailey,DT,55
+673,Louisiana,Trevor Renz,FB,55
+673,Louisiana,Kevin Briggs,FS,55
+673,Louisiana,Duce Huntington,CB,55
+673,Louisiana,Makenzie Ryan,P,54
+673,Louisiana,Kaliem Croswell,RG,54
+673,Louisiana,Aj Vinson,LT,52
+673,Louisiana,Luke Stagg,K,50
+673,Louisiana,Nate Green,C,45
+674,Louisiana–Monroe,Zion Nason,DT,86
+674,Louisiana–Monroe,Hayden Christman,RT,84
+674,Louisiana–Monroe,Hugh Mcghee,RT,84
+674,Louisiana–Monroe,Kolbe Fields,ROLB,83
+674,Louisiana–Monroe,Landon Nelson,C,83
+674,Louisiana–Monroe,Brett Canis,LT,83
+674,Louisiana–Monroe,Evan Bullock,QB,81
+674,Louisiana–Monroe,Ciante Patrick,FS,81
+674,Louisiana–Monroe,Eli Finley,TE,80
+674,Louisiana–Monroe,Cedric Woods,CB,80
+674,Louisiana–Monroe,Kenneth Bannister,LT,80
+674,Louisiana–Monroe,Noah Biglow,CB,79
+674,Louisiana–Monroe,Sifa Leota,MLB,79
+674,Louisiana–Monroe,Jacob Fields,SS,78
+674,Louisiana–Monroe,Jakari Foster,SS,78
+674,Louisiana–Monroe,Marlion Jackson,WR,78
+674,Louisiana–Monroe,Michael Richard,FS,77
+674,Louisiana–Monroe,Jay Wilkerson,WR,77
+674,Louisiana–Monroe,Trevell Vivians,DT,77
+674,Louisiana–Monroe,Ashanti Cole,RG,76
+674,Louisiana–Monroe,Mekhi Mason,LOLB,76
+674,Louisiana–Monroe,Dedrick Latulas,WR,76
+674,Louisiana–Monroe,Devin Gandy,WR,75
+674,Louisiana–Monroe,Shadeed Ahmed,WR,75
+674,Louisiana–Monroe,Cameron Hopkins,WR,75
+674,Louisiana–Monroe,Jeff Beckham,QB,74
+674,Louisiana–Monroe,Roy Brackins Iii,LG,74
+674,Louisiana–Monroe,Christian Davis,DT,73
+674,Louisiana–Monroe,Cam Hill,FS,73
+674,Louisiana–Monroe,Titus Bailey Smith,WR,72
+674,Louisiana–Monroe,Joshua Cobbs,FS,71
+674,Louisiana–Monroe,Trevor Ford,WR,71
+674,Louisiana–Monroe,Brayden Bockler,TE,71
+674,Louisiana–Monroe,Cyler Corn,RG,71
+674,Louisiana–Monroe,Blake Baker,QB,70
+674,Louisiana–Monroe,Colton Deckard,ROLB,70
+674,Louisiana–Monroe,Ean Burch,TE,70
+674,Louisiana–Monroe,Jay Simon,WR,69
+674,Louisiana–Monroe,Luke Seib,WR,69
+674,Louisiana–Monroe,Jayden Madkins,DT,69
+674,Louisiana–Monroe,Jake Riggs,TE,68
+674,Louisiana–Monroe,Jadon Smith,C,68
+674,Louisiana–Monroe,Kam Franklin,SS,67
+674,Louisiana–Monroe,Forrest Davis,CB,66
+674,Louisiana–Monroe,Clarence Joseph,SS,66
+674,Louisiana–Monroe,Nick Lampman,LG,66
+674,Louisiana–Monroe,Cole Watson,ROLB,66
+674,Louisiana–Monroe,Jordan Pierro,CB,65
+674,Louisiana–Monroe,Zheric Hill,MLB,65
+674,Louisiana–Monroe,Jermayne Pryce,WR,65
+674,Louisiana–Monroe,Gabe Boyle,QB,64
+674,Louisiana–Monroe,Brian Ayers,CB,64
+674,Louisiana–Monroe,Brian Myers,MLB,64
+674,Louisiana–Monroe,Jadon Mayfield,MLB,64
+674,Louisiana–Monroe,Jalen Mickens,WR,64
+674,Louisiana–Monroe,Donnel Coakley,WR,64
+674,Louisiana–Monroe,Nicholas Goodrich,FB,64
+674,Louisiana–Monroe,Patrick Rea,P,63
+674,Louisiana–Monroe,Rakkim Meander,CB,63
+674,Louisiana–Monroe,Alex Winslow,RT,62
+674,Louisiana–Monroe,De Andre Etienne,C,62
+674,Louisiana–Monroe,Drew Henderson,K,61
+674,Louisiana–Monroe,Alonzo Jackson Jr,LOLB,61
+674,Louisiana–Monroe,Devaunte Fitzpatrick,QB,60
+674,Louisiana–Monroe,Troy Smith Iii,RG,60
+674,Louisiana–Monroe,Austin Ellis,RT,60
+674,Louisiana–Monroe,Landon Charles,P,59
+674,Louisiana–Monroe,John Hoyet Chance,P,58
+674,Louisiana–Monroe,Craig Sheldon,WR,58
+674,Louisiana–Monroe,Sam Depaola,WR,58
+674,Louisiana–Monroe,Daquan Higgins,RG,58
+674,Louisiana–Monroe,Ernie Flinn,C,58
+674,Louisiana–Monroe,Ronald Mcmorris,DT,56
+674,Louisiana–Monroe,Ron Ellsworth,LG,55
+674,Louisiana–Monroe,Andrew Richard,C,54
+675,Louisiana Tech,Chris Bell,WR,89
+675,Louisiana Tech,Denzel Lowry,DT,89
+675,Louisiana Tech,Caullin Lacy,WR,88
+675,Louisiana Tech,Stanquan Clark,ROLB,87
+675,Louisiana Tech,Miller Moss,QB,87
+675,Louisiana Tech,Pete Nygra,C,87
+675,Louisiana Tech,Makylan Pounders,LT,87
+675,Louisiana Tech,Jordan Guerad,DT,86
+675,Louisiana Tech,Renato Brown,RG,86
+675,Louisiana Tech,Mahamane Moussa,LG,86
+675,Louisiana Tech,Tj Quinn,MLB,85
+675,Louisiana Tech,Jacob Stewart,TE,85
+675,Louisiana Tech,Treyshun Hurry,WR,84
+675,Louisiana Tech,Trevonte Sylvester,LT,84
+675,Louisiana Tech,Terrance Mcwilliams,WR,84
+675,Louisiana Tech,Rene Konga,DT,83
+675,Louisiana Tech,Jabari Mack,CB,83
+675,Louisiana Tech,Jojo Evans,SS,82
+675,Louisiana Tech,Justin Agu,CB,82
+675,Louisiana Tech,D Angelo Hutchinson,SS,82
+675,Louisiana Tech,Lance Robinson,RT,82
+675,Louisiana Tech,Bobby Golden,WR,81
+675,Louisiana Tech,Rasheed Miller,RT,81
+675,Louisiana Tech,Jordan Church,LG,80
+675,Louisiana Tech,Nate Kurisky,TE,79
+675,Louisiana Tech,Dacari Collins,WR,79
+675,Louisiana Tech,Naeer Jackson,RG,79
+675,Louisiana Tech,Tayon Holloway,CB,78
+675,Louisiana Tech,Corey Gordon,FS,78
+675,Louisiana Tech,Michael Flores,C,78
+675,Louisiana Tech,Victor Cutler,C,78
+675,Louisiana Tech,Kalib Perry,MLB,77
+675,Louisiana Tech,Rodney Johnson,CB,77
+675,Louisiana Tech,Jaleel Skinner,TE,76
+675,Louisiana Tech,Blake Ruffin,FS,76
+675,Louisiana Tech,Jerry Lawson,DT,76
+675,Louisiana Tech,Antonio Meeks,WR,75
+675,Louisiana Tech,Sam Secrest,C,75
+675,Louisiana Tech,Trent Carter,LOLB,74
+675,Louisiana Tech,Daeh Mccullough,SS,73
+675,Louisiana Tech,Joseph Jefferson Ii,FS,72
+675,Louisiana Tech,Antonio Watts,LOLB,72
+675,Louisiana Tech,Kris Hughes,WR,72
+675,Louisiana Tech,Kendrick Gilbert,LOLB,72
+675,Louisiana Tech,Grant Houser,TE,71
+675,Louisiana Tech,Deanthony Finnegan,RT,71
+675,Louisiana Tech,Mason Mims,QB,70
+675,Louisiana Tech,Jamie Wilson Hunter,LG,69
+675,Louisiana Tech,Davon Mitchell,TE,68
+675,Louisiana Tech,Carter Guillaume,RG,68
+675,Louisiana Tech,T J Capers,ROLB,67
+675,Louisiana Tech,Rae Mon Mosby,CB,67
+675,Louisiana Tech,William Walker,C,67
+675,Louisiana Tech,Ransom Mcdermott,RT,67
+675,Louisiana Tech,Carter Schwartz,P,66
+675,Louisiana Tech,Marquel Williamson,LG,66
+675,Louisiana Tech,Jathan Hatch,FS,66
+675,Louisiana Tech,Micah Rice,FS,66
+675,Louisiana Tech,Brady Allen,QB,66
+675,Louisiana Tech,Selah Brown,DT,65
+675,Louisiana Tech,Cameron White,ROLB,64
+675,Louisiana Tech,Bennett Andrews,FB,63
+675,Louisiana Tech,Keenan Montgomery,DT,62
+675,Louisiana Tech,Caleb Matelau,MLB,62
+675,Louisiana Tech,Antonio Harris,CB,61
+675,Louisiana Tech,Deuce Adams,QB,60
+675,Louisiana Tech,Joshua Aumer,RG,60
+675,Louisiana Tech,Shai Kochav,TE,59
+675,Louisiana Tech,Troy Hyder,LT,57
+675,Louisiana Tech,Dion Howdin,DT,55
+675,Louisiana Tech,Nick Keller,K,53
+676,Louisville,Garrett Nussmeier,QB,92
+676,Louisville,Harold Perkins Jr,ROLB,91
+676,Louisville,Ashton Stamps,CB,91
+676,Louisville,Mansoor Delane,CB,90
+676,Louisville,Whit Weeks,MLB,90
+676,Louisville,Aaron Anderson,WR,89
+676,Louisville,Josh Thompson,RT,89
+676,Louisville,A J Haulcy,FS,88
+676,Louisville,Nic Anderson,WR,87
+676,Louisville,Barion Brown,WR,87
+676,Louisville,Bernard Gooden,DT,87
+676,Louisville,Bauer Sharp,TE,86
+676,Louisville,Bo Bordelon,RG,85
+676,Louisville,Chris Hilton Jr,WR,84
+676,Louisville,Jacobian Guillory,DT,83
+676,Louisville,Tamarcus Cooley,FS,82
+676,Louisville,Zavion Thomas,WR,82
+676,Louisville,Braelin Moore,C,80
+676,Louisville,Dj Chester,C,79
+676,Louisville,Paul Mubenga,LG,79
+676,Louisville,Austin Ausberry,SS,78
+676,Louisville,Javien Toviano,SS,77
+676,Louisville,Dominick Mckinley,DT,77
+676,Louisville,West Weeks,ROLB,77
+676,Louisville,Dashawn Spears,FS,76
+676,Louisville,Ahmad Breaux,DT,76
+676,Louisville,Shone Washington,DT,76
+676,Louisville,Michael Van Buren Jr,QB,76
+676,Louisville,Jonathan Ferguson,TE,76
+676,Louisville,Ja Keem Jackson,CB,75
+676,Louisville,Trey Dez Green,TE,75
+676,Louisville,Coen Echols,RG,75
+676,Louisville,Donovan Green,TE,74
+676,Louisville,Destyn Hill,WR,73
+676,Louisville,Davhon Keys,MLB,73
+676,Louisville,Dj Pickett,CB,72
+676,Louisville,Jardin Gilbert,FS,72
+676,Louisville,Pj Woodland,CB,72
+676,Louisville,Zeek Waymore,LT,72
+676,Louisville,Charles Ross Ii,ROLB,70
+676,Louisville,Paul Sinclair,TE,70
+676,Louisville,John David Lafleur,TE,70
+676,Louisville,Sydir Mitchell,DT,69
+676,Louisville,Ory Williams,LG,69
+676,Louisville,Jack Habbart,LOLB,69
+676,Louisville,Khayree Lee Jr,RG,69
+676,Louisville,Damian Ramos,K,68
+676,Louisville,Kylan Billiot,WR,67
+676,Louisville,Princeton Malbrue,LOLB,67
+676,Louisville,Bryce Drayton,SS,66
+676,Louisville,Zion Williams,DT,66
+676,Louisville,Jelani Watkins,WR,65
+676,Louisville,Kyle Parker,WR,65
+676,Louisville,Weston Davis,RT,64
+676,Louisville,Ju Juan Johnson,QB,64
+676,Louisville,Joel Rogers,SS,64
+676,Louisville,Grant Chadwick,P,63
+676,Louisville,Michael Turner Jr,CB,63
+676,Louisville,Quan Rawlings,LT,63
+676,Louisville,Tylen Singleton,MLB,62
+676,Louisville,Tyree Adams,LT,60
+676,Louisville,Colin Hurley,QB,60
+676,Louisville,Parker Ridgeway,C,60
+676,Louisville,Aidan Corbello,K,59
+676,Louisville,Badger Hargett,P,58
+676,Louisville,Mitch Nixon,LG,57
+676,Louisville,Peyton Todd,P,57
+676,Louisville,Kwame Franklin,LG,56
+676,Louisville,Aeron Burrell,K,55
+676,Louisville,Jason Dial,MLB,46
+676,Louisville,Ethan Calloway,RT,44
+677,LSU,Shunmarkus Adams,LG,86
+677,LSU,Jalen Slappy,RG,84
+677,LSU,Morgan Scott,RT,84
+677,LSU,Toby Payne,TE,83
+677,LSU,Adrian Norton,WR,81
+677,LSU,Daytione Smith,CB,81
+677,LSU,Antonio Harmon,WR,80
+677,LSU,Marvae Myers Glover,CB,80
+677,LSU,Jalil Rivera Harvey,DT,78
+677,LSU,Jayland Parker,MLB,78
+677,LSU,Bryce Biggs,LG,78
+677,LSU,Jibreel Al Amin,ROLB,78
+677,LSU,Naquan Crowder,DT,78
+677,LSU,Jadarius Green Mcknight,SS,77
+677,LSU,Tariq Montgomery,LT,77
+677,LSU,Tyler Mcduffie,LT,76
+677,LSU,Bryan Robinson,WR,76
+677,LSU,Ben Turner,WR,76
+677,LSU,Tyas Martin,DT,76
+677,LSU,Javae Gilmore,MLB,75
+677,LSU,Peyton Ellis,RT,75
+677,LSU,Jalen Marshall,ROLB,75
+677,LSU,Jakolbe Baldwin,WR,75
+677,LSU,Louikenzy Jules,CB,75
+677,LSU,Eric Meeks,C,75
+677,LSU,Quincy Irving,TE,74
+677,LSU,Demarcus Lacey,WR,74
+677,LSU,Katron Evans,DT,74
+677,LSU,Evan Ferguson,RG,74
+677,LSU,Ishmael Roy,SS,74
+677,LSU,Zane Porter,MLB,74
+677,LSU,Christian Richter,RT,74
+677,LSU,Carlos Del Rio Wilson,QB,73
+677,LSU,A J Fox,QB,73
+677,LSU,Chason Clark,LOLB,73
+677,LSU,Boogie Trotter,CB,72
+677,LSU,Joshua Pierre Louis,FS,72
+677,LSU,Tevyn Brown,SS,72
+677,LSU,Cam Smith,FS,72
+677,LSU,Kerion Martin,MLB,72
+677,LSU,Cannon Lewis,LOLB,72
+677,LSU,Jamaal Whyce Jr,DT,71
+677,LSU,Rhett Mcgrew,TE,71
+677,LSU,Ali Abbasi,DT,70
+677,LSU,Atley Cowan,WR,70
+677,LSU,Rashawn Carr,ROLB,70
+677,LSU,Zion Turner,QB,69
+677,LSU,Zavier Short,WR,69
+677,LSU,Bruce Finch,RG,69
+677,LSU,Isaac Clary,RG,68
+677,LSU,Tayvon Nelson,FS,67
+677,LSU,Caleb Clark Glover,CB,67
+677,LSU,Daniel Harris,LOLB,67
+677,LSU,Tracy Stephens,TE,66
+677,LSU,Mikailin Warren,DT,65
+677,LSU,Davion Kershaw,FS,65
+677,LSU,Tashawn Jeter,FS,65
+677,LSU,Tony Martin,WR,65
+677,LSU,Koi Fagan,QB,64
+677,LSU,Sherone White Jr,WR,64
+677,LSU,Darrell Sweeting,CB,64
+677,LSU,Bubba Mcmullen,FB,63
+677,LSU,Kris Carruthers,DT,61
+677,LSU,Chris Holmes,CB,61
+677,LSU,Eahjay Mcadams,MLB,60
+677,LSU,Richard Franklin,CB,60
+677,LSU,Jacqai Long,QB,59
+677,LSU,Jack Laird,LG,59
+677,LSU,Al Robinson Curry,DT,57
+677,LSU,Eli Kaufman,LT,55
+677,LSU,Camron Nti,FS,55
+677,LSU,Corey Teal,LG,55
+677,LSU,Andrew Dudley,C,54
+677,LSU,Parker Brault,LG,54
+677,LSU,Nathan Totten,K,49
+678,Marshall,Isaiah Wright,C,88
+678,Marshall,Dorian Fleming,TE,87
+678,Marshall,Jalil Farooq,WR,85
+678,Marshall,Jalen Huskey,SS,85
+678,Marshall,Drew Busch,RT,83
+678,Marshall,Octavian Smith Jr,WR,81
+678,Marshall,Alan Herron,RT,80
+678,Marshall,Daniel Wingate,MLB,80
+678,Marshall,Cam Rice,DT,80
+678,Marshall,Dontay Joyner,CB,79
+678,Marshall,Eyan Thomas,DT,79
+678,Marshall,Rahtrel Perry,LT,78
+678,Marshall,Jamare Glasker,CB,78
+678,Marshall,Kaleb Webb,WR,77
+678,Marshall,Dj Samuels,ROLB,77
+678,Marshall,Mekhai White,WR,77
+678,Marshall,Shaleak Knotts,WR,76
+678,Marshall,Ryan Manning,WR,76
+678,Marshall,Lavain Scruggs,FS,75
+678,Marshall,Ryan Howerton,LG,75
+678,Marshall,Clarence Montrosse,LG,75
+678,Marshall,Messiah Delhomme,SS,74
+678,Marshall,Alex Moore,SS,74
+678,Marshall,Justyn Martin,QB,73
+678,Marshall,Aliou Bah,RG,73
+678,Marshall,Leon Haughton Jr,TE,73
+678,Marshall,Shamar Mcintosh,FS,73
+678,Marshall,Judah Jenkins,CB,73
+678,Marshall,Braydon Lee,CB,72
+678,Marshall,Michael Mcmonigle,LT,72
+678,Marshall,Justin Devaughn,WR,72
+678,Marshall,Jordan Scott,WR,72
+678,Marshall,Darius Grimes,LOLB,72
+678,Marshall,Chris Wells,ROLB,72
+678,Marshall,Keion Flowers,MLB,71
+678,Marshall,Ethan Gough,TE,71
+678,Marshall,Lamar Williams,LT,70
+678,Marshall,Keyari James,MLB,70
+678,Marshall,Bryce Jenkins,DT,69
+678,Marshall,Michael Hershey,C,69
+678,Marshall,Anthony Robsock,RG,69
+678,Marshall,Jayden Shipps,CB,68
+678,Marshall,Kellen Mcconnell,TE,68
+678,Marshall,Jt Taggart,TE,67
+678,Marshall,Keyshawn Flowers,MLB,67
+678,Marshall,Carlton Smith,LOLB,67
+678,Marshall,Bryce Mcferson,P,66
+678,Marshall,Trey Reddick,LOLB,66
+678,Marshall,Gavin Marshall,K,66
+678,Marshall,Ricardo Cooper Jr,WR,66
+678,Marshall,Joel Starlings,DT,65
+678,Marshall,Trevor Szymanski,RT,65
+678,Marshall,Sidney Stewart,LOLB,65
+678,Marshall,Malik Washington,QB,64
+678,Marshall,Michael Harris,MLB,64
+678,Marshall,Aj Szymanski,TE,63
+678,Marshall,Lakhi Roland,CB,63
+678,Marshall,Tommy Morehouse,MLB,62
+678,Marshall,Devondre Little,FS,62
+678,Marshall,Noah Carrington,DT,61
+678,Marshall,Jackson Hamilton,QB,61
+678,Marshall,Khristian Martin,QB,59
+678,Marshall,Logan Bennett,RT,59
+678,Marshall,Kevyn Humes,CB,58
+678,Marshall,Nick Story,FB,57
+678,Marshall,Laquan Moore,RT,53
+678,Marshall,Lloyd Irvin Iii,CB,53
+678,Marshall,Davon Watkins,LG,50
+678,Marshall,Bubba Van Martin,RG,48
+679,Maryland,Chauncey Logan,CB,88
+679,Maryland,Drue Watts,LOLB,88
+679,Maryland,Travis Burke,LT,88
+679,Maryland,Marcus Burris Jr,DT,87
+679,Maryland,Deron Tiller,LT,86
+679,Maryland,Kamari Wilson,SS,85
+679,Maryland,Isheem Young,SS,85
+679,Maryland,Everett Roussaw Jr,MLB,84
+679,Maryland,Brendon Lewis,QB,83
+679,Maryland,Mond Cole,DT,83
+679,Maryland,Chris Adams,RT,82
+679,Maryland,Cam Burden,MLB,82
+679,Maryland,Kyndall Mckenzie,RG,82
+679,Maryland,Sam Brumfield,ROLB,81
+679,Maryland,Joey Hunter,CB,81
+679,Maryland,Yakiri Walker,C,81
+679,Maryland,Omarion Cooper,CB,80
+679,Maryland,Jadon Thompson,WR,80
+679,Maryland,Jerry Cross,TE,79
+679,Maryland,Malachi Breland,RG,79
+679,Maryland,Ethan Newman,LG,79
+679,Maryland,Brady Kluse,WR,78
+679,Maryland,Myles Pollard,CB,78
+679,Maryland,Parker Peterson,LT,78
+679,Maryland,Cj Smith,WR,77
+679,Maryland,Chris Bracy,FS,77
+679,Maryland,Kourtlan Marsh,SS,77
+679,Maryland,Pooda Walker,DT,77
+679,Maryland,Jaidyn Denis,FS,76
+679,Maryland,Austin Gentle,LG,76
+679,Maryland,Ger Cari Caldwell,WR,76
+679,Maryland,Jayden Flaker,ROLB,76
+679,Maryland,Donovan Mathena,ROLB,75
+679,Maryland,Parker Mitchell,RT,75
+679,Maryland,Chase Pinkston,CB,75
+679,Maryland,Marcello Bussey,WR,75
+679,Maryland,Joshua White,DT,73
+679,Maryland,Jonathan Young,RT,73
+679,Maryland,Bryce Anderson,TE,73
+679,Maryland,Jacari Gatling,DT,73
+679,Maryland,Jamari Hawkins,WR,72
+679,Maryland,Jeremiah Jordan,FS,72
+679,Maryland,Jonathan Zarut,TE,72
+679,Maryland,Xavier Johnson,WR,71
+679,Maryland,Cameron Miller,CB,71
+679,Maryland,Demarco Ward,LOLB,71
+679,Maryland,Lane Quigley,TE,71
+679,Maryland,Jacob Norcross,C,70
+679,Maryland,Tyrod Hogan,LT,69
+679,Maryland,Jordan Bell,WR,69
+679,Maryland,Ian Rembert,MLB,69
+679,Maryland,Nahmier Robinson,CB,69
+679,Maryland,Will French,RT,68
+679,Maryland,Tanner Gillis,P,67
+679,Maryland,Keonde Henry,WR,67
+679,Maryland,Jaylen Thompson,FS,67
+679,Maryland,Nate Thomason,ROLB,67
+679,Maryland,Brandon Chambers,QB,66
+679,Maryland,Devaunte Haskins,SS,65
+679,Maryland,Cameron Harden,LT,65
+679,Maryland,Jimmy Brown,LOLB,65
+679,Maryland,Wolf Walker,MLB,65
+679,Maryland,Gianni Spetic,K,64
+679,Maryland,Kamore Harris,ROLB,64
+679,Maryland,Arrington Maiden,QB,63
+679,Maryland,Ian Williams,FS,62
+679,Maryland,Jonathan Harding,TE,61
+679,Maryland,Xavier Thompson,CB,60
+679,Maryland,Oliver Castaneda,K,59
+679,Maryland,Lachlan Carrigan,P,58
+679,Maryland,Sam Browder,RG,58
+679,Maryland,Antwaun Jackson,FB,54
+680,Memphis,Francis Mauigoa,RT,93
+680,Memphis,Carson Beck,QB,91
+680,Memphis,Anez Cooper,RG,89
+680,Memphis,Charles Brantley,CB,88
+680,Memphis,Wesley Bissainthe,ROLB,88
+680,Memphis,Cj Daniels,WR,88
+680,Memphis,Mohamed Toure,ROLB,88
+680,Memphis,Jadais Richard,CB,88
+680,Memphis,Oj Frederique Jr,CB,87
+680,Memphis,David Blay Jr,DT,87
+680,Memphis,Alex Bauman,TE,86
+680,Memphis,James Brockermeyer,C,86
+680,Memphis,Ahmad Moten Sr,DT,86
+680,Memphis,Zechariah Poyser,FS,85
+680,Memphis,Jakobe Thomas,SS,85
+680,Memphis,Keelan Marion,WR,85
+680,Memphis,Jaylin Alderman,MLB,85
+680,Memphis,Kamal Bonner,ROLB,85
+680,Memphis,Markel Bell,LT,84
+680,Memphis,Ethan O Connor,CB,83
+680,Memphis,Raul Aguirre Jr,MLB,83
+680,Memphis,Tony Johnson,WR,83
+680,Memphis,Keionte Scott,CB,81
+680,Memphis,Ray Ray Joseph,WR,81
+680,Memphis,Ryan Rodriguez,LG,81
+680,Memphis,Matthew Mccoy,LG,79
+680,Memphis,Adarius Hayes,MLB,79
+680,Memphis,Samson Okunlola,LT,78
+680,Memphis,Chase Smith,ROLB,78
+680,Memphis,Tommy Kinsler Iv,RT,78
+680,Memphis,Justin Scott,DT,77
+680,Memphis,Joshisa Trader,WR,76
+680,Memphis,Elija Lofton,TE,76
+680,Memphis,Xavier Lucas,CB,76
+680,Memphis,Seuseu Alofaituli,C,76
+680,Memphis,Damari Brown,CB,75
+680,Memphis,Juan Minaya,RG,75
+680,Memphis,Adam Booker,TE,74
+680,Memphis,Emory Williams,QB,74
+680,Memphis,Markeith Williams,FS,73
+680,Memphis,Isaiah Taylor,FS,73
+680,Memphis,Luka Gilbert,TE,73
+680,Memphis,Dylan Day,SS,72
+680,Memphis,Keon Alexander,LT,72
+680,Memphis,Bert Auburn,K,71
+680,Memphis,Cam Pruitt,ROLB,71
+680,Memphis,Jaboree Antoine,CB,71
+680,Memphis,Artavius Jones,DT,70
+680,Memphis,Nino Francavilla,C,70
+680,Memphis,Judd Anderson,QB,70
+680,Memphis,Dylan Joyce,P,69
+680,Memphis,Joshua Moore,WR,69
+680,Memphis,Andrew Fuller,LG,69
+680,Memphis,Demarcco Hodges,WR,69
+680,Memphis,Brock Schott,TE,68
+680,Memphis,Jaden Wilkerson,RG,68
+680,Memphis,Max Buchanan,LG,68
+680,Memphis,Jeremiah Carney,FB,68
+680,Memphis,Bobby Washington Jr,LOLB,67
+680,Memphis,Chris Ewald Jr,CB,66
+680,Memphis,Donta Simpson,DT,66
+680,Memphis,Deryc Plazz,LT,66
+680,Memphis,Adrian Guzman,FS,66
+680,Memphis,Jack Nickel,TE,64
+680,Memphis,Dion Morgan,LOLB,63
+680,Memphis,James Pinkston,SS,63
+680,Memphis,Ryan Mack,CB,63
+680,Memphis,Matt Chadwick,QB,60
+680,Memphis,Ny Carr,WR,59
+680,Memphis,Doug Costello,LOLB,55
+681,Miami (FL),Drew Terrill,LT,89
+681,Miami (FL),Eli Blakey,FS,85
+681,Miami (FL),Silas Walters,SS,84
+681,Miami (FL),Nasir Washington,DT,84
+681,Miami (FL),Delvin Ball,LOLB,83
+681,Miami (FL),Dequan Finn,QB,82
+681,Miami (FL),Gregory Smith Jr,LG,82
+681,Miami (FL),Austin Uke,RG,81
+681,Miami (FL),Corban Hondru,ROLB,79
+681,Miami (FL),Jackson Kuwatch,MLB,79
+681,Miami (FL),Oscar Mcwood,LOLB,78
+681,Miami (FL),Andrew Lowry,LG,78
+681,Miami (FL),Lynel Billups Williams,WR,78
+681,Miami (FL),Mychal Yharbrough,SS,77
+681,Miami (FL),Malcolm Mccain,MLB,77
+681,Miami (FL),Brandon Lawhorn Moore,LG,77
+681,Miami (FL),Gavin Rohrs,RG,76
+681,Miami (FL),Deion Colzie,WR,75
+681,Miami (FL),Luke Evans,CB,75
+681,Miami (FL),Malachi Clark,DT,75
+681,Miami (FL),Eric Smith,LT,75
+681,Miami (FL),Jackson Pons,FS,75
+681,Miami (FL),Lucas Barnes,LT,75
+681,Miami (FL),Marcus White,RG,75
+681,Miami (FL),Keith Reynolds,WR,74
+681,Miami (FL),Darion Williamson,WR,74
+681,Miami (FL),Kam Perry,WR,74
+681,Miami (FL),Devin Johnson,SS,74
+681,Miami (FL),Ryan Sims,WR,74
+681,Miami (FL),Jonathan Stangl,LT,74
+681,Miami (FL),Toney Coleman Jr,CB,73
+681,Miami (FL),Kaleb Martin,CB,73
+681,Miami (FL),Ayden Annarino,C,73
+681,Miami (FL),Cordale Russell,WR,72
+681,Miami (FL),Eli Coppess,LOLB,72
+681,Miami (FL),Grant Leeper,TE,72
+681,Miami (FL),Mitchell Butler,RT,72
+681,Miami (FL),Roosevelt Andrews Iii,DT,72
+681,Miami (FL),Brady Simmons,WR,72
+681,Miami (FL),Dom Dzioban,K,71
+681,Miami (FL),Luke Myers,ROLB,71
+681,Miami (FL),Jerome Smith,FS,71
+681,Miami (FL),Kris Manu,C,70
+681,Miami (FL),Henry Hesson,QB,69
+681,Miami (FL),Koy Beasley,CB,69
+681,Miami (FL),Leo Colombi,FS,69
+681,Miami (FL),Jacob Schorsch,RT,69
+681,Miami (FL),Steven Favazzo,SS,69
+681,Miami (FL),Mitch Bolden,TE,68
+681,Miami (FL),Payton Kirkland,RT,67
+681,Miami (FL),Aiden Howard,LT,67
+681,Miami (FL),William Goodvine Iii,DT,66
+681,Miami (FL),Christian Mckinney,ROLB,66
+681,Miami (FL),Thomas Gotkowski,QB,66
+681,Miami (FL),Brody Kosin,TE,65
+681,Miami (FL),Desmon Yharbrough,SS,65
+681,Miami (FL),Isaiah Shields,DT,65
+681,Miami (FL),Brian Shane,TE,65
+681,Miami (FL),Tyler Dikos,MLB,65
+681,Miami (FL),Oyeka Alexander,DT,62
+681,Miami (FL),Austin Ali,FS,60
+681,Miami (FL),Vito Mcconnell,MLB,59
+681,Miami (FL),Harrison Beal,FB,59
+681,Miami (FL),Wyatt Quinn,QB,58
+681,Miami (FL),Braylon Isom,WR,58
+681,Miami (FL),Hudson Powell,TE,58
+681,Miami (FL),Adrian Walker Jr,CB,55
+681,Miami (FL),Carter Holden,P,54
+681,Miami (FL),Michael Popov,RT,54
+681,Miami (FL),Kellan Mclaughlin,K,53
+682,Miami (OH),Rod Moore,FS,92
+682,Miami (OH),Jaishawn Barham,MLB,92
+682,Miami (OH),Giovanni El Hadi,LG,91
+682,Miami (OH),Rayshaun Benny,DT,91
+682,Miami (OH),Evan Link,LT,91
+682,Miami (OH),Mikey Keene,QB,91
+682,Miami (OH),Ernest Hausmann,ROLB,90
+682,Miami (OH),Donaven Mcculley,WR,87
+682,Miami (OH),Zeke Berry,CB,85
+682,Miami (OH),Nathan Efobi,RG,85
+682,Miami (OH),Anthony Simpson,WR,85
+682,Miami (OH),Greg Crippen,C,84
+682,Miami (OH),Damon Payne Jr,DT,84
+682,Miami (OH),Jyaire Hill,CB,83
+682,Miami (OH),Tre Williams,DT,83
+682,Miami (OH),Max Bredeson,FB,82
+682,Miami (OH),Peyton O Leary,WR,82
+682,Miami (OH),Marlin Klein,TE,80
+682,Miami (OH),Caleb Anderson,CB,80
+682,Miami (OH),Trey Pierce,DT,79
+682,Miami (OH),Jaden Mangham,FS,79
+682,Miami (OH),Davis Warren,QB,79
+682,Miami (OH),Tj Metcalf,SS,78
+682,Miami (OH),Troy Bowles,ROLB,78
+682,Miami (OH),Lawrence Hattar,LG,78
+682,Miami (OH),Jimmy Rolder,MLB,77
+682,Miami (OH),Brandyn Hillman,SS,76
+682,Miami (OH),Semaj Morgan,WR,76
+682,Miami (OH),Jaydon Hood,ROLB,76
+682,Miami (OH),Andrew Sprague,RT,75
+682,Miami (OH),Fredrick Moore,WR,75
+682,Miami (OH),Ty Haywood,LT,74
+682,Miami (OH),Nathaniel Owusu Boateng,ROLB,74
+682,Miami (OH),Kendrick Bell,WR,74
+682,Miami (OH),Jordan Young,FS,73
+682,Miami (OH),Jalen Hoffman,FB,73
+682,Miami (OH),Jayden Sanders,CB,73
+682,Miami (OH),Dominic Zvada,K,72
+682,Miami (OH),Andrew Babalola,LT,72
+682,Miami (OH),Shamari Earls,CB,72
+682,Miami (OH),Zander Grant,SS,72
+682,Miami (OH),Avery Gach,LG,72
+682,Miami (OH),Zack Marshall,TE,72
+682,Miami (OH),Kaden Strayhorn,C,72
+682,Miami (OH),Luke Hamilton,RG,71
+682,Miami (OH),Mason Curtis,CB,71
+682,Miami (OH),I Marion Stewart,WR,71
+682,Miami (OH),Brady Morgan,TE,71
+682,Miami (OH),Jadyn Davis,QB,70
+682,Miami (OH),Hogan Hansen,TE,69
+682,Miami (OH),Eli Owens,FB,67
+682,Miami (OH),Chase Taylor,LOLB,67
+682,Miami (OH),Zach Ludwig,MLB,67
+682,Miami (OH),Jo Ziah Edmond,CB,66
+682,Miami (OH),Bobby Kanka,DT,66
+682,Miami (OH),Brett Sykes,P,66
+682,Miami (OH),Bryce Underwood,QB,65
+682,Miami (OH),Andrew Marsh,WR,65
+682,Miami (OH),Jake Guarnera,C,65
+682,Miami (OH),Jamar Browder,WR,64
+682,Miami (OH),Chase Herbstreit,QB,64
+682,Miami (OH),Blake Frazier,RT,63
+682,Miami (OH),Connor Jones,LT,62
+682,Miami (OH),Luke Bauer,P,61
+682,Miami (OH),Tevis Metcalf,CB,61
+682,Miami (OH),Ike Iwunnah,DT,60
+682,Miami (OH),Brady Prieskorn,TE,60
+682,Miami (OH),Stuart Blake,K,60
+682,Miami (OH),Jacob Oden,FS,55
+682,Miami (OH),Cole Sullivan,MLB,50
+682,Miami (OH),Trent Tucker,RT,50
+683,Michigan,Jack Velling,TE,88
+683,Michigan,Chrishon Mccray,WR,87
+683,Michigan,Grady Kelly,DT,87
+683,Michigan,Cam Williams,LOLB,86
+683,Michigan,Omari Kelly,WR,85
+683,Michigan,Matt Gulbin,C,85
+683,Michigan,Nikai Martinez,SS,84
+683,Michigan,Conner Moore,RT,84
+683,Michigan,Malcolm Bell,CB,84
+683,Michigan,Wayne Matthews Iii,ROLB,83
+683,Michigan,Rodney Bullard Jr,WR,83
+683,Michigan,Alante Brown,WR,83
+683,Michigan,Kristian Phillips,LG,83
+683,Michigan,Darius Snow,LOLB,83
+683,Michigan,Jalen Satchell,DT,83
+683,Michigan,Luka Vincic,RG,82
+683,Michigan,Caleb Carter,RG,82
+683,Michigan,Evan Boyd,WR,81
+683,Michigan,Aisea Moa,ROLB,81
+683,Michigan,Aidan Chiles,QB,80
+683,Michigan,Jordan Hall,MLB,80
+683,Michigan,Malik Spencer,FS,79
+683,Michigan,Chance Rucker,CB,79
+683,Michigan,Devynn Cromwell,CB,79
+683,Michigan,Nick Marsh,WR,78
+683,Michigan,Tracy Revels,FS,78
+683,Michigan,Ru Quan Buckley,DT,78
+683,Michigan,Alex Vansumeren,DT,77
+683,Michigan,Brennan Parachek,TE,77
+683,Michigan,Gavin Broscious,LG,77
+683,Michigan,Stanton Ramil,LT,76
+683,Michigan,Michael Chase Sanders,CB,76
+683,Michigan,Khalil Majeed,FS,76
+683,Michigan,Cooper Terpstra,C,76
+683,Michigan,Sam Edwards,MLB,76
+683,Michigan,Michael Masunas,TE,75
+683,Michigan,Ade Willie,CB,75
+683,Michigan,Joshua Eaton,CB,74
+683,Michigan,Jeremiah Hughes,CB,74
+683,Michigan,Dontavius Nash,SS,74
+683,Michigan,Ben Roberts,DT,73
+683,Michigan,Semaj Bridgeman,LOLB,73
+683,Michigan,Ben Nelson,DT,72
+683,Michigan,Aydan West,CB,71
+683,Michigan,Rakeem Johnson,RG,71
+683,Michigan,Chris Piwowarczyk,LOLB,71
+683,Michigan,Ryan Eckley,P,70
+683,Michigan,Braylon Collier,WR,70
+683,Michigan,Marcellius Pulliam,MLB,70
+683,Michigan,Alessio Milivojevic,QB,70
+683,Michigan,Ryland Jessee,QB,70
+683,Michigan,Armorion Smith,FS,69
+683,Michigan,Jay Coyne,FB,69
+683,Michigan,Aveon Grose,SS,69
+683,Michigan,Ashton Lepo,RT,68
+683,Michigan,Brady Pretzlaff,ROLB,68
+683,Michigan,Dane Drexel,MLB,68
+683,Michigan,Justin Denson Jr,SS,67
+683,Michigan,Travis Herzogg,ROLB,66
+683,Michigan,Kaden Schickel,TE,65
+683,Michigan,Leo Hannan,QB,64
+683,Michigan,Tarik Ahmetbasic,K,64
+683,Michigan,Martin Connington,K,62
+683,Michigan,Will Mcmullins,RG,61
+683,Michigan,Temar Williams,C,61
+683,Michigan,Andrew Dennis,LG,59
+683,Michigan,Cole Dellinger,C,57
+683,Michigan,Charlton Luniewski,RT,56
+683,Michigan,Carson Voss,P,55
+683,Michigan,Mercer Luniewski,LT,53
+683,Michigan,Payton Stewart,LT,49
+683,Michigan,Rustin Young,LT,45
+684,Michigan State,Nicholas Vattiato,QB,86
+684,Michigan State,Myles Butler,WR,84
+684,Michigan State,Marcus Miller,LT,84
+684,Michigan State,John Howse Iv,FS,83
+684,Michigan State,Damonte Smith,DT,83
+684,Michigan State,Mateo Guevara,LG,83
+684,Michigan State,Aj Jones,WR,83
+684,Michigan State,Parker Hughes,ROLB,82
+684,Michigan State,Aaren Alexander,C,80
+684,Michigan State,Shakai Woods,DT,79
+684,Michigan State,Brendon Harris,SS,79
+684,Michigan State,Rickey Smith,FS,79
+684,Michigan State,Ellis Adams,LG,79
+684,Michigan State,De Arre Mcdonald,CB,79
+684,Michigan State,Kaiden Mitchell,FS,79
+684,Michigan State,Brian Brewton,WR,79
+684,Michigan State,Orlando Williams,SS,78
+684,Michigan State,Jalen Mckee,FS,78
+684,Michigan State,Juwon Gaston,CB,77
+684,Michigan State,Ikani Tuiono,C,77
+684,Michigan State,Isaac Rue,RG,77
+684,Michigan State,Cam Ron Lacy,WR,76
+684,Michigan State,Abdul Muhammad,CB,76
+684,Michigan State,Quentin Butler,C,76
+684,Michigan State,E J Harris,RG,75
+684,Michigan State,Felix Hixon,DT,75
+684,Michigan State,Jared Douglas,SS,75
+684,Michigan State,Derek Pitts,MLB,75
+684,Michigan State,Slade Alexander,TE,75
+684,Michigan State,Kenny Green,MLB,75
+684,Michigan State,Hunter Tipton,TE,75
+684,Michigan State,Tyree Patterson,WR,75
+684,Michigan State,Amorion Walker,WR,74
+684,Michigan State,Evan Poticher,TE,74
+684,Michigan State,Zach Clayton,LT,74
+684,Michigan State,Joseph Habinowski,LG,73
+684,Michigan State,Mathias Malaki Donaldson,LOLB,73
+684,Michigan State,Diego Blattler,RT,73
+684,Michigan State,Connor Dougherty,TE,72
+684,Michigan State,Korey Smith,MLB,72
+684,Michigan State,Trevon Ferrell,CB,71
+684,Michigan State,Tayvion Galloway,TE,71
+684,Michigan State,Davonte Lawrence,WR,71
+684,Michigan State,Ja Darious Morris,DT,71
+684,Michigan State,Marcus Pettis,CB,70
+684,Michigan State,Damion Savage,CB,70
+684,Michigan State,Brody Benke,TE,70
+684,Michigan State,Malik Love,LOLB,70
+684,Michigan State,Delonte Black,FS,69
+684,Michigan State,Tyler Cooper,RT,69
+684,Michigan State,Roman Gagliano,QB,69
+684,Michigan State,Chayce Smith,DT,69
+684,Michigan State,Ashton Logan,P,68
+684,Michigan State,Amarrien Bailey,ROLB,67
+684,Michigan State,Nate Herron,RG,67
+684,Michigan State,Jackson Lowe,CB,65
+684,Michigan State,Alex Gale,LG,65
+684,Michigan State,Keiwone Hilliard,CB,64
+684,Michigan State,Henry Hamlin,TE,64
+684,Michigan State,Aden Caine,P,63
+684,Michigan State,Kason Stokes,WR,62
+684,Michigan State,Demetrious Lucas,ROLB,62
+684,Michigan State,Stanley Anderson Lofton,QB,60
+684,Michigan State,Cole Simmons,LT,60
+684,Michigan State,Jeremy Tracy,LG,59
+684,Michigan State,Andy Peterson,K,59
+684,Michigan State,Dustyn Peters,FB,59
+684,Michigan State,Marlon Robinson,DT,57
+684,Michigan State,Kyle Larkin,LT,55
+684,Michigan State,Jordan Beasley,FS,55
+684,Michigan State,Zach Benedict,K,53
+684,Michigan State,Jacob Taylor,K,47
+685,Middle Tennessee,Daniel King,RG,92
+685,Middle Tennessee,Will O Steen,LT,89
+685,Middle Tennessee,Andrew Simpson,MLB,87
+685,Middle Tennessee,Thaddeus Dixon,CB,86
+685,Middle Tennessee,Kobe Paysour,WR,86
+685,Middle Tennessee,Chad Lindberg,LG,85
+685,Middle Tennessee,Marcus Allen,CB,85
+685,Middle Tennessee,Austin Blaske,C,84
+685,Middle Tennessee,Jakai Moore,RG,84
+685,Middle Tennessee,Trevyon Green,LT,84
+685,Middle Tennessee,Gio Lopez,QB,83
+685,Middle Tennessee,Kaleb Cost,CB,83
+685,Middle Tennessee,Will Hardy,FS,83
+685,Middle Tennessee,Mikai Gbayor,ROLB,83
+685,Middle Tennessee,Chris Culliver,WR,83
+685,Middle Tennessee,Cj Mims,DT,82
+685,Middle Tennessee,Max Johnson,QB,82
+685,Middle Tennessee,Paris Burroughs,FB,82
+685,Middle Tennessee,Gavin Gibson,SS,81
+685,Middle Tennessee,Jake Johnson,TE,80
+685,Middle Tennessee,Miles Mcvay,LT,80
+685,Middle Tennessee,Caleb Stepper,RT,79
+685,Middle Tennessee,Coleman Bryson,FS,78
+685,Middle Tennessee,Aziah Johnson,WR,77
+685,Middle Tennessee,Khmori House,LOLB,77
+685,Middle Tennessee,D Antre Robinson,DT,77
+685,Middle Tennessee,Christo Kelly,C,77
+685,Middle Tennessee,Jordan Shipp,WR,76
+685,Middle Tennessee,Kevin Kellwood,SS,75
+685,Middle Tennessee,Isaiah Johnson,DT,75
+685,Middle Tennessee,William Boone,RT,75
+685,Middle Tennessee,Jordan Owens,TE,75
+685,Middle Tennessee,Ken Whittington,DT,75
+685,Middle Tennessee,Gibson Macrae,ROLB,75
+685,Middle Tennessee,Paul Billups Ii,WR,75
+685,Middle Tennessee,Bo Burkes,C,74
+685,Middle Tennessee,Nathan Leacock,WR,73
+685,Middle Tennessee,Gregory Smith Iii,SS,73
+685,Middle Tennessee,Adrian Wilson,WR,73
+685,Middle Tennessee,Aidan Banfield,LG,73
+685,Middle Tennessee,Evan Bennett,MLB,72
+685,Middle Tennessee,Tyler Chambers,QB,71
+685,Middle Tennessee,Cade Law,MLB,71
+685,Middle Tennessee,Shamar Easter,TE,70
+685,Middle Tennessee,Deandrew Clark,QB,70
+685,Middle Tennessee,Connor Cox,TE,70
+685,Middle Tennessee,Gannon Burt,TE,70
+685,Middle Tennessee,Bryce Baker,QB,68
+685,Middle Tennessee,Tom Maginness,P,67
+685,Middle Tennessee,Rece Verhoff,K,66
+685,Middle Tennessee,Melvin Winborn,LOLB,66
+685,Middle Tennessee,Tyler Houser,ROLB,66
+685,Middle Tennessee,Timir Hickman Collins,MLB,66
+685,Middle Tennessee,Peter Pesansky,DT,66
+685,Middle Tennessee,Jani Norwood,RT,66
+685,Middle Tennessee,Javarius Green,WR,65
+685,Middle Tennessee,Malcolm Ziglar,SS,63
+685,Middle Tennessee,Jaiden Patterson,SS,63
+685,Middle Tennessee,Peyton Waters,FS,63
+685,Middle Tennessee,Byron Nelson,RG,63
+685,Middle Tennessee,Javion Butts,SS,63
+685,Middle Tennessee,Garrett Maddox,P,63
+685,Middle Tennessee,Spencer Triplett,TE,63
+685,Middle Tennessee,Alex Taylor,WR,62
+685,Middle Tennessee,Ladell Grant,DT,61
+685,Middle Tennessee,Jason Robinson Jr,WR,61
+685,Middle Tennessee,Jalon Thompson,CB,60
+685,Middle Tennessee,Ty Adams,CB,58
+685,Middle Tennessee,Khristian Dunbar Hawkins,FS,58
+685,Middle Tennessee,Eric Foote,K,57
+685,Middle Tennessee,Khalil Conley,CB,56
+685,Middle Tennessee,Luke Masterson,LT,54
+685,Middle Tennessee,Nate Houston,LG,53
+695,North Carolina,Jacob Finley,CB,83
+695,North Carolina,Jake Gassaway,ROLB,83
+695,North Carolina,Quinn Urwiler,MLB,80
+695,North Carolina,Dane Pardridge,WR,80
+695,North Carolina,Evan Malcore,LT,79
+695,North Carolina,La Don Bryant,WR,78
+695,North Carolina,Izuchukwu Ozoh,LT,78
+695,North Carolina,Dan Mccann,ROLB,78
+695,North Carolina,Kenji Lewis,WR,78
+695,North Carolina,Kenny Fletcher,LT,78
+695,North Carolina,Marc Pretto,MLB,77
+695,North Carolina,Jake Appleget,TE,76
+695,North Carolina,Jalen Macon,QB,76
+695,North Carolina,Cyrus Mcgarrell,FS,76
+695,North Carolina,Gary Givens Iii,WR,76
+695,North Carolina,Muhammed Jammeh,SS,75
+695,North Carolina,Josh Holst,QB,75
+695,North Carolina,Trey Porter,FS,75
+695,North Carolina,Donte Harrison,CB,75
+695,North Carolina,Dearee Rogers,WR,75
+695,North Carolina,Alvin Gulley Jr,DT,75
+695,North Carolina,George Dimopoulos,WR,75
+695,North Carolina,Brody Windham,SS,75
+695,North Carolina,Michael Jimmar,C,75
+695,North Carolina,Dasean Dixon,DT,74
+695,North Carolina,Thomas Paasch,RT,74
+695,North Carolina,Jasper Beeler,FS,73
+695,North Carolina,Abiathar Curry,RG,73
+695,North Carolina,Ty Myles,CB,73
+695,North Carolina,Jacob Welch,LG,73
+695,North Carolina,Taylor Powell,SS,72
+695,North Carolina,Kj Mcrae,ROLB,72
+695,North Carolina,Mark Hensley,DT,71
+695,North Carolina,Malik Armstrong,CB,71
+695,North Carolina,Logan Gross,LT,71
+695,North Carolina,Luke Skartvedt,RG,71
+695,North Carolina,T J Skaggs,RG,71
+695,North Carolina,Ross Liegel,LG,71
+695,North Carolina,Filip Maciorowski,LOLB,70
+695,North Carolina,Lane Mahnesmith,LG,70
+695,North Carolina,Miles Thompson,CB,69
+695,North Carolina,Brady Davidson,QB,69
+695,North Carolina,Jonathan Snowden,RG,68
+695,North Carolina,Andrew Glass,K,67
+695,North Carolina,Reggie Jean,DT,67
+695,North Carolina,Rickey Taylor Jr,WR,67
+695,North Carolina,Ben Gustafson,RT,67
+695,North Carolina,A J Mims,FB,67
+695,North Carolina,Tyler Mitchell,MLB,66
+695,North Carolina,Landon Hron,C,66
+695,North Carolina,Deveon Shaw,LOLB,65
+695,North Carolina,Dev Ion Reynolds,CB,65
+695,North Carolina,R J Mccullers,LOLB,64
+695,North Carolina,Jeff Gibson,QB,64
+695,North Carolina,Bryon Morrow,TE,62
+695,North Carolina,Jordan Bellamy,DT,61
+695,North Carolina,Timothy Rasmussen,TE,60
+695,North Carolina,Aidan Macqueen,TE,60
+695,North Carolina,Montrel Canion,DT,60
+695,North Carolina,Karl Swayne,MLB,59
+695,North Carolina,Desean Middlebrooks,CB,59
+695,North Carolina,Conor Kennedy,TE,59
+695,North Carolina,Mitch Drew,TE,59
+695,North Carolina,Nick Mooney,K,58
+695,North Carolina,Gavin Weston,C,58
+695,North Carolina,Thomas Mccoy,WR,56
+695,North Carolina,Danny Vuckovic,P,52
+695,North Carolina,Jake Seibert,K,46
+697,Northern Illinois,Johnny Dickson Iii,LG,89
+697,Northern Illinois,Dalton Carnes,WR,85
+697,Northern Illinois,Simeon Evans,WR,84
+697,Northern Illinois,Shane Whitter,LOLB,84
+697,Northern Illinois,Reese Poffenbarger,QB,84
+697,Northern Illinois,Jimto Obidegwu,LT,84
+697,Northern Illinois,Gabe Blair,C,83
+697,Northern Illinois,Evan Jackson,FS,83
+697,Northern Illinois,Landon Sides,WR,83
+697,Northern Illinois,David Fisher,CB,82
+697,Northern Illinois,Fatafehi Vailea Ii,DT,81
+697,Northern Illinois,Jackson Lataimua,SS,81
+697,Northern Illinois,Richard Outland Jr,DT,81
+697,Northern Illinois,Ethan Wesloski,ROLB,80
+697,Northern Illinois,Xzavior Kautai,ROLB,80
+697,Northern Illinois,Da Veawn Armstead,CB,79
+697,Northern Illinois,Trey Fields,MLB,79
+697,Northern Illinois,Christian Pettway,RT,79
+697,Northern Illinois,Cameron Dorner,WR,78
+697,Northern Illinois,Miles Coleman,WR,77
+697,Northern Illinois,Chase Canada,CB,77
+697,Northern Illinois,Kevin Jensen,LT,77
+697,Northern Illinois,Braydon Nelson,RT,76
+697,Northern Illinois,Tre Williams Iii,TE,76
+697,Northern Illinois,Keon Johnson,RT,76
+697,Northern Illinois,Jaren Wheaton,WR,76
+697,Northern Illinois,Quinton Hammonds,SS,75
+697,Northern Illinois,Jaymon Lamb,RT,75
+697,Northern Illinois,Drew Mestemaker,QB,75
+697,Northern Illinois,Bj Allen Jr,FS,74
+697,Northern Illinois,Will Jones Ii,CB,74
+697,Northern Illinois,Taylor Starling,CB,73
+697,Northern Illinois,Patrick Smith Young,SS,73
+697,Northern Illinois,Ugonna Nnanna,RG,73
+697,Northern Illinois,Jayden Williams,DT,73
+697,Northern Illinois,Kamdon Mcfarland,FS,72
+697,Northern Illinois,Kenton Allen,LOLB,72
+697,Northern Illinois,S Maje Burrell,ROLB,71
+697,Northern Illinois,Larry Moore Iii,LT,71
+697,Northern Illinois,Tyrane Stewart,CB,71
+697,Northern Illinois,Kollin Lewis,CB,71
+697,Northern Illinois,Tay Yanta,C,70
+697,Northern Illinois,Julio Madero Iv,LG,70
+697,Northern Illinois,Brandon Young Jr,TE,70
+697,Northern Illinois,Sawyer Evans,P,69
+697,Northern Illinois,Jj Jean Louis,LOLB,69
+697,Northern Illinois,Juwan Swayne,LOLB,69
+697,Northern Illinois,Willie Goodacre,RG,69
+697,Northern Illinois,Blake Fann,MLB,69
+697,Northern Illinois,Kyle Koch,WR,69
+697,Northern Illinois,Julian Knox,FS,68
+697,Northern Illinois,Jason Homewood,LOLB,68
+697,Northern Illinois,Isaiah Collins,CB,67
+697,Northern Illinois,Jaydon Smith,FS,65
+697,Northern Illinois,Victor Aderungboye,TE,65
+697,Northern Illinois,Connor Vaughn,TE,64
+697,Northern Illinois,Brenden Reese,MLB,64
+697,Northern Illinois,Kali Nguma,K,63
+697,Northern Illinois,Gabe Stroud,CB,62
+697,Northern Illinois,Dylan Shaw,LG,60
+697,Northern Illinois,Mack Highsmith,FB,59
+697,Northern Illinois,Phillip Firth,RG,58
+697,Northern Illinois,Caden Yates,TE,58
+697,Northern Illinois,Brandon Jarrett,C,56
+697,Northern Illinois,Jaden Manning,MLB,56
+697,Northern Illinois,Shandon King,WR,56
+697,Northern Illinois,Chris Jimerson Jr,QB,54
+697,Northern Illinois,Desmond Magiya,LT,54
+697,Northern Illinois,Anthony Buchanan,LT,52
+697,Northern Illinois,Lucas Fischer,K,48
+696,North Texas,Caleb Tiernan,LT,91
+696,North Texas,Preston Stone,QB,87
+696,North Texas,Jack Bailey,C,86
+696,North Texas,Frank Covey Iv,WR,86
+696,North Texas,Mac Uihlein,ROLB,85
+696,North Texas,Miguel Jackson,DT,84
+696,North Texas,Jack Lausch,QB,84
+696,North Texas,Braeden Edwards,LT,84
+696,North Texas,Josh Fussell,CB,83
+696,North Texas,Najee Story,DT,83
+696,North Texas,Martes Lewis,LG,83
+696,North Texas,Robert Fitzgerald,FS,82
+696,North Texas,Xavior Gray,RT,82
+696,North Texas,Carmine Bastone,DT,82
+696,North Texas,Yanni Karlaftis,MLB,82
+696,North Texas,Jack Sadowsky V,MLB,80
+696,North Texas,Ore Adeyi,CB,79
+696,North Texas,Jackson Carsello,C,79
+696,North Texas,Damon Walters,FS,78
+696,North Texas,Evan Smith,CB,77
+696,North Texas,Braydon Brus,ROLB,77
+696,North Texas,Griffin Wilde,WR,77
+696,North Texas,Matt Keeler,LT,76
+696,North Texas,Hunter Welcing,TE,76
+696,North Texas,Matt Walden,RG,76
+696,North Texas,Braden Turner,CB,75
+696,North Texas,Dillon Tatum,SS,75
+696,North Texas,Dante Wallace,QB,75
+696,North Texas,Anthony Birsa,RG,75
+696,North Texas,Aidan Gray,QB,75
+696,North Texas,Brendan Flakes,DT,75
+696,North Texas,Nick Herzog,RG,74
+696,North Texas,Nigel Glover,MLB,74
+696,North Texas,Mason Mayne,DT,74
+696,North Texas,Alphonso Peters,RT,74
+696,North Texas,Drew Wagner,WR,74
+696,North Texas,Garner Wallace,SS,73
+696,North Texas,Bradley Truman,TE,73
+696,North Texas,Jack Olsen,K,72
+696,North Texas,Talan Chandler,C,72
+696,North Texas,Ryan Boe,QB,72
+696,North Texas,Alex Falk,P,71
+696,North Texas,Tito Williams Jr,FS,71
+696,North Texas,Chase Farrell,WR,71
+696,North Texas,Camp Magee,TE,71
+696,North Texas,Tyler Gant,DT,71
+696,North Texas,Matthew Smith,LOLB,71
+696,North Texas,Simon Silva,LG,70
+696,North Texas,Lawson Albright,TE,69
+696,North Texas,Trae Barclay,TE,69
+696,North Texas,Josh Veldman,MLB,69
+696,North Texas,Hunter Mcalister,FB,69
+696,North Texas,Luke Akers,P,68
+696,North Texas,Ricky Ahumaraeze,WR,68
+696,North Texas,Cole Shivers,CB,68
+696,North Texas,Emmett Kerr,FB,68
+696,North Texas,Jason Reynolds Ii,LOLB,67
+696,North Texas,Dylan Roberts,DT,67
+696,North Texas,Jack Florentine,TE,67
+696,North Texas,Hayden Eligon Ii,WR,65
+696,North Texas,Trey Boyd,LG,64
+696,North Texas,Jonathan Stevens,FS,64
+696,North Texas,Deuce Mcguire,RT,63
+696,North Texas,Manny Gunn,CB,60
+696,North Texas,Dube Enongene,WR,59
+696,North Texas,Dennis Rahouski,RG,59
+696,North Texas,Braden Blueitt,WR,58
+696,North Texas,Sean Martin,SS,58
+696,North Texas,Will Barden,RT,54
+696,North Texas,Timi Oke,CB,50
+696,North Texas,Ezomo Oratokhai,LG,49
+698,Northwestern,Leonard Moore,CB,93
+698,Northwestern,Billy Schrauth,LG,93
+698,Northwestern,Aamil Wagner,RT,91
+698,Northwestern,Malachi Fields,WR,91
+698,Northwestern,Drayk Bowen,MLB,90
+698,Northwestern,Will Pauling,WR,90
+698,Northwestern,Ashton Craig,C,88
+698,Northwestern,Christian Gray,CB,87
+698,Northwestern,Jason Onye,DT,87
+698,Northwestern,Luke Talich,FS,86
+698,Northwestern,Jaden Greathouse,WR,85
+698,Northwestern,Adon Shuler,SS,85
+698,Northwestern,Jared Dawson,DT,85
+698,Northwestern,Anthonie Knapp,LT,84
+698,Northwestern,Jordan Faison,WR,84
+698,Northwestern,Jaylen Sneed,ROLB,83
+698,Northwestern,Jalen Stroman,FS,83
+698,Northwestern,Eli Raridon,TE,82
+698,Northwestern,Donovan Hinish,DT,82
+698,Northwestern,Charles Jagusah,RG,80
+698,Northwestern,Kyngstonn Viliamu Asa,MLB,80
+698,Northwestern,Sedrick Hatcher,FB,80
+698,Northwestern,Styles Prescod,LT,79
+698,Northwestern,Chris Terek,RG,78
+698,Northwestern,Chance Tucker,CB,78
+698,Northwestern,Devonta Smith,CB,77
+698,Northwestern,Cooper Flanagan,TE,77
+698,Northwestern,Kenny Minchey,QB,77
+698,Northwestern,Kevin Bauman,TE,75
+698,Northwestern,Sullivan Absher,LG,75
+698,Northwestern,Teddy Rezac,LOLB,75
+698,Northwestern,Xavier Pate,RT,74
+698,Northwestern,Cj Carr,QB,73
+698,Northwestern,Elijah Hughes,DT,73
+698,Northwestern,Josiah Spivey,CB,73
+698,Northwestern,Bradley Sykes,WR,73
+698,Northwestern,Jaiden Ausberry,LOLB,73
+698,Northwestern,Kk Smith,WR,73
+698,Northwestern,Derek Walker,QB,72
+698,Northwestern,Darry Robinson,CB,72
+698,Northwestern,Kahanu Kia,LOLB,72
+698,Northwestern,Guerby Lambert,RT,71
+698,Northwestern,Jamari O Neal,ROLB,71
+698,Northwestern,Andrew Kros,TE,71
+698,Northwestern,Joseph Lorriga,RT,70
+698,Northwestern,Sergio Suggs,FS,70
+698,Northwestern,Sean Sevillano Jr,DT,70
+698,Northwestern,Bodie Kahoun,MLB,70
+698,Northwestern,Noah Burnette,K,69
+698,Northwestern,Joseph Vinci,TE,69
+698,Northwestern,Aric Martin,DT,68
+698,Northwestern,Cam Williams,WR,67
+698,Northwestern,Trenton Abraham,LOLB,67
+698,Northwestern,Peter Jones,LG,67
+698,Northwestern,Jason Helton,SS,67
+698,Northwestern,Matthew Cottrell,LT,66
+698,Northwestern,Ben Minich,FS,66
+698,Northwestern,Micah Gilbert,WR,66
+698,Northwestern,Karson Hobbs,CB,66
+698,Northwestern,Gabe Gustafson,ROLB,65
+698,Northwestern,Preston Zinter,MLB,65
+698,Northwestern,James Rendell,P,64
+698,Northwestern,Victor Vinson,FS,64
+698,Northwestern,Ty Washington,TE,63
+698,Northwestern,Bobby Barden,SS,62
+698,Northwestern,Kyle Leeto,C,61
+698,Northwestern,Joe Otting,C,58
+698,Northwestern,Robb Cramer,RG,57
+698,Northwestern,Jack Larsen,TE,56
+698,Northwestern,Marcello Diomede,K,55
+699,Notre Dame,Davion Weatherspoon,LT,87
+699,Notre Dame,Trent Allen,RG,84
+699,Notre Dame,Caleb Gossett,WR,84
+699,Notre Dame,Dj Walker,FS,83
+699,Notre Dame,Adonis Williams Jr,SS,83
+699,Notre Dame,Rodney Harris Ii,WR,83
+699,Notre Dame,Michael Mack Ii,CB,82
+699,Notre Dame,Parker Navarro,QB,81
+699,Notre Dame,Tank Pearson,CB,81
+699,Notre Dame,Miles Fleming,FS,81
+699,Notre Dame,Austin Mitchell,DT,81
+699,Notre Dame,Nehemiah Dukes,DT,80
+699,Notre Dame,Eamonn Dennis,WR,80
+699,Notre Dame,Eian Pugh,WR,80
+699,Notre Dame,Jordon Jones,RT,80
+699,Notre Dame,Jalen Thomeson,FS,79
+699,Notre Dame,Mason Williams,TE,79
+699,Notre Dame,Andres Dewerk,LT,79
+699,Notre Dame,Josh Waite,LG,79
+699,Notre Dame,Jarian Shelby,RT,79
+699,Notre Dame,Chase Hendricks,WR,78
+699,Notre Dame,Bryce Parson,LG,78
+699,Notre Dame,Jaylen Johnson,SS,77
+699,Notre Dame,Chad Wharton,TE,77
+699,Notre Dame,Nathan Hale,DT,77
+699,Notre Dame,Max Rodarte,WR,77
+699,Notre Dame,Jt Haskins,CB,76
+699,Notre Dame,Jack Fries,MLB,76
+699,Notre Dame,Jakob Lemus,RT,76
+699,Notre Dame,Pius Odjugo,DT,75
+699,Notre Dame,Jake Bruno,TE,75
+699,Notre Dame,Tony Mathis,CB,75
+699,Notre Dame,Jaymar Mundy,CB,75
+699,Notre Dame,Michael Molnar,ROLB,75
+699,Notre Dame,Tigana Cisse,RG,75
+699,Notre Dame,Alfred Jordan Jr,WR,74
+699,Notre Dame,Pierre Kemeni Jr,CB,74
+699,Notre Dame,Dj Morton,FS,73
+699,Notre Dame,Kam Wright,C,73
+699,Notre Dame,Rickey Hyatt Jr,SS,72
+699,Notre Dame,Andrew Vera,SS,72
+699,Notre Dame,Desean Goldsberry,QB,72
+699,Notre Dame,Colton Grover,WR,72
+699,Notre Dame,Jasen Kelly,ROLB,72
+699,Notre Dame,Aidan Johnson,RG,71
+699,Notre Dame,Kendall Bannister,CB,71
+699,Notre Dame,Nick Poulos,QB,70
+699,Notre Dame,Dom Dorwart,WR,70
+699,Notre Dame,Rj Keuchler,DT,70
+699,Notre Dame,Tyler Jackson,DT,69
+699,Notre Dame,Kyree Henderson,C,68
+699,Notre Dame,Dominic Konopka,TE,68
+699,Notre Dame,Ben Maldonado,LG,68
+699,Notre Dame,Ryan Matheny,ROLB,68
+699,Notre Dame,Owen Difranco,LOLB,68
+699,Notre Dame,Julian Leverette,FB,66
+699,Notre Dame,Charlie Christopher,MLB,66
+699,Notre Dame,Johnathan Schroeder,P,65
+699,Notre Dame,Brady Sestili,LOLB,65
+699,Notre Dame,Nick Segarra,TE,64
+699,Notre Dame,Jeremy Richards,CB,64
+699,Notre Dame,Aj Miller,TE,64
+699,Notre Dame,Hugh Gibson,LOLB,63
+699,Notre Dame,Juan Davidson,DT,63
+699,Notre Dame,Callum Bruce,MLB,62
+699,Notre Dame,Jake Skelly,LT,60
+699,Notre Dame,Brett Campbell,LT,60
+699,Notre Dame,Jacob Winters,QB,56
+699,Notre Dame,Lukas Stiles,ROLB,56
+699,Notre Dame,David Dellenbach,K,53
+699,Notre Dame,Tim Carpenter,QB,46
+699,Notre Dame,Alex Kasee,K,46
+699,Notre Dame,Tevin Ward,CB,45
+700,Ohio,Jeremiah Smith,WR,98
+700,Ohio,Caleb Downs,FS,96
+700,Ohio,Carnell Tate,WR,91
+700,Ohio,Max Klare,TE,91
+700,Ohio,Davison Igbinosun,CB,90
+700,Ohio,Sonny Styles,ROLB,90
+700,Ohio,Arvell Reese,MLB,90
+700,Ohio,Carson Hinzman,C,88
+700,Ohio,Jermaine Mathews Jr,CB,87
+700,Ohio,Ethan Onianwa,LT,87
+700,Ohio,Lorenzo Styles Jr,CB,86
+700,Ohio,Will Kacmarek,TE,84
+700,Ohio,Phillip Daniels,RT,82
+700,Ohio,Tywone Malone Jr,DT,81
+700,Ohio,Brandon Inniss,WR,80
+700,Ohio,Austin Siereveld,RT,80
+700,Ohio,Julian Sayin,QB,79
+700,Ohio,Bennett Christian,TE,79
+700,Ohio,Bryan Wells,LOLB,79
+700,Ohio,Eddrick Houston,DT,78
+700,Ohio,Jelani Thurman,TE,77
+700,Ohio,Lincoln Kienholz,QB,77
+700,Ohio,Tegra Tshabola,RG,77
+700,Ohio,Keenan Nelson Jr,SS,76
+700,Ohio,Malik Hartford,SS,75
+700,Ohio,Bryson Rodgers,WR,75
+700,Ohio,Kayden Mcdonald,DT,74
+700,Ohio,Payton Pierce,MLB,74
+700,Ohio,De Zie Jones,WR,74
+700,Ohio,Kaleb Gaffney,FS,73
+700,Ohio,Quincy Porter,WR,73
+700,Ohio,Jason Moore,DT,73
+700,Ohio,Nate Roberts,TE,73
+700,Ohio,Mylan Graham,WR,72
+700,Ohio,Garrett Stover,ROLB,72
+700,Ohio,Tarvos Alford,ROLB,72
+700,Ohio,Bodpegn Miller,WR,72
+700,Ohio,Jake Cook,LG,72
+700,Ohio,Jaylen Mcclain,SS,71
+700,Ohio,Justin Grimes Iii,CB,71
+700,Ohio,Deontae Armstrong,RT,71
+700,Ohio,Luke Montgomery,LG,70
+700,Ohio,Julian Goines Jackson,RG,70
+700,Ohio,Tavien St Clair,QB,69
+700,Ohio,Carter Lowe,LT,69
+700,Ohio,Riley Pettijohn,ROLB,69
+700,Ohio,Trajen Odom,DT,69
+700,Ohio,Cody Haddad,SS,69
+700,Ohio,John Ferlmann,TE,69
+700,Ohio,Bryce West,CB,68
+700,Ohio,Joshua Padilla,C,68
+700,Ohio,Maxence Leblanc,TE,68
+700,Ohio,Trayvon Fuller,CB,67
+700,Ohio,Deshawn Stewart,FS,67
+700,Ohio,Aaron Scott Jr,CB,65
+700,Ohio,Joe Mcguire,P,65
+700,Ohio,Jarquez Carter,DT,65
+700,Ohio,Blake Carney,MLB,64
+700,Ohio,Anthony Venneri,P,63
+700,Ohio,Jayden Fielding,K,62
+700,Ohio,Jackson Courville,K,61
+700,Ohio,Ryan Wesley,FB,61
+700,Ohio,Leroy Roker Iii,FS,61
+700,Ohio,Miles Lockhart,CB,57
+700,Ohio,Christopher Mclaughlin,RG,56
+700,Ohio,Ian Moore,LT,55
+700,Ohio,Casey Magyar,K,55
+700,Ohio,Nick Mclarty,P,53
+700,Ohio,Devontae Armstrong,LG,53
+700,Ohio,Eric Neaves,LG,51
+700,Ohio,Gabe Vansickle,RG,49
+701,Ohio State,John Mateer,QB,91
+701,Ohio State,Robert Spears Jennings,FS,89
+701,Ohio State,Kip Lewis,ROLB,89
+701,Ohio State,Deion Burks,WR,88
+701,Ohio State,Eli Bowen,CB,88
+701,Ohio State,Gracen Halton,DT,88
+701,Ohio State,Kendal Daniels,SS,87
+701,Ohio State,Jake Maikkula,C,86
+701,Ohio State,Luke Baklenko,RT,86
+701,Ohio State,Damonic Williams,DT,85
+701,Ohio State,Isaiah Sategna,WR,85
+701,Ohio State,Troy Everett,C,85
+701,Ohio State,Febechi Nwaiwu,RG,85
+701,Ohio State,Kendel Dolby,CB,84
+701,Ohio State,Jacob Sexton,LT,84
+701,Ohio State,Kobie Mckinzie,MLB,83
+701,Ohio State,Jaren Kanak,TE,83
+701,Ohio State,Jayden Gibson,WR,82
+701,Ohio State,Keontez Lewis,WR,80
+701,Ohio State,Carson Kent,TE,80
+701,Ohio State,Jake Taylor,RT,79
+701,Ohio State,Tee Parrish,WR,79
+701,Ohio State,Jayden Jackson,DT,78
+701,Ohio State,Peyton Bowen,SS,78
+701,Ohio State,Logan Howland,LT,78
+701,Ohio State,Jake Wakefield,QB,77
+701,Ohio State,Jaydan Hardy,SS,77
+701,Ohio State,Devon Jordan,CB,77
+701,Ohio State,Sammy Omosigho,ROLB,76
+701,Ohio State,Siolaa Lolohea,DT,76
+701,Ohio State,David Stone,DT,75
+701,Ohio State,Gavin Frakes,QB,75
+701,Ohio State,Michael Hawkins Jr,QB,74
+701,Ohio State,Gentry Williams,CB,74
+701,Ohio State,Jacobe Johnson,CB,74
+701,Ohio State,Jeremiah Newcombe,CB,74
+701,Ohio State,Marcus Wimberly,SS,74
+701,Ohio State,Michael Fasusi,LT,73
+701,Ohio State,Eddy Pierre Louis,RG,73
+701,Ohio State,Zion Kearney,WR,73
+701,Ohio State,Michael Boganowski,FS,73
+701,Ohio State,Elijah Thomas,WR,72
+701,Ohio State,Owen Heinecke,MLB,72
+701,Ohio State,Tramon Wheeler,TE,71
+701,Ohio State,Markus Strong,DT,71
+701,Ohio State,Taylor Heim,ROLB,71
+701,Ohio State,Kade Mcintyre,TE,70
+701,Ohio State,Jacob Ulrich,P,69
+701,Ohio State,Reggie Powers Iii,SS,69
+701,Ohio State,Kaden Helms,TE,69
+701,Ohio State,Ivan Carreon,WR,68
+701,Ohio State,Kelvin Tucker,FB,68
+701,Ohio State,Prince Samuels,LG,67
+701,Ohio State,Trynae Washington,TE,66
+701,Ohio State,Edward Garcia,FS,66
+701,Ohio State,Daniel Akinkunmi,LG,66
+701,Ohio State,Ryan Fodje,RG,65
+701,Ohio State,Tate Sandell,K,65
+701,Ohio State,Roscoe Russell,MLB,65
+701,Ohio State,Seth Freeman,TE,65
+701,Ohio State,Austin Welch,K,64
+701,Ohio State,James Nesta,MLB,62
+701,Ohio State,Heath Ozaeta,LG,62
+701,Ohio State,Marcus Grimes,RT,61
+701,Ohio State,Jacob Jordan,WR,61
+701,Ohio State,Liam Evans,K,61
+701,Ohio State,Devin Anderson,C,60
+701,Ohio State,Karmelo Upton,LOLB,59
+701,Ohio State,Ben Anderson,TE,56
+701,Ohio State,T J Minton,LOLB,51
+701,Ohio State,Callum Thomas,LOLB,49
+701,Ohio State,Wandy Mackenzie,RG,49
+701,Ohio State,Grayson Miller,P,45
+702,Oklahoma,Oscar Hammond,TE,87
+702,Oklahoma,Markell Samuel,LT,86
+702,Oklahoma,Jaylin Davies,CB,84
+702,Oklahoma,Iman Oates,DT,84
+702,Oklahoma,Cam Smith,CB,84
+702,Oklahoma,Michael Diatta,DT,83
+702,Oklahoma,Christian Fitzpatrick,WR,82
+702,Oklahoma,Gavin Freeman,WR,82
+702,Oklahoma,Louie Canepa,RT,82
+702,Oklahoma,Talyn Shettron,WR,81
+702,Oklahoma,Bob Schick,RG,81
+702,Oklahoma,Bryan Mccoy,MLB,80
+702,Oklahoma,Sam Jackson V,WR,80
+702,Oklahoma,Aden Kelley,DT,80
+702,Oklahoma,Darius Thomas,MLB,80
+702,Oklahoma,Mordecai Mcdaniel,FS,79
+702,Oklahoma,Grant Seagren,C,79
+702,Oklahoma,Sitiveni Havili Kaufusi,DT,79
+702,Oklahoma,Jaleel Johnson,LOLB,79
+702,Oklahoma,Josh Ford,TE,78
+702,Oklahoma,Cameron Epps,FS,78
+702,Oklahoma,Kenneth Harris,CB,78
+702,Oklahoma,Kale Smith,CB,78
+702,Oklahoma,Parker Robertson,SS,78
+702,Oklahoma,Jack Endean,RT,78
+702,Oklahoma,Shamar Rigby,WR,77
+702,Oklahoma,Brandon Rawls,MLB,77
+702,Oklahoma,Austin Kawecki,RG,77
+702,Oklahoma,Trip White,ROLB,77
+702,Oklahoma,Bubba Nichols,LT,77
+702,Oklahoma,Dallas Hammonds,LT,77
+702,Oklahoma,De Marion Thomas,DT,76
+702,Oklahoma,Malik Charles,LOLB,76
+702,Oklahoma,Jaylen Lloyd,WR,75
+702,Oklahoma,Davis Dotson,RG,75
+702,Oklahoma,Zane Flores,QB,75
+702,Oklahoma,Chandavian Bradley,LOLB,75
+702,Oklahoma,Poasa Utu,ROLB,75
+702,Oklahoma,Zaquan Patterson,FS,74
+702,Oklahoma,Jk Johnson,CB,73
+702,Oklahoma,Ryan Trout,LG,73
+702,Oklahoma,Jeremy Cook,SS,73
+702,Oklahoma,Ike Esonwune,ROLB,73
+702,Oklahoma,Kyler Pearson,WR,73
+702,Oklahoma,Carl Veon Young,LOLB,72
+702,Oklahoma,Ayo Shotomide King,WR,72
+702,Oklahoma,Deandre Boykins,SS,71
+702,Oklahoma,Will Monney,TE,71
+702,Oklahoma,Jakobe Sanders,C,71
+702,Oklahoma,Noah Mckinney,RT,70
+702,Oklahoma,Kobi Foreman,WR,70
+702,Oklahoma,Dylan Smith,FS,69
+702,Oklahoma,Raymond Gay Ii,CB,69
+702,Oklahoma,Quinton Stewart,TE,69
+702,Oklahoma,Nuku Mafi,LG,69
+702,Oklahoma,Caleb Hackleman,LT,68
+702,Oklahoma,Kasen Carpenter,C,67
+702,Oklahoma,Grayson Brousseau,TE,67
+702,Oklahoma,Hunter Mcgeary,SS,67
+702,Oklahoma,Jacob Tuttle,FB,67
+702,Oklahoma,Wes Pahl,P,66
+702,Oklahoma,Hauss Hejny,QB,65
+702,Oklahoma,Miguel Chavez,RG,65
+702,Oklahoma,Matrail Lopez,WR,64
+702,Oklahoma,Edward Hance,TE,64
+702,Oklahoma,Logan Ward,K,63
+702,Oklahoma,David Kabongo,FS,63
+702,Oklahoma,Eric Fletcher,CB,61
+702,Oklahoma,Gabe Panikowski,K,60
+702,Oklahoma,Jaylan Beckley,LG,58
+702,Oklahoma,Brad Dorman,QB,55
+702,Oklahoma,Gunnar Wilson,MLB,50
+702,Oklahoma,Shea Freibaum,TE,48
+703,Oklahoma State,Jason Henderson,MLB,91
+703,Oklahoma State,Mario Thompson,ROLB,85
+703,Oklahoma State,Deandre Lynch,DT,83
+703,Oklahoma State,Zach Barlev,LT,82
+703,Oklahoma State,Koa Naotala,MLB,82
+703,Oklahoma State,Sidney Mbanasor,WR,82
+703,Oklahoma State,Jalen Butler,TE,81
+703,Oklahoma State,Jahleel Culbreath,LOLB,81
+703,Oklahoma State,Colton Joseph,QB,80
+703,Oklahoma State,Tj Lott,WR,78
+703,Oklahoma State,Elijah Hoskin,LG,78
+703,Oklahoma State,Botros Alisandro,CB,77
+703,Oklahoma State,Maarten Woudsma,LG,77
+703,Oklahoma State,Seth Naotala,LOLB,77
+703,Oklahoma State,Billy Gough,C,77
+703,Oklahoma State,Stephon Dubose Bourne,RT,77
+703,Oklahoma State,Jace Coats,FS,77
+703,Oklahoma State,Raysean Walters,TE,77
+703,Oklahoma State,Ja Cory Thomas,WR,76
+703,Oklahoma State,Jeremy Mack Jr,SS,76
+703,Oklahoma State,Skyler Grant,RG,76
+703,Oklahoma State,Cole Daniels,DT,75
+703,Oklahoma State,Colin Henrich,C,75
+703,Oklahoma State,Nickendre Stiger,CB,75
+703,Oklahoma State,Na Eem Abdul Rahim Gladding,WR,75
+703,Oklahoma State,Dawson Johnson,TE,75
+703,Oklahoma State,Tevan Corbett,SS,74
+703,Oklahoma State,Dustin Swift,FB,74
+703,Oklahoma State,Josh Schuetzmann,LT,74
+703,Oklahoma State,Jerome Carter,FS,74
+703,Oklahoma State,Jumbo Griffin,RT,74
+703,Oklahoma State,Langston Williams,CB,73
+703,Oklahoma State,Kollin Collier,FS,73
+703,Oklahoma State,Jameel Madison,FS,73
+703,Oklahoma State,Mario Easterly,FS,72
+703,Oklahoma State,Keshawn Thomas,ROLB,72
+703,Oklahoma State,Tre Brown,WR,71
+703,Oklahoma State,Connor Drake,RG,71
+703,Oklahoma State,Ryan Ramey,SS,71
+703,Oklahoma State,Christopher Donald,C,70
+703,Oklahoma State,Theo Bachelder,RG,70
+703,Oklahoma State,Quinn Henicle,QB,69
+703,Oklahoma State,Aj Ashworth,MLB,69
+703,Oklahoma State,Justin Pierce,TE,68
+703,Oklahoma State,Daevon Iles,SS,68
+703,Oklahoma State,Jorian Haynes,CB,68
+703,Oklahoma State,Zion Frink,CB,67
+703,Oklahoma State,Kainan Miller,LG,67
+703,Oklahoma State,Gage Sawyers,MLB,66
+703,Oklahoma State,Matthew Patton,LT,65
+703,Oklahoma State,Tj Johnson,WR,65
+703,Oklahoma State,Xavier Goodwin,WR,65
+703,Oklahoma State,Ryan Huff,QB,64
+703,Oklahoma State,Cam Hill,C,64
+703,Oklahoma State,Early Newsome,WR,64
+703,Oklahoma State,Dirrick Goodman,ROLB,64
+703,Oklahoma State,Holden Brown,QB,63
+703,Oklahoma State,Derek Beasley,FS,63
+703,Oklahoma State,Lorenzo Mcfadden Pressley,DT,63
+703,Oklahoma State,Brandon Crutchfield,CB,63
+703,Oklahoma State,Hunter Malecki,DT,63
+703,Oklahoma State,Jackson Forrest,LOLB,63
+703,Oklahoma State,Riley Callaghan,K,62
+703,Oklahoma State,Justin Kalitsnik,ROLB,61
+703,Oklahoma State,Tyrell Dorsett,LT,59
+703,Oklahoma State,Cecil Armstead,FB,59
+703,Oklahoma State,Sean Mayer,RT,59
+703,Oklahoma State,Nathanial Eichner,K,58
+703,Oklahoma State,Quinton Weatherspoon,LG,58
+703,Oklahoma State,Bobby Bowie,SS,58
+703,Oklahoma State,Chris Forbes,DT,58
+703,Oklahoma State,Denique Sherman,WR,56
+703,Oklahoma State,Carson Bradley,RT,55
+703,Oklahoma State,Ian Brandt,P,53
+704,Old Dominion,Suntarine Perkins,ROLB,93
+704,Old Dominion,Luke Hasz,TE,89
+704,Old Dominion,De Zhaun Stribling,WR,88
+704,Old Dominion,Zxavian Harris,DT,88
+704,Old Dominion,Wydett Williams Jr,SS,88
+704,Old Dominion,Kapena Gushiken,CB,87
+704,Old Dominion,Cayden Lee,WR,87
+704,Old Dominion,Harrison Wallace Iii,WR,87
+704,Old Dominion,Tj Dottery,MLB,87
+704,Old Dominion,Diego Pounds,LT,87
+704,Old Dominion,Ricky Fletcher,CB,85
+704,Old Dominion,Sage Ryan,FS,84
+704,Old Dominion,Percy Lewis,LT,84
+704,Old Dominion,Trace Bruckler,TE,84
+704,Old Dominion,Deuce Alexander,WR,84
+704,Old Dominion,Dae Quan Wright,TE,83
+704,Old Dominion,Jamarious Brown,DT,83
+704,Old Dominion,Jayden Williams,RT,83
+704,Old Dominion,Jaylon Braxton,CB,82
+704,Old Dominion,Traylon Ray,WR,82
+704,Old Dominion,Brycen Sanders,C,80
+704,Old Dominion,Andrew Jones,ROLB,80
+704,Old Dominion,Delano Townsend,LG,79
+704,Old Dominion,Austin Simmons,QB,78
+704,Old Dominion,Duncan Grant,QB,78
+704,Old Dominion,Tyler Banks,MLB,78
+704,Old Dominion,Jeffery Rush,DT,78
+704,Old Dominion,William Echoles,DT,77
+704,Old Dominion,Jaden Yates,ROLB,77
+704,Old Dominion,Raymond Collins,MLB,76
+704,Old Dominion,Terez Davis,RT,75
+704,Old Dominion,John Wayne Oliver,C,75
+704,Old Dominion,Jude Foster,LT,75
+704,Old Dominion,Tj Banks,CB,74
+704,Old Dominion,Joe Koury,C,74
+704,Old Dominion,Antonio Kite,CB,73
+704,Old Dominion,Cedrick Beavers,CB,72
+704,Old Dominion,Winston Watkins Jr,WR,72
+704,Old Dominion,Andy Jaffe,FS,72
+704,Old Dominion,Maealiuaki Smith,QB,72
+704,Old Dominion,Pj Wilkins,LG,72
+704,Old Dominion,Caleb Odom,WR,72
+704,Old Dominion,Mark Trigg Jr,ROLB,72
+704,Old Dominion,Tavoy Feagin,CB,71
+704,Old Dominion,Dustin Seay,K,71
+704,Old Dominion,Andre Threatt,SS,70
+704,Old Dominion,Aj Maddox,QB,70
+704,Old Dominion,Anthony Robinson Iii,SS,68
+704,Old Dominion,Jarcoby Hopson,LOLB,68
+704,Old Dominion,Chris Graves Jr,CB,67
+704,Old Dominion,Devin Harper,RG,67
+704,Old Dominion,Bryson Walters,LOLB,67
+704,Old Dominion,Patrick Kutas,RG,66
+704,Old Dominion,Dillon Alfred,WR,66
+704,Old Dominion,Andrew Maddox,DT,66
+704,Old Dominion,Kortlen Wilfawn,TE,66
+704,Old Dominion,Alex Robertson,MLB,65
+704,Old Dominion,Quintin Walker,FS,65
+704,Old Dominion,Zyaire Johnson,QB,64
+704,Old Dominion,Major Preston,CB,64
+704,Old Dominion,Connor Howes,LT,64
+704,Old Dominion,Hayden Bradley,TE,64
+704,Old Dominion,Chris Mcmason,MLB,64
+704,Old Dominion,Ethan Fields,RG,63
+704,Old Dominion,Tavante Barry,FB,63
+704,Old Dominion,Carter Short,TE,63
+704,Old Dominion,Oscar Bird,P,62
+704,Old Dominion,Nick Cull,SS,60
+704,Old Dominion,Talib Graham,ROLB,59
+704,Old Dominion,Ramsay Griffen,RT,58
+704,Old Dominion,Myron Ray,FS,56
+704,Old Dominion,Samari Reed,WR,55
+704,Old Dominion,Dalvin Bradford,LG,53
+704,Old Dominion,Mike Baker,K,50
+705,Ole Miss,Emmanuel Pregnon,LG,96
+705,Ole Miss,Dillon Thieneman,SS,93
+705,Ole Miss,Evan Stewart,WR,91
+705,Ole Miss,Isaiah World,LT,91
+705,Ole Miss,Bear Alexander,DT,90
+705,Ole Miss,Theran Johnson,CB,89
+705,Ole Miss,Teitum Tuioti,LOLB,88
+705,Ole Miss,Bryce Boettcher,MLB,88
+705,Ole Miss,Gilbert Garcia,WR,88
+705,Ole Miss,Iapani Laloulu,C,87
+705,Ole Miss,Kyler Kasper,WR,87
+705,Ole Miss,Justius Lowe,WR,86
+705,Ole Miss,Alex Harkey,RT,85
+705,Ole Miss,Malik Benson,WR,84
+705,Ole Miss,Matthew Bedford,RG,84
+705,Ole Miss,Devon Jackson,ROLB,83
+705,Ole Miss,Kenyon Sadiq,TE,82
+705,Ole Miss,Blake Purchase,LOLB,82
+705,Ole Miss,Charlie Pickard,C,82
+705,Ole Miss,Dante Moore,QB,80
+705,Ole Miss,Jadon Canady,SS,80
+705,Ole Miss,Jerry Mixon,MLB,79
+705,Ole Miss,Jahlil Florence,CB,78
+705,Ole Miss,Kawika Rogers,LG,78
+705,Ole Miss,Terrance Green,DT,77
+705,Ole Miss,Austin Novosad,QB,76
+705,Ole Miss,Solomon Davis,SS,76
+705,Ole Miss,Dillon Gresham,WR,76
+705,Ole Miss,Ross James,P,75
+705,Ole Miss,Kingston Lopa,FS,75
+705,Ole Miss,Roger Saleapaga,TE,75
+705,Ole Miss,Sione Laulea,CB,74
+705,Ole Miss,Jurrion Dickey,WR,74
+705,Ole Miss,Jamari Johnson,TE,74
+705,Ole Miss,Cooper Perry,WR,74
+705,Ole Miss,Ify Obidegwu,CB,73
+705,Ole Miss,Brandon Finney,CB,73
+705,Ole Miss,Trent Ferguson,RT,73
+705,Ole Miss,Amir Scroggins,CB,72
+705,Ole Miss,Lipe Moala,RG,72
+705,Ole Miss,Nick Duzansky,TE,72
+705,Ole Miss,Peyton Woodyard,FS,71
+705,Ole Miss,Bryce Boulton,C,71
+705,Ole Miss,Fox Crader,LT,70
+705,Ole Miss,Elijah Rushing,LOLB,70
+705,Ole Miss,Dakorien Moore,WR,69
+705,Ole Miss,Daylen Austin,CB,69
+705,Ole Miss,Aaron Flowers,SS,69
+705,Ole Miss,Akili Smith Jr,QB,69
+705,Ole Miss,Jeremiah Mcclellan,WR,69
+705,Ole Miss,Gernorris Wilson,RT,69
+705,Ole Miss,Luke Basso,TE,69
+705,Ole Miss,Aydin Breland,DT,68
+705,Ole Miss,Orlando Burks,DT,68
+705,Ole Miss,Jericho Johnson,DT,68
+705,Ole Miss,Zach Clay,FB,68
+705,Ole Miss,Dave Iuli,RG,67
+705,Ole Miss,Trey Mcnutt,FS,67
+705,Ole Miss,Brady Keane,LT,67
+705,Ole Miss,Dakoda Fields,CB,67
+705,Ole Miss,Vander Ploog,TE,65
+705,Ole Miss,Dylan Williams,MLB,64
+705,Ole Miss,Atticus Sappington,K,63
+705,Ole Miss,Markus Ingle,C,62
+705,Ole Miss,Andrew Boyle,K,60
+705,Ole Miss,Demetri Manning,LG,59
+705,Ole Miss,Josh Quarterman,MLB,59
+705,Ole Miss,Luke Moga,QB,57
+705,Ole Miss,Billy Fanene,LT,53
+705,Ole Miss,Brayden Platt,ROLB,50
+705,Ole Miss,Kamar Mothudi,ROLB,44
+705,Ole Miss,Korbyn Scott,RG,44
+706,Oregon,Trent Walker,WR,86
+706,Oregon,Tyler Voltin,LG,85
+706,Oregon,Oluwaseyi Omotosho,LOLB,85
+706,Oregon,Skyler Thomas,SS,84
+706,Oregon,Darrius Clemons,WR,84
+706,Oregon,Raesjon Davis,MLB,84
+706,Oregon,Tyler Morano,RT,84
+706,Oregon,Nick Norris,DT,84
+706,Oregon,Van Wells,C,83
+706,Oregon,Josiah Timoteo,RG,83
+706,Oregon,Jimmy Valsin Iii,WR,83
+706,Oregon,Makiya Tongue,ROLB,83
+706,Oregon,Nikko Taylor,LOLB,81
+706,Oregon,Maalik Murphy,QB,81
+706,Oregon,Jacob Schuster,DT,81
+706,Oregon,Jaheim Patterson,FS,81
+706,Oregon,Jacob Strand,LT,81
+706,Oregon,Sailasa Vadrawale Iii,CB,81
+706,Oregon,Amarion York,FS,81
+706,Oregon,Kobe Singleton,CB,80
+706,Oregon,Zakaih Saez,ROLB,80
+706,Oregon,Exodus Ayers,CB,79
+706,Oregon,Tj Crandall,CB,79
+706,Oregon,Walker Harris,LOLB,79
+706,Oregon,Riley Williams,TE,78
+706,Oregon,Noble Thomas Jr,CB,78
+706,Oregon,Thomas Collins,DT,78
+706,Oregon,Bryce Caufield,TE,78
+706,Oregon,Jt Hand,C,78
+706,Oregon,Mason White,CB,78
+706,Oregon,Eddie Freauff,WR,78
+706,Oregon,David Wells Jr,WR,77
+706,Oregon,Gabarri Johnson,QB,76
+706,Oregon,Taz Reddicks,WR,76
+706,Oregon,Clive Pond,MLB,76
+706,Oregon,Dexter Foster,ROLB,76
+706,Oregon,Drake Vickers,CB,76
+706,Oregon,Jackson Bowers,TE,75
+706,Oregon,Jojo Johnson,DT,75
+706,Oregon,Gyriece Goodman,ROLB,75
+706,Oregon,Tyrice Ivy Jr,SS,74
+706,Oregon,Nathan Elu,LG,74
+706,Oregon,Zachary Card,WR,74
+706,Oregon,Tahjae Mullix,DT,74
+706,Oregon,Shamar Meikle,ROLB,74
+706,Oregon,Dylan Sikorski,RG,73
+706,Oregon,Andy Alfieri,ROLB,73
+706,Oregon,Jayden Tuia,C,73
+706,Oregon,Harlem Howard,FS,72
+706,Oregon,Jacob Anderson,LT,72
+706,Oregon,Milan Clark,SS,71
+706,Oregon,Thomas Schnapp,RG,71
+706,Oregon,Cooper Jensen,TE,71
+706,Oregon,Keyon Cox,RT,70
+706,Oregon,Zander Esty,RG,70
+706,Oregon,Jackson Robertson,TE,70
+706,Oregon,Gabe Milbourn,TE,69
+706,Oregon,Aiden Sullivan,MLB,68
+706,Oregon,Jack Wagner,RT,68
+706,Oregon,Kallen Gutridge,QB,67
+706,Oregon,Caleb Ojeda,K,65
+706,Oregon,Jake Normoyle,LG,65
+706,Oregon,Logan Mccreery,K,64
+706,Oregon,Daniel Oakley,C,64
+706,Oregon,Malachi Durant,WR,64
+706,Oregon,Jeff Newgrader,DT,63
+706,Oregon,Jared Paulding,CB,63
+706,Oregon,Kord Shaw,MLB,62
+706,Oregon,Dylan Black,TE,58
+706,Oregon,Max Walker,P,57
+706,Oregon,Sean Fox,FB,56
+706,Oregon,Marquis Patterson,LT,53
+706,Oregon,Aj Winsor,P,52
+707,Oregon State,Olaivavega Ioane,LG,93
+707,Oregon State,Drew Allar,QB,92
+707,Oregon State,Devonte Ross,WR,92
+707,Oregon State,Zakee Wheatley,FS,92
+707,Oregon State,Dominic Deluca,LOLB,92
+707,Oregon State,A J Harris,CB,91
+707,Oregon State,Zane Durant,DT,90
+707,Oregon State,Trebor Pena,WR,90
+707,Oregon State,Amare Campbell,MLB,90
+707,Oregon State,Liam Clifford,WR,90
+707,Oregon State,Nick Dawkins,C,90
+707,Oregon State,Drew Shelton,LT,88
+707,Oregon State,Tony Rojas,ROLB,85
+707,Oregon State,Kyron Hudson,WR,85
+707,Oregon State,Kaleb Artis,DT,85
+707,Oregon State,Khalil Dinkins,TE,81
+707,Oregon State,Luke Reynolds,TE,79
+707,Oregon State,Cooper Cousins,RG,78
+707,Oregon State,Tyseer Denmark,WR,78
+707,Oregon State,Alonzo Ford Jr,DT,78
+707,Oregon State,Nolan Rucci,RT,77
+707,Oregon State,Kaden Saunders,WR,77
+707,Oregon State,Anthony Varner,QB,77
+707,Oregon State,Lamont Payne Jr,FS,77
+707,Oregon State,Elliot Washington Ii,CB,76
+707,Oregon State,Anthony Donkoh,RT,76
+707,Oregon State,Audavion Collins,CB,76
+707,Oregon State,Dakaari Nelson,ROLB,76
+707,Oregon State,Tj Shanahan,RG,75
+707,Oregon State,Dejuan Lane,SS,75
+707,Oregon State,Andrew Olesh,TE,75
+707,Oregon State,Ethan Grunkemeyer,QB,75
+707,Oregon State,Dominic Rulli,C,75
+707,Oregon State,Andrew Rappleyea,TE,73
+707,Oregon State,Vaboue Toure,FS,73
+707,Oregon State,Ty Blanding,DT,73
+707,Oregon State,Anthony Speca,MLB,73
+707,Oregon State,King Mack,SS,72
+707,Oregon State,Kenny Woseley Jr,CB,72
+707,Oregon State,Shane Simms,LT,72
+707,Oregon State,Kolin Dinkins,CB,72
+707,Oregon State,Tyler Armstead,CB,72
+707,Oregon State,J Ven Williams,LG,71
+707,Oregon State,Anthony Ivey,WR,71
+707,Oregon State,Matthew Outten,WR,71
+707,Oregon State,Peter Gonzalez,WR,71
+707,Oregon State,Keon Wylie,ROLB,70
+707,Oregon State,Jaxon Smolik,QB,70
+707,Oregon State,Christian Purcell,LOLB,69
+707,Oregon State,Liam Andrews,DT,69
+707,Oregon State,Winston Yates,LOLB,69
+707,Oregon State,Jefferson Wimbley,RT,68
+707,Oregon State,L J Williamson,MLB,68
+707,Oregon State,Tyler Duzansky,TE,68
+707,Oregon State,Marion Campbell Ii,FS,67
+707,Oregon State,Riley Thompson,P,67
+707,Oregon State,Brian Kortovich,TE,67
+707,Oregon State,Kari Jackson,MLB,67
+707,Oregon State,Blaise Sokach Minnick,TE,67
+707,Oregon State,A Quan Roche,RT,66
+707,Oregon State,Zion Tracy,CB,66
+707,Oregon State,Antoine Belgrave Shorter,SS,65
+707,Oregon State,Ryan Barker,K,64
+707,Oregon State,Eric Rance,MLB,64
+707,Oregon State,Alex Birchmeier,RG,62
+707,Oregon State,Gabriel Nwosu,P,62
+707,Oregon State,Jake Wilder,QB,61
+707,Oregon State,Trent Norton Jr,C,60
+707,Oregon State,Garrett Sexton,LT,52
+707,Oregon State,Chimdy Onoh,LG,49
+708,Penn State,Kyle Louis,ROLB,93
+708,Penn State,Rasheem Biles,LOLB,89
+708,Penn State,Javon Mcintyre,SS,88
+708,Penn State,Bj Williams,RG,88
+708,Penn State,Lyndon Cooper,C,87
+708,Penn State,Ryan Baer,RT,86
+708,Penn State,Rashad Battle,CB,85
+708,Penn State,Nick James,DT,85
+708,Penn State,Kenny Johnson,WR,84
+708,Penn State,Keith Gouveia,LG,84
+708,Penn State,Raphael Williams Jr,WR,83
+708,Penn State,Censere Lee,WR,83
+708,Penn State,Sean Fitzsimmons,DT,83
+708,Penn State,Jeffrey Persi,LT,83
+708,Penn State,Jake Overman,TE,83
+708,Penn State,Francis Brewu,DT,82
+708,Penn State,Kendall Stanley,RT,82
+708,Penn State,Justin Holmes,TE,82
+708,Penn State,Eli Holstein,QB,80
+708,Penn State,Isaiah Montgomery,LT,80
+708,Penn State,Braylan Lovelace,MLB,78
+708,Penn State,Deuce Spann,WR,78
+708,Penn State,Cole Gonzales,QB,78
+708,Penn State,Troy Lathan,LG,78
+708,Penn State,Malachi Thomas,TE,77
+708,Penn State,Finn Daley,LT,77
+708,Penn State,Cruce Brookins,FS,76
+708,Penn State,Tamon Lynum,CB,76
+708,Penn State,Isaiah Neal,DT,76
+708,Penn State,Garrison Williams,TE,76
+708,Penn State,Jackson Brown,RT,74
+708,Penn State,Jesse Anderson,SS,74
+708,Penn State,Ty Yuhas,DT,74
+708,Penn State,Cataurus Hicks,WR,74
+708,Penn State,Jiavani Cooley,RG,74
+708,Penn State,Jaiden Randall,C,73
+708,Penn State,Nick Lapi,LOLB,72
+708,Penn State,Allen Bryant,FS,72
+708,Penn State,Jayden Bonsu,ROLB,71
+708,Penn State,Mason Heintschel,QB,71
+708,Penn State,Che Nwabuko,WR,71
+708,Penn State,Ryan Carretta,C,71
+708,Penn State,Luke Delgaudio,LOLB,71
+708,Penn State,Tai Ray,RG,70
+708,Penn State,Gage Drummond,FS,68
+708,Penn State,Brian Wellington,FB,68
+708,Penn State,Caleb Holmes,LG,67
+708,Penn State,Toby Kerry,C,67
+708,Penn State,Nilay Upadhyayula,TE,67
+708,Penn State,Zion Fowler El,WR,66
+708,Penn State,Tyreek Robinson,WR,66
+708,Penn State,Caleb Junko,P,65
+708,Penn State,Duke Mcmillon,SS,65
+708,Penn State,Jahsear Whittington,DT,65
+708,Penn State,Jaxson Joseph,CB,64
+708,Penn State,Immanuel Mims,FS,64
+708,Penn State,Denim Cook,ROLB,64
+708,Penn State,Nico Crawford,TE,64
+708,Penn State,Cade Dowd,P,62
+708,Penn State,Perry Blankenship,K,62
+708,Penn State,Rajon Conner,CB,61
+708,Penn State,Davion Pritchard,CB,60
+708,Penn State,Zion Ferguson,CB,59
+708,Penn State,Eric Childress,MLB,58
+708,Penn State,Jeremiah Marcelin,MLB,58
+708,Penn State,Davin Brewton,ROLB,54
+708,Penn State,Nigel Maynard,CB,54
+708,Penn State,Kent Hilton,QB,52
+708,Penn State,Cortez Miller,FB,52
+708,Penn State,Akram Elnagmi,LT,51
+708,Penn State,Sam Carpenter,K,51
+708,Penn State,David Lynch,QB,51
+708,Penn State,Cameron Lindsey,ROLB,49
+709,Pittsburgh,Crew Wakley,SS,83
+709,Pittsburgh,Charles Ross,WR,83
+709,Pittsburgh,Jude Mccoskey,RT,83
+709,Pittsburgh,Jesse Watson,WR,83
+709,Pittsburgh,Tony Grimes,CB,82
+709,Pittsburgh,De Nylon Morrissette,WR,82
+709,Pittsburgh,Christian Moore,TE,82
+709,Pittsburgh,Jalen St John,LT,81
+709,Pittsburgh,Chad Brown,CB,81
+709,Pittsburgh,Hershey Mclaurin,SS,81
+709,Pittsburgh,Tahj Ra El,CB,80
+709,Pittsburgh,Richard Toney Jr,FS,79
+709,Pittsburgh,Chauncey Magwood,WR,79
+709,Pittsburgh,Jamarius Dinkins,DT,79
+709,Pittsburgh,Bradyn Joiner,LG,79
+709,Pittsburgh,Giordano Vaccaro,C,79
+709,Pittsburgh,Joey Tanona,LT,78
+709,Pittsburgh,Michael Jackson Iii,WR,77
+709,Pittsburgh,George Burhenn,TE,77
+709,Pittsburgh,Moses Robinson Tyson,RG,77
+709,Pittsburgh,An Darius Coffey,SS,76
+709,Pittsburgh,Marcus Moore Jr,DT,76
+709,Pittsburgh,Malachi Singleton,QB,76
+709,Pittsburgh,Luca Puccinelli,TE,76
+709,Pittsburgh,Ryan Turner,CB,75
+709,Pittsburgh,Ian Jeffries,DT,75
+709,Pittsburgh,Mason Vicari,RG,75
+709,Pittsburgh,Owen Davis,LOLB,75
+709,Pittsburgh,Ryan Browne,QB,74
+709,Pittsburgh,T J Lindsey,DT,74
+709,Pittsburgh,Sterling Smith,FS,74
+709,Pittsburgh,Christian Earls,TE,74
+709,Pittsburgh,Ej Horton,WR,73
+709,Pittsburgh,Mani Powell,MLB,73
+709,Pittsburgh,Alex Sanford,ROLB,73
+709,Pittsburgh,Traveon Wright,CB,73
+709,Pittsburgh,Corey Smith,WR,73
+709,Pittsburgh,Udonis Davis,LG,72
+709,Pittsburgh,Bakyne Coly,RT,72
+709,Pittsburgh,Nitro Tuggle,WR,72
+709,Pittsburgh,Drake Carlson,DT,72
+709,Pittsburgh,Carson Dean,MLB,72
+709,Pittsburgh,David Tauanuu,RG,72
+709,Pittsburgh,Rico Walker,TE,71
+709,Pittsburgh,Marc Nave Jr,RT,71
+709,Pittsburgh,Jamarrion Harkless,DT,70
+709,Pittsburgh,Arhmad Branch,WR,70
+709,Pittsburgh,T D Williams,CB,70
+709,Pittsburgh,Ethan Trent,C,68
+709,Pittsburgh,John Randle Jr,LT,68
+709,Pittsburgh,Jack Mccallister,P,67
+709,Pittsburgh,Demeco Kennedy,DT,67
+709,Pittsburgh,Evans Chuba,QB,67
+709,Pittsburgh,Marques Easley,LG,66
+709,Pittsburgh,Hudauri Hines,CB,66
+709,Pittsburgh,Winston Berglund,MLB,66
+709,Pittsburgh,Sam Steward,LOLB,65
+709,Pittsburgh,Tra Mar Harris,WR,65
+709,Pittsburgh,Dirk Palmer,FB,64
+709,Pittsburgh,Smiley Bradford,FS,62
+709,Pittsburgh,Zyntreacs Otey,CB,62
+709,Pittsburgh,Bennett Boehnlein,P,61
+709,Pittsburgh,Tylan Scales,ROLB,61
+709,Pittsburgh,Shane Honeycutt,QB,60
+709,Pittsburgh,Trevin Baxter,FS,60
+709,Pittsburgh,Spencer Porath,K,59
+709,Pittsburgh,Justin Sherman,TE,59
+709,Pittsburgh,Sam Dubwig,P,59
+709,Pittsburgh,Marquis Nicolas,ROLB,58
+709,Pittsburgh,D Mon Marable,SS,58
+709,Pittsburgh,Antwan Lands,FB,58
+709,Pittsburgh,Max Parrott,LT,58
+710,Purdue,Ty Morris,ROLB,85
+710,Purdue,Plae Wyatt,LOLB,84
+710,Purdue,David Stickle,C,84
+710,Purdue,Marcus Williams,FS,84
+710,Purdue,Daveon Hook,SS,83
+710,Purdue,Jack Kane,SS,83
+710,Purdue,Max Ahoia,CB,83
+710,Purdue,Matthew Aribisala,DT,83
+710,Purdue,Aaron Turner,WR,81
+710,Purdue,Brad Baur,RT,81
+710,Purdue,Netane Fehoko,C,81
+710,Purdue,Blake Boenisch,DT,80
+710,Purdue,Artis Cole,WR,80
+710,Purdue,Rawson Macneill,WR,80
+710,Purdue,Andrew Awe,MLB,79
+710,Purdue,Landon Ransom Goelz,WR,79
+710,Purdue,Omari Porter,CB,79
+710,Purdue,Braylen Walker,WR,79
+710,Purdue,Geron Hargon,FB,79
+710,Purdue,Weston Kropp,RG,78
+710,Purdue,Dj Arkansas,MLB,78
+710,Purdue,Max Lofy,CB,78
+710,Purdue,Micah Barnett,TE,78
+710,Purdue,Peyton Stevenson,FS,77
+710,Purdue,Elroyal Morris Iii,DT,77
+710,Purdue,Levi Berry,RG,77
+710,Purdue,Jerrick Harper,CB,76
+710,Purdue,Tyson Thompson,WR,76
+710,Purdue,Drew Devillier,QB,76
+710,Purdue,Dillan Botts,DT,76
+710,Purdue,James Falk,TE,76
+710,Purdue,Patrick Valent,RT,76
+710,Purdue,John Long,LG,75
+710,Purdue,Drayden Dickmann,WR,75
+710,Purdue,Aj Padgett,QB,75
+710,Purdue,Blaise Tita,ROLB,75
+710,Purdue,Shepherd Bowling,LOLB,75
+710,Purdue,Jalen Hargrove,DT,75
+710,Purdue,Cole Morgan,RG,75
+710,Purdue,Lamont Narcisse,CB,74
+710,Purdue,Chase Jenkins,QB,73
+710,Purdue,Joe Chavez,LOLB,73
+710,Purdue,Trace Norfleet,LG,73
+710,Purdue,Cooper King,ROLB,72
+710,Purdue,Isaiah Gonzalez,LT,71
+710,Purdue,Luke Needham,RT,71
+710,Purdue,Beau Barton,MLB,71
+710,Purdue,Lane Heenan,LOLB,71
+710,Purdue,Peyton Farmer,LT,70
+710,Purdue,Luke Miller,LG,70
+710,Purdue,Jabari Ellison,FS,70
+710,Purdue,Spencer Hedgecock,RG,69
+710,Purdue,Chase Allen,K,68
+710,Purdue,Alex Bacchetta,P,67
+710,Purdue,Aj Stephens,CB,67
+710,Purdue,Nate Bledsoe,RG,67
+710,Purdue,Kaleb Blanton,MLB,64
+710,Purdue,Markus Cormier,LT,63
+710,Purdue,Colter Alberding,C,62
+710,Purdue,Michael Amey Iii,FS,61
+710,Purdue,Robert Rooks,DT,60
+710,Purdue,Justin Williams Jr,WR,60
+710,Purdue,Patrick Crayton Jr,QB,57
+710,Purdue,Wyatt Freeman,TE,55
+710,Purdue,Will Swartz,TE,54
+710,Purdue,Enock Gota,K,54
+710,Purdue,Don Williams,LT,53
+710,Purdue,Roman Livingston,LG,53
+710,Purdue,Aquantis Clemmons,DT,51
+710,Purdue,Nick Joyner,ROLB,48
+711,Rice,Ryan Clifford,LT,93
+711,Rice,Dt Sheffield,WR,90
+711,Rice,Patrick Millard,RT,90
+711,Rice,Athan Kaliakmanis,QB,89
+711,Rice,Bryan Felter,LG,87
+711,Rice,Dantae Chin,LG,87
+711,Rice,Gus Zilinskas,C,86
+711,Rice,Dariel Djabome,MLB,86
+711,Rice,Ian Strong,WR,85
+711,Rice,Jett Elad,SS,85
+711,Rice,Colin Weber,TE,85
+711,Rice,Oliver Billotte,DT,85
+711,Rice,Kwabena Asamoah,RG,84
+711,Rice,Hank Zilinskas,C,84
+711,Rice,Terrence Salami,C,84
+711,Rice,Tyler Needham,LT,83
+711,Rice,Bo Mascoe,CB,82
+711,Rice,Abram Wright,ROLB,82
+711,Rice,Carson Lacy,C,82
+711,Rice,Cam Miller,CB,80
+711,Rice,Doug Blue Eli,DT,80
+711,Rice,Logan Blake,TE,80
+711,Rice,Kenny Fletcher,TE,79
+711,Rice,Ethan Schultz,QB,79
+711,Rice,Keshon Griffin,DT,79
+711,Rice,Al Shadee Salaam,CB,79
+711,Rice,Victor Konopka,TE,79
+711,Rice,Aj Surace,QB,79
+711,Rice,Kaj Sanders,FS,78
+711,Rice,Jacobie Henderson,CB,77
+711,Rice,Kj Duff,WR,77
+711,Rice,Taj White,RT,77
+711,Rice,Caleb Johnston,TE,77
+711,Rice,Noah Shaw,ROLB,77
+711,Rice,Taj Beck,RG,76
+711,Rice,Darold Dengohe,DT,75
+711,Rice,Jesse Ofurie,FS,74
+711,Rice,Michael Robinson Ii,FS,74
+711,Rice,Desean Kramer,FS,74
+711,Rice,D J Rivers,WR,74
+711,Rice,Sage Clawges,CB,73
+711,Rice,Alonzo Calhoun,SS,73
+711,Rice,John Stone,LG,73
+711,Rice,Nick Oliveira,RG,73
+711,Rice,Timmy Ward,FS,72
+711,Rice,Sammy El Hadidi,TE,72
+711,Rice,Ben Black,WR,71
+711,Rice,Raymond Giacobbe,LT,71
+711,Rice,Mj Johnson,MLB,71
+711,Rice,Sam Pilof,LOLB,71
+711,Rice,Emir Stinette,RG,69
+711,Rice,Davoun Fuse,SS,69
+711,Rice,Kenny Jones,LG,69
+711,Rice,Henry Hughes Jr,DT,68
+711,Rice,Zilan Williams,CB,67
+711,Rice,Sam Robinson,MLB,67
+711,Rice,Khalil Avery Jones,ROLB,67
+711,Rice,Heath Paul,FB,65
+711,Rice,Kevin Levy,CB,65
+711,Rice,Monte Keener,TE,65
+711,Rice,Moses Walker,ROLB,64
+711,Rice,Jakob Anderson,P,64
+711,Rice,Dylan Braithwaite,WR,64
+711,Rice,Jai Patel,K,63
+711,Rice,Riley Mccann,K,63
+711,Rice,Famah Toure,WR,63
+711,Rice,Rob Jordan,FB,62
+711,Rice,Jameer Green,MLB,59
+711,Rice,Michael Marion,DT,59
+711,Rice,Dk Gilley,SS,59
+711,Rice,Carter Kadow,RT,56
+711,Rice,Raynor Andrews,RT,47
+712,Rutgers,Rhett Larson,LG,87
+712,Rutgers,Qua Vez Humphreys,WR,84
+712,Rutgers,Antavious Fish,ROLB,84
+712,Rutgers,Graceson Jackson Smith,RT,84
+712,Rutgers,Michael Phoenix Ii,WR,83
+712,Rutgers,Devin Broyles,DT,83
+712,Rutgers,Trey Winfrey,DT,82
+712,Rutgers,James Dawn Ii,RG,81
+712,Rutgers,Dylan Frazier,DT,80
+712,Rutgers,Hunter Watson,QB,79
+712,Rutgers,Thomas Jewett,TE,79
+712,Rutgers,Alonzo Edwards,SS,79
+712,Rutgers,Isaac Sohn,C,79
+712,Rutgers,Kaleb Black,WR,78
+712,Rutgers,Cj Brown,FS,78
+712,Rutgers,Kolt Dieterich,LT,77
+712,Rutgers,Malik Phillips,WR,77
+712,Rutgers,Quinton Williams,RT,76
+712,Rutgers,Luke Eckardt,LT,76
+712,Rutgers,Ca Lub Holloway,LOLB,75
+712,Rutgers,Cecil Powell,SS,75
+712,Rutgers,Emon Allen,CB,75
+712,Rutgers,Fernando Garza Iii,TE,75
+712,Rutgers,Trey Harris,FS,75
+712,Rutgers,Jaidan Scott,FS,75
+712,Rutgers,Shane Johnson,WR,75
+712,Rutgers,Aviyon Smith Mack,WR,74
+712,Rutgers,Jace Arnold,CB,74
+712,Rutgers,Jeremy Fitzgerald,C,74
+712,Rutgers,Deshawn Kirby,DT,74
+712,Rutgers,Tyler Bailey,CB,72
+712,Rutgers,Jacquis Ishmeal Jr,LOLB,72
+712,Rutgers,Lonnie Adkism,WR,72
+712,Rutgers,Will Hutchens,LG,72
+712,Rutgers,Mich Le Joseph,LG,72
+712,Rutgers,Austin Smith,TE,72
+712,Rutgers,Mabrey Mettauer,QB,71
+712,Rutgers,Railyn Adams,FS,71
+712,Rutgers,Kesean Raven,CB,71
+712,Rutgers,Bubba Kimbrough,LT,70
+712,Rutgers,Darrick Bledsoe Iii,WR,70
+712,Rutgers,Jamair Diaz,MLB,70
+712,Rutgers,Joshua Frayre,DT,70
+712,Rutgers,Carter Buchheit,RT,70
+712,Rutgers,Jeremiah Edmond,RG,70
+712,Rutgers,Cam Todd,C,70
+712,Rutgers,Jalen Stevens,C,69
+712,Rutgers,Jaredh Frayre,DT,69
+712,Rutgers,Forest Gatlin Iii,MLB,69
+712,Rutgers,Dravon Wilson,CB,68
+712,Rutgers,Carson Whitington,TE,68
+712,Rutgers,Eli Wallace,ROLB,67
+712,Rutgers,Dean Ford,ROLB,65
+712,Rutgers,Kyle Bruce,TE,65
+712,Rutgers,Colby Sessums,K,64
+712,Rutgers,Jalyn Stanford,SS,64
+712,Rutgers,Gannon Tullos,ROLB,64
+712,Rutgers,Byron Green,WR,64
+712,Rutgers,Landyn Locke,QB,63
+712,Rutgers,Elijah Hardy,MLB,63
+712,Rutgers,Tim Rials,WR,63
+712,Rutgers,Braylen Wortham,FS,62
+712,Rutgers,Zach Stricker,TE,62
+712,Rutgers,Dj Bailey,QB,61
+712,Rutgers,R J Massey,FB,61
+712,Rutgers,Caius Coy,LOLB,61
+712,Rutgers,Christian Pavon,K,60
+712,Rutgers,Logan Cahill,RG,60
+712,Rutgers,Graceson Spann,RT,60
+712,Rutgers,Cooper Stevens,TE,60
+712,Rutgers,Jojo Robinson Jr,CB,57
+712,Rutgers,Kordell Lathan,MLB,48
+713,Sam Houston,Joseph Borjon,RT,87
+713,Sam Houston,Chris Johnson,CB,86
+713,Sam Houston,Sam Benjamin,DT,86
+713,Sam Houston,Jordan Napier,WR,85
+713,Sam Houston,Dallas Fincher,LG,85
+713,Sam Houston,Tevin Warner,LG,85
+713,Sam Houston,Bryce Phillips,CB,84
+713,Sam Houston,Owen Chambliss,ROLB,84
+713,Sam Houston,Kalan Ellis,RG,83
+713,Sam Houston,Eric Butler,FS,83
+713,Sam Houston,Cordell Lyons,LG,82
+713,Sam Houston,Ross Ulugalu Maseuli,C,81
+713,Sam Houston,Dalesean Staley,SS,81
+713,Sam Houston,Tano Letuli,MLB,80
+713,Sam Houston,Jelani Whitmore,CB,80
+713,Sam Houston,Tyler Irving,LOLB,80
+713,Sam Houston,Christian Jones,LT,80
+713,Sam Houston,Josiah Cox,SS,79
+713,Sam Houston,Dj Herman,ROLB,77
+713,Sam Houston,Tyler Mcmahan,RG,77
+713,Sam Houston,Brady Anderson,MLB,77
+713,Sam Houston,Jacob Bostick,WR,77
+713,Sam Houston,Teivis Tuioti,DT,76
+713,Sam Houston,Cortez Mayo,FB,76
+713,Sam Houston,Arthur Ban,TE,76
+713,Sam Houston,Deshawn Mccuin,FS,75
+713,Sam Houston,Jayden Denegal,QB,75
+713,Sam Houston,Mister Williams,MLB,75
+713,Sam Houston,Creed Barnett,FB,75
+713,Sam Houston,Mikey Welsh,WR,75
+713,Sam Houston,Cam May,LT,74
+713,Sam Houston,Seth Adams,TE,74
+713,Sam Houston,Bert Emanuel Jr,QB,73
+713,Sam Houston,Jerry Mcclure,WR,73
+713,Sam Houston,Dwayne Mcdougle,FS,73
+713,Sam Houston,Jae Jennings,LOLB,73
+713,Sam Houston,Jatavious Magee,CB,73
+713,Sam Houston,Max Garrison,FS,72
+713,Sam Houston,Saipale Fuimaono,LT,72
+713,Sam Houston,Zhaire Hankins,WR,72
+713,Sam Houston,Jelani Mclaughlin,SS,72
+713,Sam Houston,Tyson Chavez,TE,71
+713,Sam Houston,Orlando Jackson,C,71
+713,Sam Houston,Michael Levelle Watkins,RG,71
+713,Sam Houston,Ben Patterson,RT,71
+713,Sam Houston,Derrick Mobley,LOLB,71
+713,Sam Houston,Will Cianfrini,WR,71
+713,Sam Houston,Josh Hunter,CB,70
+713,Sam Houston,Nathan Acevedo,WR,70
+713,Sam Houston,Nate Mcneal,RT,69
+713,Sam Houston,Prince Williams,CB,69
+713,Sam Houston,Parker Threatt,WR,69
+713,Sam Houston,Jp Mialovski,QB,68
+713,Sam Houston,Reggie Jarrett,ROLB,68
+713,Sam Houston,Ben Scolari,WR,67
+713,Sam Houston,Tanner Williams,ROLB,67
+713,Sam Houston,Gabriel Plascencia,K,65
+713,Sam Houston,Don Callahan,C,65
+713,Sam Houston,Malachi Finau,DT,65
+713,Sam Houston,Ryan Wolfer,TE,65
+713,Sam Houston,Marshall Carrington,DT,64
+713,Sam Houston,Kyle Crum,QB,63
+713,Sam Houston,Hunter Haines,SS,63
+713,Sam Houston,Isaiah Buxton,CB,63
+713,Sam Houston,Kodi Cornelius,DT,62
+713,Sam Houston,Demar Johnson,MLB,61
+713,Sam Houston,Heath Mcree,WR,61
+713,Sam Houston,Ray Winston Wheeler,RG,58
+713,Sam Houston,Nick Clegg,K,57
+713,Sam Houston,Ben Fleming,DT,56
+713,Sam Houston,Aaron Westberry,P,56
+713,Sam Houston,Jackson Ford,TE,53
+713,Sam Houston,Cody Wilber,P,45
+714,San Diego State,Ethan Powell,LOLB,87
+714,San Diego State,Jordan Pollard,MLB,86
+714,San Diego State,Taniela Latu,ROLB,85
+714,San Diego State,Jackson Canaan,TE,84
+714,San Diego State,Hudson Mesa,C,84
+714,San Diego State,Adam Matthews,QB,83
+714,San Diego State,Isiah Revis,FS,83
+714,San Diego State,Noah Mcneal Franklin,MLB,83
+714,San Diego State,Peseti Lapuaho,LT,83
+714,San Diego State,Gafa Faga,DT,82
+714,San Diego State,Mason Starling,WR,82
+714,San Diego State,Darien Aldridge,WR,81
+714,San Diego State,Walker Eget,QB,80
+714,San Diego State,Matthew Coleman,WR,79
+714,San Diego State,Mark Quincy,LG,79
+714,San Diego State,Uluakinofo Taliauli,RG,79
+714,San Diego State,Sione Nomani,LG,78
+714,San Diego State,Jalen Apalit Williams,SS,78
+714,San Diego State,Leland Smith,WR,78
+714,San Diego State,Runye Norton,CB,78
+714,San Diego State,John Norwood,ROLB,78
+714,San Diego State,Malachi Riley,WR,77
+714,San Diego State,Makoni Manukainiu,LT,76
+714,San Diego State,Tyler Chen,RG,76
+714,San Diego State,Nate Hale,RT,75
+714,San Diego State,Zane Carter,MLB,75
+714,San Diego State,Kejuan Bullard Jr,CB,75
+714,San Diego State,Malakai Hoeft,LOLB,75
+714,San Diego State,Manuel Serna,RT,75
+714,San Diego State,Jimmy Woodard,FB,75
+714,San Diego State,Denaris Derosa Jr,RG,74
+714,San Diego State,Joseph Harbert,C,74
+714,San Diego State,Jalen Bainer,CB,73
+714,San Diego State,Grant Norberg,TE,73
+714,San Diego State,Charles Cox Iii,FS,73
+714,San Diego State,Reggie Jones Jr,DT,73
+714,San Diego State,Blake Tabaracci,MLB,73
+714,San Diego State,David Tuihalangingie,ROLB,73
+714,San Diego State,Josh Steinbach,TE,72
+714,San Diego State,Maliki Crawford,CB,72
+714,San Diego State,Marzeal Smith,SS,72
+714,San Diego State,Damion Gilchrist,LG,71
+714,San Diego State,Hunter Nowell,SS,71
+714,San Diego State,Caleb Womack,CB,71
+714,San Diego State,Daniel Moleni,RT,71
+714,San Diego State,Akio Martinson,DT,71
+714,San Diego State,Kyri Shoels,WR,70
+714,San Diego State,Nassir Pitters,LOLB,70
+714,San Diego State,Larry Turner Gooden,SS,69
+714,San Diego State,Noa Siaosi,DT,69
+714,San Diego State,Calvin Essex,DT,68
+714,San Diego State,Joseph Bey,FS,68
+714,San Diego State,Jaylen Thomas,CB,68
+714,San Diego State,Cooper Hoch,WR,68
+714,San Diego State,Naseri Danielson,ROLB,68
+714,San Diego State,Denis Lynch,K,67
+714,San Diego State,Cayden Woolwine,MLB,67
+714,San Diego State,Dylan Lee,MLB,67
+714,San Diego State,Nathan Balestrieri,RG,67
+714,San Diego State,Justice Turner,C,66
+714,San Diego State,Tama Amisone,QB,65
+714,San Diego State,David Perez,LG,65
+714,San Diego State,Mitchell Brown,LT,65
+714,San Diego State,Trent Carrizosa,P,64
+714,San Diego State,Xavier Ward,QB,64
+714,San Diego State,Malik Powers,CB,64
+714,San Diego State,Mohammad Othman,RT,63
+714,San Diego State,Kamaehu Kopa Kaawalauole,TE,62
+714,San Diego State,Aj Campos,TE,60
+714,San Diego State,Jordan Tonga,C,60
+714,San Diego State,Timmie Barton,WR,57
+714,San Diego State,Jimmy Garrard,RG,54
+714,San Diego State,Greco Carrillo,CB,52
+714,San Diego State,Mathias Brown,K,50
+715,San Jose State,Isaiah Nwokobia,SS,91
+715,San Jose State,Logan Parr,LG,90
+715,San Jose State,Kevin Jennings,QB,89
+715,San Jose State,Rj Maryland,TE,89
+715,San Jose State,Ahmaad Moses,FS,89
+715,San Jose State,Pj Williams,RT,88
+715,San Jose State,Rocket Rahimi,SS,88
+715,San Jose State,Matthew Hibner,TE,87
+715,San Jose State,Yamir Knight,WR,86
+715,San Jose State,Jeffrey M Ba,DT,86
+715,San Jose State,Keveion Ta Spears,DT,86
+715,San Jose State,Savion Byrd,LT,85
+715,San Jose State,Jordan Hudson,WR,84
+715,San Jose State,Deuce Harmon,CB,84
+715,San Jose State,Addison Nichols,RG,84
+715,San Jose State,Terry Webb,DT,83
+715,San Jose State,Brandon Miyazono,MLB,83
+715,San Jose State,Alexander Kilgore,MLB,82
+715,San Jose State,James Altman,C,82
+715,San Jose State,Dylan Goffney,WR,81
+715,San Jose State,Tyler Van Dyke,QB,80
+715,San Jose State,Zion Nelson,RT,80
+715,San Jose State,Romello Brinson,WR,79
+715,San Jose State,Zakye Barker,ROLB,79
+715,San Jose State,Andrew Chamblee,LT,78
+715,San Jose State,Jonathan Jefferson,DT,77
+715,San Jose State,Damarjhe Lewis,DT,76
+715,San Jose State,Blake Burris,DT,76
+715,San Jose State,Stone Eby,FB,76
+715,San Jose State,Case Holleron,WR,76
+715,San Jose State,Nate Anderson,LG,75
+715,San Jose State,Jalen Cooper,WR,75
+715,San Jose State,Jaelyn Davis Robinson,CB,74
+715,San Jose State,Collin Rogers,K,73
+715,San Jose State,Justin Medlock,MLB,73
+715,San Jose State,Jack Laphen,RT,73
+715,San Jose State,Brock O Quinn,TE,73
+715,San Jose State,Paris Patterson Jr,LG,72
+715,San Jose State,Morgan Tribbett,TE,72
+715,San Jose State,Jaden Milliner Jones,SS,71
+715,San Jose State,Gabriel Patterson,P,70
+715,San Jose State,Alex Woods,RG,70
+715,San Jose State,Joshua Bates,C,70
+715,San Jose State,Mark Iheanachor,ROLB,70
+715,San Jose State,William Nettles,CB,70
+715,San Jose State,Henry Douglass,RG,70
+715,San Jose State,Daylon Singleton,WR,69
+715,San Jose State,Kyron Chambers,CB,69
+715,San Jose State,Adam Moore,TE,68
+715,San Jose State,William Spencer,DT,68
+715,San Jose State,Brendan Mullen,RT,68
+715,San Jose State,Ty Hawkins,QB,67
+715,San Jose State,Grant Griffin,CB,67
+715,San Jose State,Graham Uter,C,67
+715,San Jose State,Drew Hill,LG,66
+715,San Jose State,King Large,RT,66
+715,San Jose State,Leron Boss,SS,66
+715,San Jose State,Miles Uter,TE,65
+715,San Jose State,Elijah Pratt,FS,64
+715,San Jose State,Jaxson Lavender,WR,64
+715,San Jose State,Armani Medlock,FS,64
+715,San Jose State,Carterrious Brown,WR,63
+715,San Jose State,Tripp Riordan,TE,63
+715,San Jose State,Abdul Muhammad,FS,62
+715,San Jose State,Dramodd Odoms,LT,60
+715,San Jose State,Marcellus Barnes Jr,CB,59
+715,San Jose State,B J Streeter,RG,59
+715,San Jose State,Sam Keltner,K,54
+715,San Jose State,Jaylen Moses,FS,54
+715,San Jose State,Cameron Roberson,LOLB,51
+715,San Jose State,Brandon Booker,ROLB,49
+716,SMU,Ar Maj Reed Adams,RG,93
+716,SMU,Trey Zuhn Iii,LT,91
+716,SMU,Kevin Concepcion,WR,90
+716,SMU,Taurean York,ROLB,90
+716,SMU,Dametrious Crownover,RT,90
+716,SMU,Albert Regis,DT,90
+716,SMU,Tyler Onyedim,DT,88
+716,SMU,Dalton Brooks,SS,88
+716,SMU,Will Lee Iii,CB,88
+716,SMU,Chase Bisontis,LG,88
+716,SMU,Scooby Williams,MLB,88
+716,SMU,Amari Niblack,TE,87
+716,SMU,Nate Boerkircher,TE,87
+716,SMU,Kolinu U Faaiu,C,86
+716,SMU,Mark Nabou Jr,C,85
+716,SMU,Marcel Reed,QB,84
+716,SMU,Daymion Sanford,MLB,84
+716,SMU,Bravion Rogers,CB,83
+716,SMU,Jacob Zeno,QB,83
+716,SMU,Trent Carroll,FB,83
+716,SMU,Trey Hall,DT,82
+716,SMU,Bryce Anderson,FS,81
+716,SMU,Theo Melin Ohrstrom,TE,81
+716,SMU,Jordan Shaw,CB,80
+716,SMU,Marcus Ratcliffe,SS,80
+716,SMU,Mario Craver,WR,79
+716,SMU,Tyreek Chappell,CB,79
+716,SMU,Dezz Ricks,CB,78
+716,SMU,Jonah Wilson,WR,77
+716,SMU,Julian Humphrey,CB,76
+716,SMU,Dj Hicks,DT,76
+716,SMU,Jordan Lockhart,ROLB,76
+716,SMU,Jayvon Thomas,CB,75
+716,SMU,Jordan Pride,CB,75
+716,SMU,Brady Bradshaw,P,74
+716,SMU,Terry Bussey,WR,74
+716,SMU,Brady Hart,QB,74
+716,SMU,Jarred Kerr,FS,73
+716,SMU,Robert Bourdon,LT,73
+716,SMU,Myles Davis,FS,72
+716,SMU,Tristan Jernigan,ROLB,72
+716,SMU,Randy Bond,K,71
+716,SMU,Lamont Rogers,LT,71
+716,SMU,Ashton Funk,LG,71
+716,SMU,Reuben Fatheree Ii,RT,70
+716,SMU,Jared Zirkel,K,70
+716,SMU,Micah Riley,TE,70
+716,SMU,Blake Ivy,RG,70
+716,SMU,Marcus Garcia,RT,70
+716,SMU,Tristan Norman,WR,69
+716,SMU,Dealyn Evans,DT,68
+716,SMU,Jacob Graham,TE,68
+716,SMU,Blake Richmond,LOLB,67
+716,SMU,Ashton Bethel Roman,WR,67
+716,SMU,Tyler White,P,66
+716,SMU,Kiotti Armstrong,TE,66
+716,SMU,Deyjhon Pettaway,CB,66
+716,SMU,Rashad Johnson Jr,SS,66
+716,SMU,Levi Hancock,TE,66
+716,SMU,Joshua Moses,C,65
+716,SMU,Kelvion Riggins,LOLB,65
+716,SMU,Cody Smith,RG,64
+716,SMU,Kevin Russo,LOLB,63
+716,SMU,Miles O Neill,QB,63
+716,SMU,Isendre Ahfua,LG,61
+716,SMU,Eli Morcos,QB,60
+716,SMU,Izaiah Williams,WR,59
+716,SMU,A J Bridges,LG,54
+716,SMU,Chase Brown,MLB,53
+716,SMU,Sidney Ware,LOLB,49
+727,Texas A&M,Dorion Strawn,LT,86
+727,Texas A&M,Tellek Lockette,RG,85
+727,Texas A&M,Beau Sparks,WR,84
+727,Texas A&M,Deon Mckinley,SS,84
+727,Texas A&M,Michael Beckett,RG,84
+727,Texas A&M,Chris Dawn Jr,WR,83
+727,Texas A&M,Mavin Anderson,WR,83
+727,Texas A&M,Bobby Crosby,SS,82
+727,Texas A&M,Darius Jackson,FS,82
+727,Texas A&M,Treylin Payne,ROLB,82
+727,Texas A&M,Ryan Nolan,SS,81
+727,Texas A&M,Brian Gonzalez,LOLB,81
+727,Texas A&M,Nate Yarnell,QB,80
+727,Texas A&M,Terrence Cooks,MLB,80
+727,Texas A&M,Trez Moore,CB,79
+727,Texas A&M,Emeka Obigbo,LG,79
+727,Texas A&M,Ezra Dotson Oyetade,C,79
+727,Texas A&M,Kyran Bourda,DT,78
+727,Texas A&M,Khamari Terrell,CB,77
+727,Texas A&M,Lysander Moeolo,LG,77
+727,Texas A&M,Titus Lyons,TE,76
+727,Texas A&M,Ayden Jones,ROLB,76
+727,Texas A&M,Ty Stamey,TE,75
+727,Texas A&M,Jaden Rios,CB,75
+727,Texas A&M,Michael Nwokocha,DT,75
+727,Texas A&M,Michael Boudoin Iii,LOLB,75
+727,Texas A&M,Terrance Ballentine,FS,75
+727,Texas A&M,Kameron Pearson,FS,75
+727,Texas A&M,Sully Burns,RT,75
+727,Texas A&M,Anfernee Crease,LT,75
+727,Texas A&M,Javis Mynatt,SS,74
+727,Texas A&M,Kamren Washington,DT,74
+727,Texas A&M,Charlie Leota,DT,73
+727,Texas A&M,Jordan Sanders,DT,73
+727,Texas A&M,Canden Grogan,CB,73
+727,Texas A&M,Holden Geriner,QB,72
+727,Texas A&M,Devarrick Woods,DT,72
+727,Texas A&M,Justin Deleon,RG,71
+727,Texas A&M,Blake Smith,TE,70
+727,Texas A&M,Brad Jackson,QB,70
+727,Texas A&M,L J Johnson Jr,WR,70
+727,Texas A&M,Chantz Johnson,MLB,70
+727,Texas A&M,Cole Nilles,ROLB,70
+727,Texas A&M,Eric Reddick,WR,70
+727,Texas A&M,Austin Turner,TE,70
+727,Texas A&M,Aidin Rhodes,LT,70
+727,Texas A&M,Malik Willis,CB,69
+727,Texas A&M,Alan Grimme,LG,69
+727,Texas A&M,Ashton Heflin,MLB,69
+727,Texas A&M,Will Mitchell,FS,68
+727,Texas A&M,Bami Badusi,RT,68
+727,Texas A&M,Keldric Luster,QB,67
+727,Texas A&M,Chase Davis,CB,67
+727,Texas A&M,Brock Riker,C,67
+727,Texas A&M,Colt Sparks,QB,65
+727,Texas A&M,Jake Simpson,TE,65
+727,Texas A&M,D Ante Keys,LOLB,65
+727,Texas A&M,Gavin Parkhurst,QB,64
+727,Texas A&M,William Shaw,C,64
+727,Texas A&M,Roosevelt Barnett,FB,64
+727,Texas A&M,Jaren Herring,K,63
+727,Texas A&M,Skylar Lewis,WR,62
+727,Texas A&M,Tyler Norris,RT,61
+727,Texas A&M,Kylen Evans,WR,60
+727,Texas A&M,Cameron Schultz,RG,58
+727,Texas A&M,John Palumbo,RT,57
+727,Texas A&M,Preston Ward,LG,55
+727,Texas A&M,Cordarian Powell,CB,54
+727,Texas A&M,David Nunez,P,49
+727,Texas A&M,Heath Ward,K,48
+728,Texas State,Jacob Rodriguez,ROLB,91
+728,Texas State,Behren Morton,QB,91
+728,Texas State,Ben Roberts,MLB,91
+728,Texas State,Lee Hunter,DT,89
+728,Texas State,Skyler Gill Howard,DT,89
+728,Texas State,Terrance Carter,TE,88
+728,Texas State,Sheridan Wilson,C,88
+728,Texas State,Will Jados,LT,88
+728,Texas State,Vinny Sciury,LG,87
+728,Texas State,Reggie Virgil,WR,87
+728,Texas State,Davion Carter,RG,87
+728,Texas State,Caleb Douglas,WR,87
+728,Texas State,Maurion Horn,CB,87
+728,Texas State,Coy Eakin,WR,86
+728,Texas State,E Maurion Banks,DT,86
+728,Texas State,Bryce Ramirez,ROLB,86
+728,Texas State,Dontae Balfour,CB,85
+728,Texas State,Howard Sampson,LT,85
+728,Texas State,Chapman Lewis,FS,84
+728,Texas State,A J Mccarty,CB,83
+728,Texas State,Anthony Holmes Jr,DT,83
+728,Texas State,Brenden Jordan,SS,83
+728,Texas State,Cash Cleveland,C,83
+728,Texas State,John Curry,MLB,81
+728,Texas State,T J West,WR,81
+728,Texas State,Johncarlos Miller Ii,TE,80
+728,Texas State,Brice Pollock,CB,80
+728,Texas State,Mitch Griffis,QB,80
+728,Texas State,Caleb Rodkey,C,80
+728,Texas State,Hunter Zambrano,RG,79
+728,Texas State,Braylon Rigsby,DT,79
+728,Texas State,Micah Hudson,WR,78
+728,Texas State,Macho Stevenson,CB,78
+728,Texas State,Amier Boyd,CB,78
+728,Texas State,Jayden Cofield,DT,76
+728,Texas State,Rylan Vagana,TE,76
+728,Texas State,Will Hammond,QB,76
+728,Texas State,Holton Hendrix,RG,76
+728,Texas State,Blake Dempsey,FB,76
+728,Texas State,Maurice Rodriques,LT,75
+728,Texas State,Ted Grimm,RG,75
+728,Texas State,Grant Mcdaniel,QB,74
+728,Texas State,Trent Low,MLB,74
+728,Texas State,Alex Turnbull,RT,73
+728,Texas State,Miquel Dingle Jr,SS,72
+728,Texas State,Daniel Sill,RT,71
+728,Texas State,Jacob Ponton,LT,70
+728,Texas State,Jason Llewellyn,TE,70
+728,Texas State,Jalen Winfree,RG,68
+728,Texas State,Lane Baker,ROLB,68
+728,Texas State,Upton Bellenfant,K,67
+728,Texas State,Mikal Harrison Pilot,FS,67
+728,Texas State,Kelby Valsin,WR,67
+728,Texas State,George Price,LG,67
+728,Texas State,Samuel Crawford,LT,67
+728,Texas State,Malik Esquerra,FS,66
+728,Texas State,Leyton Stone,WR,66
+728,Texas State,Horace Ghent,RT,66
+728,Texas State,Ellis Davis,RT,65
+728,Texas State,Jack Burgess,P,64
+728,Texas State,Tyson Turner,WR,64
+728,Texas State,Patrick Mcmath,LG,62
+728,Texas State,Marcus Ramon Edwards,SS,61
+728,Texas State,Braxton Harris,SS,61
+728,Texas State,Wesley Smith,MLB,61
+728,Texas State,Peyton Morgan,FS,60
+728,Texas State,Deante Lindsay,CB,60
+728,Texas State,Mylo Taylor,SS,60
+728,Texas State,Nehemiah Wynn,CB,59
+728,Texas State,Brien Moore,FS,58
+728,Texas State,Trey Jackson,WR,56
+728,Texas State,Stone Harrington,K,52
+728,Texas State,Justin Horne,MLB,51
+729,Texas Tech,Emmanuel Mcneil Warren,SS,90
+729,Texas Tech,Junior Vandeross Iii,WR,86
+729,Texas Tech,Braden Awls,CB,86
+729,Texas Tech,Carter Fouty,LG,86
+729,Texas Tech,Jeremiah Peters,LOLB,86
+729,Texas Tech,Ethan Spoth,RG,85
+729,Texas Tech,Trayvon Rudolph,WR,84
+729,Texas Tech,Terrence Moore,C,84
+729,Texas Tech,Nasir Bowers,CB,84
+729,Texas Tech,Avery Smith,CB,84
+729,Texas Tech,Tucker Gleason,QB,84
+729,Texas Tech,Martez Poynter,DT,84
+729,Texas Tech,K Von Sherman,MLB,82
+729,Texas Tech,Esean Carter,DT,82
+729,Texas Tech,Andre Fuller,CB,82
+729,Texas Tech,Cole Rhett,RT,81
+729,Texas Tech,Jacob Petersen,TE,80
+729,Texas Tech,Tashi Braceful,WR,80
+729,Texas Tech,Damon Ollison Ii,ROLB,79
+729,Texas Tech,Langston Long,MLB,79
+729,Texas Tech,Maddox Marcotte,C,79
+729,Texas Tech,Jaden Dottin,FS,78
+729,Texas Tech,Eric Holley Iii,WR,78
+729,Texas Tech,Marcus Batten,SS,78
+729,Texas Tech,Phillip Snead,LT,78
+729,Texas Tech,Stephen Gales,LT,77
+729,Texas Tech,John Allen,SS,77
+729,Texas Tech,Jonathan Harder,LT,76
+729,Texas Tech,Amare Snowden,CB,76
+729,Texas Tech,Michael Glenn Matthews,LG,76
+729,Texas Tech,Tyler Hackenbracht,FS,76
+729,Texas Tech,Dom Redmond,FB,76
+729,Texas Tech,Cc Ezirim,TE,75
+729,Texas Tech,Thomas Zsiros,WR,75
+729,Texas Tech,Brett Lockhart,TE,75
+729,Texas Tech,Cooper Rusk,WR,75
+729,Texas Tech,Jediyah Willoughby,WR,75
+729,Texas Tech,Brian Keane,C,75
+729,Texas Tech,Braedyn Moore,FS,74
+729,Texas Tech,Doran Ray Jr,DT,74
+729,Texas Tech,Terrell Crosby Jr,WR,73
+729,Texas Tech,Braxton Harrison,SS,72
+729,Texas Tech,John Alan Richter,QB,72
+729,Texas Tech,Bryson Hammer,WR,72
+729,Texas Tech,Chris D Appolonia,ROLB,71
+729,Texas Tech,Kalieb Osborne,QB,70
+729,Texas Tech,Matt Hofer,LT,70
+729,Texas Tech,Walter Moses,QB,69
+729,Texas Tech,Tyler Mckinstry,CB,69
+729,Texas Tech,Grant Zimmerly,RG,68
+729,Texas Tech,Julian Allen,WR,68
+729,Texas Tech,Christian Medlock,LG,68
+729,Texas Tech,Matthew Bailey,TE,68
+729,Texas Tech,Laith Shamma,DT,67
+729,Texas Tech,Jacob Kropchak,RG,67
+729,Texas Tech,Connor Jones,TE,66
+729,Texas Tech,Zy Marion Lang,WR,66
+729,Texas Tech,Jordin Farrow,DT,66
+729,Texas Tech,Emilio Duran,P,65
+729,Texas Tech,Anthony Boswell,LG,65
+729,Texas Tech,Dennis Charles,FS,65
+729,Texas Tech,Jake Dehaan,QB,64
+729,Texas Tech,Jaden Evans,RT,63
+729,Texas Tech,Jake Grimm,C,63
+729,Texas Tech,Trae Gaston,MLB,62
+729,Texas Tech,Kamren Flowers,WR,61
+729,Texas Tech,Maddox Arnold,MLB,60
+729,Texas Tech,Rickey Williams,LOLB,59
+729,Texas Tech,Glenn Spade,K,59
+729,Texas Tech,Hyajah Miller,CB,57
+729,Texas Tech,Jude Jenkins,RT,57
+729,Texas Tech,Carlos Hazelwood,DT,56
+729,Texas Tech,Cole Stewart,LG,56
+729,Texas Tech,Nicholas Thompson,FS,54
+730,Toledo,Goose Crowder,QB,84
+730,Toledo,Zerian Hudson,LG,84
+730,Toledo,Julian Peterson,DT,83
+730,Toledo,Jordan Perry,LOLB,83
+730,Toledo,Eli Russ,LG,82
+730,Toledo,Rara Thomas,WR,82
+730,Toledo,Jordan Stringer,MLB,82
+730,Toledo,Devin Lafayette,LOLB,82
+730,Toledo,Malik Ellis,LT,81
+730,Toledo,Trent Henry,CB,81
+730,Toledo,Justin Powe,SS,81
+730,Toledo,Peyton Higgins,WR,80
+730,Toledo,Taleeq Robbins,DT,80
+730,Toledo,Gabriel Elfman,RT,80
+730,Toledo,Elijah Prather,LT,79
+730,Toledo,Kam Curry,DT,79
+730,Toledo,Matt Henry,RG,79
+730,Toledo,Steven Cattledge,ROLB,79
+730,Toledo,Ethan Conner,TE,78
+730,Toledo,Vysen Lang,C,78
+730,Toledo,Dariyonne Bryant,WR,78
+730,Toledo,Trae Swartz,TE,78
+730,Toledo,Tyler Cappi,C,78
+730,Toledo,Luis Medina,DT,77
+730,Toledo,Zeriah Beason,WR,77
+730,Toledo,Grant Barton,FS,77
+730,Toledo,Kaleno Levine,CB,77
+730,Toledo,Kyler Gibson,LT,77
+730,Toledo,Tucker Kilcrease,QB,76
+730,Toledo,Luke Hodge,MLB,76
+730,Toledo,Az Williams,FS,76
+730,Toledo,Jamel Fils Aime,DT,75
+730,Toledo,Mark Britton,MLB,75
+730,Toledo,Steven Sannieniola,SS,74
+730,Toledo,Garner Langlo,RT,74
+730,Toledo,Dorion Jackson,CB,74
+730,Toledo,Tray Taylor,WR,73
+730,Toledo,Tj Thompson,ROLB,73
+730,Toledo,Rondell Carter,SS,73
+730,Toledo,Jaquez White,CB,73
+730,Toledo,Keyshawn Campbell,MLB,73
+730,Toledo,Mojo Dortch,WR,72
+730,Toledo,Kristian Tate,WR,72
+730,Toledo,Paul Bowling,RT,72
+730,Toledo,Roman Mothershed,WR,72
+730,Toledo,Kamal Matthews,FS,72
+730,Toledo,Malaki Pegues,LOLB,72
+730,Toledo,Scott Taylor Renfroe,K,71
+730,Toledo,Kc Bradford,FS,71
+730,Toledo,Jackson Thomas,WR,71
+730,Toledo,Justin Mills,RG,70
+730,Toledo,Joe Lott,FS,69
+730,Toledo,Casey Fua Au,RT,68
+730,Toledo,Caleb Ash,RT,68
+730,Toledo,Jack James,QB,67
+730,Toledo,Noah Mercer,LG,67
+730,Toledo,Patrick Screws Jr,RG,66
+730,Toledo,Chad Barham,TE,66
+730,Toledo,Jackson Worley,TE,65
+730,Toledo,Kam Weaver,ROLB,65
+730,Toledo,Shemar Welch,CB,65
+730,Toledo,Keion Dunlap,SS,65
+730,Toledo,Adam Pemberton,TE,65
+730,Toledo,Tyler Bell,C,62
+730,Toledo,Dylan Mann,DT,61
+730,Toledo,Zeke Robinson,CB,60
+730,Toledo,Treo Donald,FB,60
+730,Toledo,Alex Ellison,LT,59
+730,Toledo,Colton Walls,TE,59
+730,Toledo,Keshun June,LT,56
+730,Toledo,Evan Crenshaw,P,55
+730,Toledo,Kletus Watts,C,53
+730,Toledo,Adam Ford,QB,52
+731,Troy,Shadre Hurst,LG,89
+731,Troy,Derrick Graham,LT,88
+731,Troy,Sam Howard,ROLB,88
+731,Troy,Kadin Semonza,QB,85
+731,Troy,Kameron Hamilton,DT,84
+731,Troy,Jack Hollifield,C,83
+731,Troy,Omari Hayes,WR,83
+731,Troy,Tre Shackelford,WR,83
+731,Troy,Bailey Despanie,SS,82
+731,Troy,Jack Tchienchou,FS,82
+731,Troy,Kevin Adams Iii,SS,82
+731,Troy,Bryce Bohanon,WR,82
+731,Troy,Brendan Sullivan,QB,82
+731,Troy,Elijah Champaigne,DT,82
+731,Troy,Shazz Preston,WR,81
+731,Troy,Justyn Reid,TE,80
+731,Troy,John Bock Ii,RG,80
+731,Troy,Derrick Shepard Jr,DT,79
+731,Troy,Dickson Agu,MLB,79
+731,Troy,Makai Williams,MLB,79
+731,Troy,Chris Rodgers,ROLB,77
+731,Troy,Jordan Hall,RT,77
+731,Troy,Trevon Mcalpine,DT,76
+731,Troy,Isaiah Wadsworth,CB,76
+731,Troy,Anthony Brown Stephens,WR,76
+731,Troy,Jimmy Calloway,WR,75
+731,Troy,Javion White,CB,75
+731,Troy,Anthony Miller,TE,75
+731,Troy,Jean Claude Joseph Iii,ROLB,75
+731,Troy,Elijah Baker,C,75
+731,Troy,Lj Green,CB,74
+731,Troy,Dallas Winner Johnson,MLB,74
+731,Troy,Eliyt Nairne,DT,74
+731,Troy,Landry Cannon,LG,74
+731,Troy,Donovan Leary,QB,73
+731,Troy,Cameron Roberts,TE,73
+731,Troy,Jayce Mitchell,C,73
+731,Troy,Kc Eziomume,CB,72
+731,Troy,Reese Baker,LT,72
+731,Troy,Dominic Steward,RG,71
+731,Troy,Darion Reed,RT,71
+731,Troy,Joshua Moore,FS,71
+731,Troy,Mitch Hodnett,LT,71
+731,Troy,Jason Arredondo,TE,71
+731,Troy,Jaxon Ducre,LG,71
+731,Troy,Shaun Nicholas,WR,71
+731,Troy,Kellen Tasby,QB,70
+731,Troy,Tavare Smith,LOLB,70
+731,Troy,Dashone Neal,TE,70
+731,Troy,Tristen Fortenberry,RT,69
+731,Troy,Jahiem Johnson,CB,69
+731,Troy,Chase Green,FS,69
+731,Troy,Joshua Brantley,QB,68
+731,Troy,Jayden Lewis,CB,68
+731,Troy,Colin O Carroll,C,68
+731,Troy,Ray Knott,K,67
+731,Troy,Daquan Greer,DT,67
+731,Troy,Warren Roberts Jr,ROLB,66
+731,Troy,E Zaiah Shine,CB,66
+731,Troy,Gavin Moore,TE,66
+731,Troy,Leron Husbands,TE,65
+731,Troy,Zachery Jennings,QB,65
+731,Troy,Michael Igbinoghene,CB,64
+731,Troy,Oliver Mitchell Jr,WR,63
+731,Troy,Antwaun Parham,CB,62
+731,Troy,Gresham Perry,LG,62
+731,Troy,William Hudlow,P,59
+731,Troy,Jett Toussaint,WR,59
+731,Troy,Patrick Durkin,K,58
+731,Troy,Ameer Billups,FB,57
+731,Troy,Kenyan Clark,LT,52
+731,Troy,Justin Kingman,P,50
+732,Tulane,Codie Hornsby,C,85
+732,Tulane,Jeremiah Ballard,WR,84
+732,Tulane,Sean Hill,LG,84
+732,Tulane,Dave Blackburn,LG,83
+732,Tulane,Elijah Green,CB,82
+732,Tulane,Mekhi Miller,WR,82
+732,Tulane,Tim Hardiman,DT,82
+732,Tulane,Braylin Presley,WR,81
+732,Tulane,Simon Wilson,C,80
+732,Tulane,Jaquan Adams,LT,80
+732,Tulane,Devin Robinson,LOLB,80
+732,Tulane,Ty Cooper,MLB,80
+732,Tulane,Zach Williams,SS,79
+732,Tulane,Joe Hjelle,DT,79
+732,Tulane,Kirk Francis,QB,79
+732,Tulane,Zion Steptoe,WR,79
+732,Tulane,Tai Newhouse,DT,78
+732,Tulane,Chris Thompson,MLB,78
+732,Tulane,Georderrial Williams,CB,78
+732,Tulane,Ender Aguilar,RG,78
+732,Tulane,Grayson Tempest,WR,78
+732,Tulane,Jd Drew,CB,77
+732,Tulane,Nahki Johnson,DT,77
+732,Tulane,Calvin Johnson Ii,WR,77
+732,Tulane,Keuan Parker,CB,77
+732,Tulane,Nunu Campbell,CB,77
+732,Tulane,Jehlen Cannady,FS,76
+732,Tulane,D J Warner,FS,76
+732,Tulane,Will Morris,LG,76
+732,Tulane,Zion Booker,WR,75
+732,Tulane,Anthony Romphf,CB,75
+732,Tulane,Ty Williams,SS,75
+732,Tulane,Bennett Ringleb,RT,75
+732,Tulane,Buddha Garrett,LOLB,75
+732,Tulane,Tyler Rich,DT,75
+732,Tulane,Jewlyen Roberts,TE,75
+732,Tulane,Landen Lucas,TE,74
+732,Tulane,Edward Rossum,ROLB,74
+732,Tulane,Micah Tease,WR,73
+732,Tulane,C J Turner,SS,73
+732,Tulane,Logan Clinton,QB,73
+732,Tulane,Stockton Ryan,ROLB,73
+732,Tulane,Evan Mcclure,C,73
+732,Tulane,Josh Anglin,MLB,72
+732,Tulane,Ashton Williams,FS,72
+732,Tulane,Luke Boyd,MLB,72
+732,Tulane,Lento Smith,CB,72
+732,Tulane,Jack Hood,RT,71
+732,Tulane,Cam East,RG,71
+732,Tulane,Elijah Wilson,ROLB,71
+732,Tulane,Andrew Alford,QB,70
+732,Tulane,Brody Duffel,LT,70
+732,Tulane,Kenny Johnson,LT,69
+732,Tulane,Aquavious Dunbar,MLB,68
+732,Tulane,Colten Christian,RG,68
+732,Tulane,Hunter Erb,RT,67
+732,Tulane,Stephen Kittleman,QB,67
+732,Tulane,Dax Collins,FS,67
+732,Tulane,Dedaunte Scott,SS,67
+732,Tulane,Angus Davies,P,66
+732,Tulane,Seth Morgan,K,66
+732,Tulane,Brody Foley,TE,66
+732,Tulane,Tramon Gilchrist,FB,65
+732,Tulane,Tyson Macdonald,LT,64
+732,Tulane,Donnell Gee Jr,WR,64
+732,Tulane,Miguel Kelley,LT,62
+732,Tulane,Carson Horton,QB,61
+732,Tulane,Dashaun Combs,FS,59
+732,Tulane,Parker Stone,TE,51
+732,Tulane,Michael Slaba,K,49
+733,Tulsa,Aj Brown,SS,85
+733,Tulsa,Denver Warren,DT,84
+733,Tulsa,Iverson Hooks,WR,83
+733,Tulsa,Perry Fisher,CB,83
+733,Tulsa,Sirad Bryant,SS,81
+733,Tulsa,Kaleb Brown,WR,80
+733,Tulsa,Adam Lepkowski,C,80
+733,Tulsa,Corri Milliner,WR,79
+733,Tulsa,Tariq Watson,CB,79
+733,Tulsa,Nigel Tate,DT,79
+733,Tulsa,Eddy Toussom,MLB,79
+733,Tulsa,Baron Franks Ii,RT,79
+733,Tulsa,Jondarius Morgan,LT,78
+733,Tulsa,Jalen Cheek,CB,78
+733,Tulsa,Josh Baka,FS,77
+733,Tulsa,Rod Orr,RG,77
+733,Tulsa,Calib Perez,LG,77
+733,Tulsa,Brandon Hawkins Jr,WR,77
+733,Tulsa,Jason Riles Jr,MLB,77
+733,Tulsa,Eli Ennis,ROLB,76
+733,Tulsa,Devin Hightower,MLB,76
+733,Tulsa,T Sai Mcdaniel,CB,76
+733,Tulsa,Aj Johnson,WR,76
+733,Tulsa,Jaylen Elder,WR,75
+733,Tulsa,Evan Mccray,WR,75
+733,Tulsa,Brandon Franklin,ROLB,75
+733,Tulsa,Ryan Gunter,LG,75
+733,Tulsa,Thomas Hatch,LT,75
+733,Tulsa,Jax Van Zandt,ROLB,75
+733,Tulsa,Jalen Kitna,QB,74
+733,Tulsa,Gabriel Cline,TE,74
+733,Tulsa,Trey Miles,CB,74
+733,Tulsa,Eamon Smalls,DT,73
+733,Tulsa,Pierre Royster,FS,73
+733,Tulsa,Antonio Ferguson,TE,73
+733,Tulsa,Donald Lee,CB,73
+733,Tulsa,Nasir Bashir,CB,73
+733,Tulsa,Elijah Lagg,TE,73
+733,Tulsa,Tamarion Crumpley,CB,72
+733,Tulsa,Jeremiah Vessel,FS,72
+733,Tulsa,Logan Moore,LT,72
+733,Tulsa,George Sims,DT,72
+733,Tulsa,Jonah Delange,K,71
+733,Tulsa,Calvin Pitcher,SS,71
+733,Tulsa,J C Sivley,TE,71
+733,Tulsa,Ryder Burton,QB,70
+733,Tulsa,Evan Bishop,TE,70
+733,Tulsa,Dillon Kidd,DT,70
+733,Tulsa,Bobby Marshall,MLB,69
+733,Tulsa,Tylan Mcnichols,ROLB,69
+733,Tulsa,Gill Renfrow,QB,69
+733,Tulsa,Jasire Peterson,DT,67
+733,Tulsa,Duane Myrick,RG,67
+733,Tulsa,Caleb Moser,TE,67
+733,Tulsa,Jaden Ligon,RT,66
+733,Tulsa,Mason Chorak,C,65
+733,Tulsa,Kade Martin,C,64
+733,Tulsa,Kenny Peete,SS,63
+733,Tulsa,Barry Walker,RG,63
+733,Tulsa,Xavier Daisy,WR,63
+733,Tulsa,Britton Forney,TE,62
+733,Tulsa,Ja Lyen Judson,CB,61
+733,Tulsa,Patrick Foley,P,60
+733,Tulsa,Wyatt Martin,K,59
+733,Tulsa,Dominique Hitchens,LG,57
+733,Tulsa,Trace Campbell,QB,56
+733,Tulsa,Raymond Russell,FB,56
+733,Tulsa,Malachi Glover,LG,50
+733,Tulsa,Cole Charles,LT,47
+734,UAB,Cameron Kinnie,C,90
+734,UAB,Patrick Barnett,RG,90
+734,UAB,Gaard Memmelaar,LG,87
+734,UAB,Preston Cushman,RG,86
+734,UAB,Keli Lawson,MLB,85
+734,UAB,Paul Rubelt,RT,85
+734,UAB,Keegan Smith,RG,85
+734,UAB,John Walker,DT,84
+734,UAB,Jayden Bellamy,CB,84
+734,UAB,Marcus Burke,WR,84
+734,UAB,Cole Kozlowski,ROLB,84
+734,UAB,Jabari Brooks,LG,83
+734,UAB,Jayden Williams,CB,83
+734,UAB,Carter Miller,C,82
+734,UAB,Cam Fancher,QB,82
+734,UAB,Tyreek E Robinson,DT,82
+734,UAB,Laroyce Johnson,LT,82
+734,UAB,Braeden Marshall,CB,81
+734,UAB,Johnte Davis,RT,81
+734,UAB,R J Jackson Jr,DT,81
+734,UAB,Benry Wilson,C,81
+734,UAB,Duane Thomas Jr,WR,80
+734,UAB,Jakob Gude,SS,80
+734,UAB,Dj Bell,CB,78
+734,UAB,Jayden Mcdonald,ROLB,78
+734,UAB,Antione Jackson,CB,78
+734,UAB,Phillip Dunnam,FS,77
+734,UAB,Lewis Carter,ROLB,77
+734,UAB,Dylan Wade,TE,77
+734,UAB,Sam Hopewell,C,77
+734,UAB,Jake Borland,LT,77
+734,UAB,Jaeden Gould,SS,76
+734,UAB,Christian Peterson,FS,76
+734,UAB,Laparka Langston,LT,76
+734,UAB,Owen Spell,RT,76
+734,UAB,Demari Henderson,SS,75
+734,UAB,Horace Lockett,DT,75
+734,UAB,Nehemiah Hughes,WR,75
+734,UAB,Ja Cari Henderson,CB,74
+734,UAB,Tayven Jackson,QB,74
+734,UAB,Justin Royes,LT,74
+734,UAB,Isaiah Reed,CB,74
+734,UAB,Bredell Richardson,WR,74
+734,UAB,Keshaun Hudson,DT,73
+734,UAB,Kam Moore,MLB,73
+734,UAB,Jordyn Bridgewater,WR,72
+734,UAB,Garrison Robinson,WR,72
+734,UAB,Tony Williams,FS,71
+734,UAB,Ezequiel Blake,SS,71
+734,UAB,Andrew Phelan,LG,71
+734,UAB,Grant Stevens,TE,70
+734,UAB,Kylan Fox,TE,69
+734,UAB,Ric Darious Farmer,WR,69
+734,UAB,Kaden Mayfield,FS,69
+734,UAB,D J Heard,FB,68
+734,UAB,Davi Belfort,QB,67
+734,UAB,Rukeem Stroud,CB,66
+734,UAB,Jacurri Brown,QB,65
+734,UAB,Jyaire Brown,CB,65
+734,UAB,Rodney Lora,DT,65
+734,UAB,Jairus Briggs,TE,65
+734,UAB,Noe Ruelas,K,64
+734,UAB,Carl Jenkins Jr,WR,64
+734,UAB,Malakhi Boone,MLB,64
+734,UAB,Raishaun Mchaney,RT,64
+734,UAB,Max Drag,TE,62
+734,UAB,Troy Ford Jr,MLB,61
+734,UAB,Tj Bullard,ROLB,61
+734,UAB,Jaquez Joiner,RG,61
+734,UAB,Kayson Lee,WR,60
+734,UAB,Caden Piening,TE,59
+734,UAB,Slate Ashley,WR,57
+734,UAB,Michael Carter,P,55
+734,UAB,Josh Whittington,MLB,52
+735,UCF,Garrett Digiorgio,RT,91
+735,UCF,Nico Iamaleava,QB,88
+735,UCF,Kaedin Robinson,WR,85
+735,UCF,Siale Taupaki,DT,85
+735,UCF,K D Arnold,LT,84
+735,UCF,Courtland Ford,LT,83
+735,UCF,Jake Renda,TE,83
+735,UCF,Hudson Habermehl,TE,83
+735,UCF,Rico Flores Jr,WR,82
+735,UCF,Andre Jordan Jr,CB,81
+735,UCF,Keanu Williams,DT,81
+735,UCF,Kwazi Gilmer,WR,81
+735,UCF,Jamier Johnson,CB,80
+735,UCF,Gary Smith Iii,DT,80
+735,UCF,Reuben Unije,LT,80
+735,UCF,Jonjon Vaughns,MLB,80
+735,UCF,Titus Mokiao Atimalala,WR,79
+735,UCF,Jaedon Wilson,WR,79
+735,UCF,Yutaka Mahe,RG,79
+735,UCF,Bryon Threats,FS,78
+735,UCF,Isaiah Chisom,MLB,78
+735,UCF,Noah Pulealii,RG,78
+735,UCF,Benjamin Perry,FS,77
+735,UCF,Leo Kemp,FB,77
+735,UCF,Jalen Woods,ROLB,77
+735,UCF,Larry Edwards Iii,MLB,77
+735,UCF,Sam Yoon,C,76
+735,UCF,Jamaal Jordan,WR,76
+735,UCF,Mikey Matthews,WR,75
+735,UCF,Jaylan Jeffers,RT,75
+735,UCF,Aaron Williams,CB,75
+735,UCF,Jensen Somerville,RT,75
+735,UCF,Carter Shaw,WR,75
+735,UCF,A J Fuimaono,DT,74
+735,UCF,Scooter Jackson,CB,74
+735,UCF,Pierce Clarkson,QB,73
+735,UCF,Croix Stewart,FS,73
+735,UCF,Kanye Clark,CB,73
+735,UCF,Edward Dermott,QB,72
+735,UCF,Oluwafunto Akinshilo,LG,72
+735,UCF,Ezavier Staples,WR,71
+735,UCF,Asher Reynolds,SS,71
+735,UCF,Jack Pedersen,TE,71
+735,UCF,Colton Gumino,QB,71
+735,UCF,Thomas Sua,TE,71
+735,UCF,Rodrick Pleasant,CB,70
+735,UCF,Robert Stafford,CB,70
+735,UCF,Zeke Thomas,SS,70
+735,UCF,Garrison Blank,RT,70
+735,UCF,Ashton Sanders,DT,70
+735,UCF,Lucien Holland,LOLB,70
+735,UCF,Brett Barry,FS,69
+735,UCF,Luke Duncan,QB,68
+735,UCF,Mateen Bhaghani,K,67
+735,UCF,Will Karoll,P,67
+735,UCF,Jadyn Marshall,WR,67
+735,UCF,Tez Hester,MLB,67
+735,UCF,Caleb Walker,C,66
+735,UCF,Donavyn Pellot,ROLB,66
+735,UCF,Eric Chester,LT,66
+735,UCF,Cole Martin,SS,64
+735,UCF,Ty Lee,ROLB,63
+735,UCF,Julian Armella,RG,61
+735,UCF,Adam Rhodes,LOLB,61
+735,UCF,Braden Houston,RG,61
+735,UCF,Salem Abdul Wahab,TE,61
+735,UCF,Eugene Brooks,LG,55
+735,UCF,Wade Moore,LG,54
+735,UCF,Mone Malafu,MLB,52
+736,UCLA,Wes Hoeh,C,88
+736,UCLA,Joe Fagnano,QB,87
+736,UCLA,Naiem Simmons,WR,86
+736,UCLA,Skyler Bell,WR,85
+736,UCLA,Bryun Parham,MLB,85
+736,UCLA,Louis Hansen,TE,84
+736,UCLA,Ben Murawski,LG,84
+736,UCLA,Nick Russell,DT,84
+736,UCLA,Reymello Murphy,WR,83
+736,UCLA,Donovan Branch,LOLB,83
+736,UCLA,Cam Chadwick,CB,82
+736,UCLA,Chris Parker,WR,82
+736,UCLA,Kyle Juergens,LG,81
+736,UCLA,Aaron Key,LOLB,81
+736,UCLA,Tank Green,RG,81
+736,UCLA,Perry Moorehead,ROLB,81
+736,UCLA,D Mon Brinson,CB,80
+736,UCLA,Tyquan King,MLB,80
+736,UCLA,Sione Moa,ROLB,80
+736,UCLA,Will Bright,LT,80
+736,UCLA,Lee Molette Iii,FS,79
+736,UCLA,Kamo I Latu,SS,78
+736,UCLA,Carsten Casady,C,78
+736,UCLA,Brady Wayburn,RG,78
+736,UCLA,Caleb Burton Iii,WR,77
+736,UCLA,Tamarus Walker,RG,77
+736,UCLA,Vincent Carroll Jackson,DT,76
+736,UCLA,Shamar Porter,WR,76
+736,UCLA,Dontrell Jones,DT,76
+736,UCLA,Kylish Hicks,WR,76
+736,UCLA,Danny Antolovich,LT,76
+736,UCLA,Ty Chan,LT,75
+736,UCLA,Nick Evers,QB,75
+736,UCLA,Tyrece Mills,SS,75
+736,UCLA,Devin Pringle,CB,75
+736,UCLA,Alex Honig,TE,74
+736,UCLA,Jayden Bass,RT,74
+736,UCLA,Tucker Mcdonald,QB,74
+736,UCLA,Kolubah Pewee Jr,CB,73
+736,UCLA,Deron Mclaughlin,LG,73
+736,UCLA,Amir Renwick,ROLB,72
+736,UCLA,John Neider,WR,72
+736,UCLA,Nader Chirchi,TE,71
+736,UCLA,Deveon Collins,MLB,71
+736,UCLA,Kervins Choute,DT,70
+736,UCLA,Kobi Albert,FS,70
+736,UCLA,Malachi Mclean,FS,70
+736,UCLA,Chris Hudson,CB,70
+736,UCLA,Chris Freeman,K,69
+736,UCLA,Javonte Vereen,TE,69
+736,UCLA,Oumar Diomande,ROLB,69
+736,UCLA,Cole Mcdaniels,FS,69
+736,UCLA,Connor Stutz,P,68
+736,UCLA,Jackson Harper,WR,67
+736,UCLA,Ksaan Farrar,QB,66
+736,UCLA,Jake Kiernan,C,66
+736,UCLA,Liam Fuller,MLB,65
+736,UCLA,Toluwanimi Tunde,LT,65
+736,UCLA,Diego Rodriguez,LT,65
+736,UCLA,Jayln Wilkinson,CB,64
+736,UCLA,Nykobi Brown,LOLB,64
+736,UCLA,Zach Christinat,TE,64
+736,UCLA,Xavier Watson,TE,63
+736,UCLA,Carson Childress,FB,62
+736,UCLA,Axavier Bridges Brooks,SS,61
+736,UCLA,Hill Greenlee,RT,61
+736,UCLA,Toriyan Johnson,RT,61
+736,UCLA,Joe Mcgann,RT,60
+736,UCLA,Eric Amaya,MLB,58
+736,UCLA,Saxton Suchanic,CB,57
+736,UCLA,Osiris Gilbert,FS,56
+736,UCLA,Courtney Weaver,DT,55
+736,UCLA,Lukas Slaby,FS,52
+737,UConn,Luke Painton,RT,84
+737,UConn,T Y Harding,WR,80
+737,UConn,Malcolm Greene,CB,79
+737,UConn,Benjamin Roy Jr,C,78
+737,UConn,Jacquon Gibson,WR,78
+737,UConn,Mao Glynn Ii,RG,78
+737,UConn,Dezmond Hanks,LOLB,78
+737,UConn,Tim Grant Randall,DT,77
+737,UConn,Sullivan Weidman,RG,77
+737,UConn,Grant Jordan,QB,77
+737,UConn,Reece Adkins,TE,77
+737,UConn,Tyler Leinberger,LG,77
+737,UConn,Derrieon Craig,ROLB,76
+737,UConn,Owen Anderson,TE,76
+737,UConn,Donnie Gray,WR,76
+737,UConn,Jashon Watkins,CB,76
+737,UConn,Jake Mcconnachie,WR,76
+737,UConn,Kendall Bournes,FS,75
+737,UConn,Dd Snyder,SS,75
+737,UConn,Zachary Franks,LT,75
+737,UConn,Dean Shaffer,MLB,75
+737,UConn,Steven Ortiz,SS,75
+737,UConn,Peyton Miller,LG,75
+737,UConn,Ryan Barnes,CB,74
+737,UConn,Tj Magee,CB,74
+737,UConn,Kezion Dia Johnson,WR,74
+737,UConn,Jovoni Borbon,TE,74
+737,UConn,Shymell Davis,DT,74
+737,UConn,Ryan Mosesso,RT,73
+737,UConn,Max Dowling,TE,73
+737,UConn,Jaxon King,RT,73
+737,UConn,Tyree Kelly,WR,73
+737,UConn,Nick Hawthorne,ROLB,73
+737,UConn,Brandon Rose,QB,72
+737,UConn,Jeremiah Mcgill,FS,72
+737,UConn,Sam Staruch,WR,72
+737,UConn,Tyler Martin,MLB,71
+737,UConn,Donovan Dyson,ROLB,71
+737,UConn,Chris Glass,RG,71
+737,UConn,Ahmad Haston,QB,71
+737,UConn,James Horton,TE,71
+737,UConn,Zeraun Daniel,SS,70
+737,UConn,Santana Sanders,ROLB,70
+737,UConn,Aj Hairston,QB,69
+737,UConn,Kevin Swann,CB,69
+737,UConn,Montario Spells,CB,68
+737,UConn,Brennen Bailey,CB,68
+737,UConn,Michael Pangaro,FS,68
+737,UConn,Justin Howser,LT,68
+737,UConn,Noah Kellogg,LT,68
+737,UConn,Jaylin Moore,DT,67
+737,UConn,Will Motley,FB,67
+737,UConn,Dallas Elliott,WR,67
+737,UConn,Drew Granderson,CB,66
+737,UConn,Timothy Passmore Jr,DT,66
+737,UConn,Michael Anderson,TE,66
+737,UConn,Jimmie Bartow,WR,66
+737,UConn,Zach Lawrence,QB,65
+737,UConn,Tanner Burlingame,LT,65
+737,UConn,Matthew Ogunniyi,TE,65
+737,UConn,Magnus Von Saldern,TE,61
+737,UConn,William Boston,DT,61
+737,UConn,Derek Morris,K,58
+737,UConn,Keegan Andrews,P,57
+737,UConn,Brock Taylor,C,57
+737,UConn,Antonio Reagor,CB,56
+737,UConn,Cooper Proctor,TE,55
+737,UConn,Marcus Lye,K,55
+737,UConn,Rashad Henry,LOLB,55
+737,UConn,Paul Cooper,MLB,52
+737,UConn,Will Newton Iii,LG,52
+738,UNLV,Jalen Lee,DT,86
+738,UNLV,Cohen Fuller,DT,85
+738,UNLV,Aamaris Brown,CB,85
+738,UNLV,Justin Flowe,ROLB,85
+738,UNLV,Jaden Bradley,WR,85
+738,UNLV,Anthony Colandrea,QB,84
+738,UNLV,Troy Omeire,WR,84
+738,UNLV,Var Keyes Gumms,TE,84
+738,UNLV,Kodi Decambra,FS,84
+738,UNLV,Bryce Edmondson,ROLB,84
+738,UNLV,Malik Mcgowan,LG,84
+738,UNLV,Reid Williams,C,84
+738,UNLV,Alani Makihele,RG,83
+738,UNLV,Lucas Conti,DT,83
+738,UNLV,Nick Scalise,RT,83
+738,UNLV,Jaheem Joseph,SS,82
+738,UNLV,Nick Elksnis,TE,82
+738,UNLV,Koy Moore,WR,82
+738,UNLV,Daejon Reynolds,WR,82
+738,UNLV,Denver Harris,CB,81
+738,UNLV,Austin Boyd,RG,81
+738,UNLV,Jayden Ahboah,LT,81
+738,UNLV,Marsel Mcduffie,MLB,80
+738,UNLV,Laterrance Welch,CB,80
+738,UNLV,Kamuela Ka Aihue,ROLB,80
+738,UNLV,Ben Christman,LT,80
+738,UNLV,Jojo Earle,WR,79
+738,UNLV,Donavan Manson,RG,79
+738,UNLV,Graham Keating Iii,C,79
+738,UNLV,Jake Pope,SS,78
+738,UNLV,James Faminu,LT,77
+738,UNLV,Cameron Friel,QB,77
+738,UNLV,Matt Byrnes,TE,76
+738,UNLV,Anthony Costanzo,FS,76
+738,UNLV,Jah Von Grigsby,FS,75
+738,UNLV,Waisale Muavesi,DT,75
+738,UNLV,Jordan Eubanks,ROLB,75
+738,UNLV,Will Thomas,RT,75
+738,UNLV,Dyllan Drummond,RT,75
+738,UNLV,Deangelo Irvin Jr,WR,74
+738,UNLV,Saadite Green Jr,CB,73
+738,UNLV,Melvin Laster,MLB,73
+738,UNLV,Layne Roosevelt,LT,72
+738,UNLV,Taeshaun Lyons,WR,72
+738,UNLV,Rashawn Jackson,WR,72
+738,UNLV,Nijrell Eason Ii,CB,71
+738,UNLV,Alex Orji,QB,70
+738,UNLV,Toby Moore,LG,70
+738,UNLV,Tre Fulton,FS,70
+738,UNLV,Koi Pa Ao Ao,MLB,70
+738,UNLV,Tevin Owens,LG,70
+738,UNLV,David Yarborough,CB,69
+738,UNLV,Alexander Green,LOLB,67
+738,UNLV,Caden Costa,K,65
+738,UNLV,Stefan Crothers,CB,64
+738,UNLV,Jaylen Allen,CB,64
+738,UNLV,Brandon Knowles,FB,62
+738,UNLV,Nigel Watters,DT,61
+738,UNLV,Mohamed Altayeb,DT,61
+738,UNLV,Ben Lisk,TE,61
+738,UNLV,Bo Belton,MLB,60
+738,UNLV,Shamir Fowler,LT,59
+738,UNLV,Jae Beasley Ii,TE,59
+738,UNLV,Quincy Bernard,LG,58
+738,UNLV,Justin Mccloud,P,58
+738,UNLV,Chase Royer,QB,57
+738,UNLV,Gael Ochoa,QB,55
+738,UNLV,Devin Brenner,C,52
+738,UNLV,Terrelle Joseph,MLB,50
+739,USC,Christian Hilborn,RT,91
+739,USC,Aj Vaipulu,RG,89
+739,USC,Jeremiah Noga,WR,87
+739,USC,Parker Mckenna,ROLB,86
+739,USC,Jonny Lester,LG,85
+739,USC,Brock Dieu,C,84
+739,USC,Keith Brown,MLB,84
+739,USC,Nathan Pritchard,LT,83
+739,USC,Matt Kinglake,RT,83
+739,USC,Josh Meredith,WR,82
+739,USC,Devin Ellison,WR,82
+739,USC,Matt Durrance,SS,82
+739,USC,Zevi Eckhaus,QB,82
+739,USC,Darrion Dalton,DT,82
+739,USC,Tucker Large,FS,81
+739,USC,Max Baloun,DT,81
+739,USC,Colby Humphrey,CB,81
+739,USC,Mike Yoan Sandjo Njiki,DT,80
+739,USC,Jamorri Colson,CB,78
+739,USC,Ashton Tripp,LT,78
+739,USC,Ademola Faleye,TE,77
+739,USC,Caleb Francl,LOLB,77
+739,USC,Jaylin Caldwell,RT,77
+739,USC,Hudson Cedarland,TE,77
+739,USC,Cale Reeder,SS,76
+739,USC,Andre Dollar,TE,76
+739,USC,Leyton Smithson,WR,76
+739,USC,Gavin Barthiel,ROLB,76
+739,USC,Antwaan Wall,LT,76
+739,USC,Tony Freeman,WR,75
+739,USC,Kai Rapolla,CB,75
+739,USC,Kaden Beatty,DT,75
+739,USC,Chris Lino,LT,75
+739,USC,Edward Lui,RG,75
+739,USC,Aj Davis,CB,74
+739,USC,Nick Bakken,LG,74
+739,USC,Soni Finau,DT,73
+739,USC,Trey Leckner,TE,73
+739,USC,Kyle Martin,C,73
+739,USC,Anthony Palano,MLB,73
+739,USC,Xavier Thorpe,RT,72
+739,USC,Branden Ganashamoorthy,WR,72
+739,USC,Bryson Lamb,DT,71
+739,USC,Beau Baker,TE,71
+739,USC,Kayo Patu,FS,71
+739,USC,Jaxon Potter,QB,70
+739,USC,Colton Peoples,TE,70
+739,USC,Noah Dunham,RG,69
+739,USC,Trey Ridley,SS,68
+739,USC,Gage Jones,LOLB,67
+739,USC,Deandre Southwood,MLB,67
+739,USC,Noah Westbrook,WR,67
+739,USC,Carsten Reynolds,LOLB,66
+739,USC,Tyson Weaver,FS,66
+739,USC,Julian Dugger,QB,65
+739,USC,Kenny Worthy Iii,CB,65
+739,USC,Isaiah Lyons,LG,65
+739,USC,Derrick Jinkins,FB,65
+739,USC,Jamarey Smith,CB,64
+739,USC,Brian Ouellette,K,63
+739,USC,Jovan Clark,MLB,62
+739,USC,Xavier Squires,FS,61
+739,USC,Kyle Peterson,FS,61
+739,USC,Isaiah Hung,ROLB,61
+739,USC,Doug Claxton,C,59
+739,USC,Kamani Jackson,CB,57
+739,USC,Ajani Sheppard,QB,56
+739,USC,Ryan Harris,P,55
+739,USC,Kurt Rawlinson,RT,55
+739,USC,Mika Tulafono,QB,54
+739,USC,James Mccauley,QB,51
+739,USC,Jack Stevens,K,51
+750,West Virginia,Kody Epps,WR,84
+750,West Virginia,Anthony Brackenridge,ROLB,84
+750,West Virginia,Maverick Mcivor,QB,83
+750,West Virginia,Kent Robinson,CB,83
+750,West Virginia,Isaiah Myers,WR,83
+750,West Virginia,Nick Reimer,RT,83
+750,West Virginia,Matthew Henry,WR,82
+750,West Virginia,Al Ma Hi Ali,FS,82
+750,West Virginia,Jalen Emery,CB,81
+750,West Virginia,Marshall Jackson,LT,80
+750,West Virginia,Demarko Williams,CB,80
+750,West Virginia,Jaylen Wester,ROLB,79
+750,West Virginia,Kelby Williams,WR,79
+750,West Virginia,Mackavelli Malotumau,DT,79
+750,West Virginia,Weston Wallace,LG,79
+750,West Virginia,K D Hutchinson,WR,78
+750,West Virginia,Karsten Upchurch,RT,78
+750,West Virginia,Moussa Barry,WR,78
+750,West Virginia,Nazir Ward,ROLB,78
+750,West Virginia,Dylan Flowers,CB,78
+750,West Virginia,Laurence Seymore,LG,77
+750,West Virginia,Virgil Marshall,SS,77
+750,West Virginia,Noah Meyers,TE,77
+750,West Virginia,Jackson West,TE,77
+750,West Virginia,Jakeem Fletcher,DT,77
+750,West Virginia,Kennon Loftin,MLB,77
+750,West Virginia,Kamren Bolden,WR,77
+750,West Virginia,Markus Knight,SS,76
+750,West Virginia,Devon Smith,LT,76
+750,West Virginia,Quincy Jenkins,RG,76
+750,West Virginia,Avarion Cole,SS,76
+750,West Virginia,Jemeil Jackson,C,76
+750,West Virginia,Rylen Su A Filo,DT,75
+750,West Virginia,Jaavan Mack,CB,75
+750,West Virginia,Cross Nimmo,TE,75
+750,West Virginia,Eric Etienne,DT,74
+750,West Virginia,Dave Herard,FS,74
+750,West Virginia,Korbyn Green,CB,74
+750,West Virginia,Enrique Smith Diaz,RT,74
+750,West Virginia,Kendle Waters,DT,73
+750,West Virginia,Miller Malone,MLB,73
+750,West Virginia,Jai Eugene Jr,FS,72
+750,West Virginia,Justin Wolf,TE,72
+750,West Virginia,Caleb Nitta,C,72
+750,West Virginia,Rodney Tisdale Jr,QB,72
+750,West Virginia,Melvin Collins Jr,RG,72
+750,West Virginia,Joshua Mensah,LOLB,72
+750,West Virginia,Kolbyn Price,TE,72
+750,West Virginia,Jaylen Lewis,SS,71
+750,West Virginia,Koron Hayward,LOLB,71
+750,West Virginia,Braxton Myers,CB,70
+750,West Virginia,Max Thurston,RT,70
+750,West Virginia,Chukwunedu Okeke,DT,69
+750,West Virginia,Tate Titshaw,SS,69
+750,West Virginia,Elijah Williams,C,69
+750,West Virginia,Cole Maynard,P,68
+750,West Virginia,Cameron Flowers,WR,68
+750,West Virginia,Robby Harrison,DT,67
+750,West Virginia,Zsacari Minnis,MLB,67
+750,West Virginia,John Cannon,K,66
+750,West Virginia,Quincy Burroughs,WR,66
+750,West Virginia,Xavion Griffin,CB,65
+750,West Virginia,Jordan Donald,MLB,65
+750,West Virginia,Rex Robich,TE,65
+750,West Virginia,Nathan Reeves,FB,64
+750,West Virginia,Jackson Smith,P,63
+750,West Virginia,Tucker Parks,QB,63
+750,West Virginia,Caleb Mcmickle,QB,61
+750,West Virginia,Zack Calhoun,LG,61
+750,West Virginia,Chris Small,LG,60
+750,West Virginia,Zach Smith,MLB,58
+750,West Virginia,Antoine Manning,RG,57
+750,West Virginia,Trumaine Pointer,RG,56
+750,West Virginia,Isiah Stoudemire,LT,52
+752,Western Kentucky,Cade Conley,TE,86
+752,Western Kentucky,Blake Bosma,TE,84
+752,Western Kentucky,Tailique Williams,WR,83
+752,Western Kentucky,Tate Hallock,SS,82
+752,Western Kentucky,Aaron Wofford,FS,81
+752,Western Kentucky,Adam Vandervest,LT,81
+752,Western Kentucky,Raheem Anderson,C,80
+752,Western Kentucky,Dakari Frazier,DT,80
+752,Western Kentucky,Malique Dieudonne,WR,79
+752,Western Kentucky,Domanick Moon,MLB,79
+752,Western Kentucky,Jarvarius Sims,CB,79
+752,Western Kentucky,Trevor Shaw,RG,79
+752,Western Kentucky,Matthew Bulluck,ROLB,79
+752,Western Kentucky,Christian Leary,WR,78
+752,Western Kentucky,John Hofer,LG,78
+752,Western Kentucky,Mareyohn Hrabowski,TE,78
+752,Western Kentucky,Baylin Brooks,WR,77
+752,Western Kentucky,Jordon Thomas,CB,77
+752,Western Kentucky,James Camden,ROLB,77
+752,Western Kentucky,Caden Peddie,C,77
+752,Western Kentucky,Dillon Moore,LOLB,76
+752,Western Kentucky,Micah Davis,SS,76
+752,Western Kentucky,Jayden Davis,SS,76
+752,Western Kentucky,Sefa Saipaia,MLB,76
+752,Western Kentucky,Chad Schuster,RG,76
+752,Western Kentucky,Race Stewart,DT,75
+752,Western Kentucky,Zach Vaughan,RT,75
+752,Western Kentucky,Fitzroy Ledgister,FS,75
+752,Western Kentucky,Isaiah Paul,CB,75
+752,Western Kentucky,Marcel Tyler,DT,75
+752,Western Kentucky,Jack Parker,LG,75
+752,Western Kentucky,Conor Kenzinger,LT,75
+752,Western Kentucky,Hunter Whitenack,RG,74
+752,Western Kentucky,Broc Lowry,QB,74
+752,Western Kentucky,Brady Rhoad,TE,74
+752,Western Kentucky,Derek Pennington,ROLB,74
+752,Western Kentucky,Sean Spencer,MLB,72
+752,Western Kentucky,Jeremy Schleicher,C,72
+752,Western Kentucky,Joey Pope,FS,71
+752,Western Kentucky,Cj Miles Jr,SS,69
+752,Western Kentucky,Mason Reynolds,QB,69
+752,Western Kentucky,Joshua Franklin,CB,69
+752,Western Kentucky,Dan Klein,TE,69
+752,Western Kentucky,Gavin Dabo,RT,69
+752,Western Kentucky,Garrison Beasley,QB,68
+752,Western Kentucky,Jaden Lyles,SS,68
+752,Western Kentucky,Keivin Boone Nelson,WR,68
+752,Western Kentucky,Brendan Budeselich,MLB,68
+752,Western Kentucky,Kenan Crothers,FB,68
+752,Western Kentucky,Palmer Domschke,K,66
+752,Western Kentucky,Dalton Gustwiller,DT,66
+752,Western Kentucky,Carlos Mitchell Jr,CB,66
+752,Western Kentucky,Jaylin Valentine,DT,65
+752,Western Kentucky,Lashawn Newkirk,SS,65
+752,Western Kentucky,Brady Jones,QB,64
+752,Western Kentucky,Dean Lawson,LT,64
+752,Western Kentucky,Terence Marshall,WR,64
+752,Western Kentucky,Carlos Rose,TE,62
+752,Western Kentucky,Chase Peralta,TE,61
+752,Western Kentucky,Tavarez Edwards,FS,61
+752,Western Kentucky,Liam Vaughan,C,61
+752,Western Kentucky,Ryan Millmore,P,59
+752,Western Kentucky,R W Cobb,CB,59
+752,Western Kentucky,Jason Mitchell,FS,59
+752,Western Kentucky,Rj Todd,TE,59
+752,Western Kentucky,Byron Ragland,LG,57
+752,Western Kentucky,Jacob Wilk,LT,56
+752,Western Kentucky,Anthony Beacom,P,55
+752,Western Kentucky,Maddux Babin,LOLB,53
+752,Western Kentucky,Kj Kotalik,RT,52
+753,Western Michigan,Fred Perry,FS,89
+753,Western Michigan,Michael Coats Jr,CB,87
+753,Western Michigan,Walter Young Bear,LG,87
+753,Western Michigan,Chase Wilson,ROLB,87
+753,Western Michigan,Hammond Russell Iv,DT,87
+753,Western Michigan,Jordan Scruggs,CB,86
+753,Western Michigan,Ben Cutter,MLB,86
+753,Western Michigan,Kekoura Tarnue,FS,85
+753,Western Michigan,Reid Carrico,MLB,85
+753,Western Michigan,Derek Carter,CB,85
+753,Western Michigan,Asani Redwood,DT,85
+753,Western Michigan,Carson Lee,C,84
+753,Western Michigan,Rodney Gallagher Iii,WR,84
+753,Western Michigan,Jaden Bray,WR,84
+753,Western Michigan,Cam Vaughn,WR,83
+753,Western Michigan,Grayson Barnes,TE,83
+753,Western Michigan,Edward Vesterinen,DT,83
+753,Western Michigan,Oran Singleton,WR,83
+753,Western Michigan,Ty Kieast Crawford,RT,83
+753,Western Michigan,Preston Fox,WR,83
+753,Western Michigan,Xavier Bausley,LT,83
+753,Western Michigan,Jason Chambers,CB,82
+753,Western Michigan,Jacob Barrick,TE,82
+753,Western Michigan,Ayden Bussell,RG,81
+753,Western Michigan,Justin Harrington,SS,80
+753,Western Michigan,Darrian Lewis,CB,80
+753,Western Michigan,Kimo Makane Ole,RG,79
+753,Western Michigan,Malik Agbo,LT,78
+753,Western Michigan,Christian Hamilton,WR,78
+753,Western Michigan,Landen Livingston,C,77
+753,Western Michigan,Nate Gabriel,DT,77
+753,Western Michigan,Xander Stone,LOLB,77
+753,Western Michigan,William Davis,SS,76
+753,Western Michigan,Jordan Walker,FS,76
+753,Western Michigan,Macguire Moss,TE,76
+753,Western Michigan,Nicco Marchiol,QB,75
+753,Western Michigan,Colin Mcbee,FB,75
+753,Western Michigan,Nick Krahe,RT,75
+753,Western Michigan,Caden Biser,MLB,75
+753,Western Michigan,Lyle Scott,LT,75
+753,Western Michigan,Jordan Mccants,WR,74
+753,Western Michigan,T J Wayne,CB,74
+753,Western Michigan,Corey Mcintyre Jr,DT,74
+753,Western Michigan,Kaden Seller,TE,74
+753,Western Michigan,Cooper Young,LG,74
+753,Western Michigan,Kelvin Conlan,LT,74
+753,Western Michigan,Wyatt Minor,RG,73
+753,Western Michigan,Jarod Bowie,WR,73
+753,Western Michigan,Israel Boyce,SS,72
+753,Western Michigan,Max Brown,QB,72
+753,Western Michigan,Greg Genross,TE,72
+753,Western Michigan,Ryan Ward,TE,72
+753,Western Michigan,Andy Whitmore,RG,71
+753,Western Michigan,Brandon Homady,LG,71
+753,Western Michigan,Devonte Golden Nelson,CB,70
+753,Western Michigan,Jaylen Henderson,QB,70
+753,Western Michigan,Ashton Woods,ROLB,70
+753,Western Michigan,Josh Aisosa,C,70
+753,Western Michigan,Isaiah Shelton,WR,68
+753,Western Michigan,Oliver Straw,P,66
+753,Western Michigan,Ethan Head,K,66
+753,Western Michigan,Kade Hensley,K,65
+753,Western Michigan,Khalil Wilkins,QB,64
+753,Western Michigan,Zae Jennings,SS,64
+753,Western Michigan,Michael Hastie,ROLB,64
+753,Western Michigan,Jason Cross Jr,FS,62
+753,Western Michigan,Nate Flower,K,62
+753,Western Michigan,Darrell Moon,MLB,62
+753,Western Michigan,Will Hoffman,LOLB,61
+753,Western Michigan,Robby Martin,C,51
+753,Western Michigan,Rj Kocan,K,46
+751,Wisconsin,Ricardo Hallman,CB,90
+751,Wisconsin,Riley Mahlman,RT,89
+751,Wisconsin,Preston Zachman,SS,88
+751,Wisconsin,Nyzier Fourqurean,CB,87
+751,Wisconsin,Billy Edwards Jr,QB,87
+751,Wisconsin,Mason Reiger,ROLB,87
+751,Wisconsin,Vinny Anthony Ii,WR,86
+751,Wisconsin,Darryl Peterson,LOLB,86
+751,Wisconsin,Davis Heinzen,LT,86
+751,Wisconsin,Jake Renfro,C,85
+751,Wisconsin,Austin Brown,FS,85
+751,Wisconsin,Kerry Kodanko,RG,85
+751,Wisconsin,Joe Brunner,LG,84
+751,Wisconsin,Christian Alliegro,MLB,84
+751,Wisconsin,Parker Petersen,DT,84
+751,Wisconsin,Tackett Curtis,MLB,83
+751,Wisconsin,D Yoni Hill,CB,82
+751,Wisconsin,Dekel Crowdus,WR,82
+751,Wisconsin,Leyton Nelson,LT,82
+751,Wisconsin,Antarron Turner,MLB,82
+751,Wisconsin,Sebastian Cheeks,LOLB,80
+751,Wisconsin,Danny O Neil,QB,80
+751,Wisconsin,Tucker Ashcraft,TE,80
+751,Wisconsin,Matt Jung,SS,79
+751,Wisconsin,Lance Mason,TE,78
+751,Wisconsin,Jayden Ballard,WR,78
+751,Wisconsin,Jp Benzschawel,RG,78
+751,Wisconsin,Trech Kekahuna,WR,78
+751,Wisconsin,Jackson Acker,TE,78
+751,Wisconsin,Charlie Jarvis,FS,78
+751,Wisconsin,Tyrell Henry,WR,77
+751,Wisconsin,Aaron Witt,ROLB,77
+751,Wisconsin,Geimere Latimer,CB,76
+751,Wisconsin,Barrett Nelson,RT,76
+751,Wisconsin,Matthew Traynor,FS,76
+751,Wisconsin,Tyreese Fearbry,LOLB,75
+751,Wisconsin,Owen Arnett,FS,75
+751,Wisconsin,Tony Moore Watkins,LOLB,75
+751,Wisconsin,Joey Okla,C,74
+751,Wisconsin,Colin Cubberly,LG,74
+751,Wisconsin,Duane Tanglewood,SS,74
+751,Wisconsin,Nicolas Clayton,ROLB,74
+751,Wisconsin,Tyler Jansey,MLB,74
+751,Wisconsin,Chase Venable,P,73
+751,Wisconsin,Dillan Johnson,DT,73
+751,Wisconsin,Kam Adams Parker,WR,73
+751,Wisconsin,Michael Roeske,LT,72
+751,Wisconsin,Chris Brooks Jr,WR,72
+751,Wisconsin,Milos Spasojevic,QB,72
+751,Wisconsin,Ryan Cory,C,71
+751,Wisconsin,Jt Seagreaves,TE,71
+751,Wisconsin,Kevin Heywood,RT,70
+751,Wisconsin,Carter Smith,QB,70
+751,Wisconsin,Emerson Mandell,LT,70
+751,Wisconsin,Kyan Berry Johnson,WR,70
+751,Wisconsin,Trumaine Oliver,ROLB,69
+751,Wisconsin,Brian Ridge,QB,67
+751,Wisconsin,Remington Moss,FS,67
+751,Wisconsin,Hardy Watts,LG,65
+751,Wisconsin,Xavier Ukponu,DT,65
+751,Wisconsin,Nathanial Vakos,K,64
+751,Wisconsin,Gavin Lahm,K,64
+751,Wisconsin,Eugene Hilton Jr,WR,64
+751,Wisconsin,Atticus Bertrams,P,63
+751,Wisconsin,Michael Wells,C,63
+751,Wisconsin,Nick Levy,TE,60
+751,Wisconsin,Jamel Howard,DT,59
+751,Wisconsin,Stewart Sullivan,DT,59
+751,Wisconsin,Landon Gauthier,MLB,58
+751,Wisconsin,Jalen Bristow,RT,57
+751,Wisconsin,Jaimier Scott,CB,57
+751,Wisconsin,Grant Stec,TE,57
+751,Wisconsin,Jay Rabb,LOLB,45
+754,Wyoming,Jack Walsh,C,89
+754,Wyoming,Caden Barnett,RT,86
+754,Wyoming,Evan Eller,MLB,86
+754,Wyoming,John Michael Gyllenborg,TE,85
+754,Wyoming,Wes King,LG,84
+754,Wyoming,Ethan Stuhlsatz,ROLB,84
+754,Wyoming,Ben Florentine,DT,84
+754,Wyoming,Jaylen Sargent,WR,83
+754,Wyoming,Ian Bell,CB,82
+754,Wyoming,Keany Parks,CB,81
+754,Wyoming,Luke Sandy,C,78
+754,Wyoming,Phillip Rush,QB,78
+754,Wyoming,Jackson Holman,WR,78
+754,Wyoming,Brayden Johnson,MLB,78
+754,Wyoming,Justin Erb,TE,78
+754,Wyoming,Jake Davies,LT,78
+754,Wyoming,Chris Durr Jr,WR,77
+754,Wyoming,Caleb Robinson,DT,77
+754,Wyoming,Carson York,TE,77
+754,Wyoming,Andrew Johnson,FS,76
+754,Wyoming,Malique Singleton,FS,76
+754,Wyoming,Rex Johnsen,RG,76
+754,Wyoming,Evan Svoboda,TE,76
+754,Wyoming,Kaden Anderson,QB,75
+754,Wyoming,Brian Fowler,QB,75
+754,Wyoming,Dante Drake,DT,75
+754,Wyoming,Aneesh Vyas,DT,75
+754,Wyoming,Isaac Schoenfeld,TE,75
+754,Wyoming,Nathan Geiger,LT,74
+754,Wyoming,Eric Richardson,WR,74
+754,Wyoming,Dante Gavito,C,74
+754,Wyoming,Landon Pace,TE,73
+754,Wyoming,Jayden Williams,DT,72
+754,Wyoming,Caleb Merritt,CB,72
+754,Wyoming,Bj Inmon,CB,72
+754,Wyoming,Jaylan Bean,WR,72
+754,Wyoming,Josiah Petaia,RG,72
+754,Wyoming,Brandt Rice,LT,71
+754,Wyoming,Quinn Grovesteen Matchey,LG,70
+754,Wyoming,Desman Hearns,SS,70
+754,Wyoming,Bleyne Bryant,SS,70
+754,Wyoming,Tyler Nystrom,WR,70
+754,Wyoming,Ralph Sheldon,LG,70
+754,Wyoming,Dash Bauman,MLB,68
+754,Wyoming,Jones Thomas,FS,68
+754,Wyoming,Braylon Jenkins,RG,68
+754,Wyoming,Jaden Dacosta,FS,67
+754,Wyoming,Hugh Barnes,C,67
+754,Wyoming,Courtney Collins,CB,66
+754,Wyoming,Deion Deblanc,WR,66
+754,Wyoming,Cameron Watson,RT,66
+754,Wyoming,Jack Harvey,ROLB,66
+754,Wyoming,Clay Nanke,TE,65
+754,Wyoming,Johnathan Bush,LG,65
+754,Wyoming,Juan Miner,CB,64
+754,Wyoming,Markie Grant,CB,64
+754,Wyoming,Brooklyn Cheek,SS,64
+754,Wyoming,Gary Rutherford,MLB,63
+754,Wyoming,Ke Lyn Washom,WR,61
+754,Wyoming,Lucas Samsula,DT,60
+754,Wyoming,Eli Baggs,QB,59
+754,Wyoming,Miles Miner,FB,59
+754,Wyoming,Levi Dishman,FB,58
+754,Wyoming,Manny Williams,SS,58
+754,Wyoming,Erik Sandvik,K,57
+754,Wyoming,Cooper Lawson,LT,56
+754,Wyoming,Justin Silva,LG,56
+754,Wyoming,Steven Perez,MLB,54
+754,Wyoming,Brycen Lotz,RT,54
+754,Wyoming,Keelan Anderson,K,52
+754,Wyoming,Gavyn Helm,P,48


### PR DESCRIPTION
## Summary
- convert the full 2026 TeamCrafters JSON roster dump to CSV

## Testing
- `python3 scripts/convert_teamcrafters_json_to_csv.py data/raw/teamcrafters_cfb26_final_complete.json outputs/teamcrafters_cfb26_final_complete.csv`


------
https://chatgpt.com/codex/tasks/task_e_6859fe826508832abeabdb1e3863cdb6