### PR TITLE
Add Italian Open per-round projection script

### DIFF
--- a/outputs/Italian Open Projected Strokes 20250624.csv
+++ b/outputs/Italian Open Projected Strokes 20250624.csv
@@ -1,0 +1,157 @@
+PLAYER NAME,PROJECTED STROKES
+"Smith, Jordan",68.531
+"Ferguson, Ewen",68.619
+"Laporta, Francesco",68.808
+"Schaper, Jayden",68.826
+"Nakajima, Keita",68.883
+"Chacarra, Eugenio",68.914
+"Reitan, Kristoffer",68.992
+"Parry, John",68.992
+"Penge, Marco",69.017
+"Ayora, Angel",69.075
+"Couvra, Martin",69.082
+"Lindell, Oliver",69.264
+"Von Dellingshausen, Nicolai",69.268
+"Sullivan, Andy",69.268
+"Lacroix, Frederic",69.283
+"Stone, Brandon",69.287
+"Fitzpatrick, Alex",69.291
+"Ding, Wenyi",69.302
+"Saddier, Adrien",69.327
+"Crocker, Sean",69.338
+"Campillo, Jorge",69.344
+"Molinari, Edoardo",69.361
+"Zanotti, Fabrizio",69.37
+"Norris, Shaun",69.382
+"Schneider, Marcel",69.383
+"Catlin, John",69.41
+"Hillier, Daniel",69.414
+"Mansell, Richard",69.426
+"Olesen, Jacob Skov",69.471
+"Siem, Marcel",69.493
+"Armitage, Marcus",69.514
+"Langasque, Romain",69.551
+"Katsuragawa, Yuto",69.575
+"Ramsay, Richie",69.576
+"Clements, Todd",69.578
+"Robinson-Thompson, Brandon",69.597
+"Soderberg, Sebastian",69.612
+"Otaegui, Adrian",69.647
+"Kobori, Kazuma",69.655
+"Elvira Mijares, Ignacio",69.663
+"Scrivener, Jason",69.666
+"Van Driel, Darius",69.686
+"Wiesberger, Bernd",69.689
+"Bradbury, Dan",69.696
+"Migliozzi, Guido",69.723
+"Winther, Jeff",69.724
+"Pavan, Andrea",69.725
+"Paul, Yannik",69.75
+"Ravetto, David",69.757
+"Kieffer, Maximilian",69.763
+"Gouveia, Ricardo",69.775
+"Aphibarnrat, Kiradech",69.784
+"Lemke, Niklas",69.793
+"Coussaud, Ugo",69.807
+"Vaillant, Tom",69.836
+"Del Rey, Alejandro",69.836
+"Wilson, Andrew",69.843
+"Purcell, Conor",69.859
+"Senior, Jack",69.866
+"Forrest, Grant",69.866
+"Cockerill, Aaron",69.876
+"Hill, Calum",69.888
+"Elvira, Manuel",69.931
+"Merritt, Troy",69.935
+"Dantorp, Jens",69.939
+"Shinkwin, Callum",69.942
+"Schmidt, Ben",69.943
+"Hebert, Benjamin",69.95
+"Cantero Gutierrez, Ivan",69.962
+"Hidalgo, Angel",69.963
+"Jamieson, Scott",69.964
+"Dean, Joe",69.974
+"Green, Gavin",69.986
+"Nienaber, Wilco",70.047
+"Larrazabal, Pablo",70.052
+"Wu, Brandon",70.055
+"Halvorsen, Andreas",70.072
+"Smylie, Elvis",70.105
+"Bryant, Davis",70.132
+"Kinhult, Marcus",70.138
+"Williams, Robin",70.149
+"Mazzoli, Stefano",70.172
+"De Leo, Gregorio",70.187
+"Schott, Freddy",70.196
+"Iwata, Hiroshi",70.218
+"Fichardt, Darren",70.218
+"Lagergren, Joakim",70.221
+"Micheluzzi, David",70.229
+"Gumberg, Jordan",70.236
+"Forsstrom, Simon",70.239
+"Brown, Hamish",70.298
+"Sharma, Shubhankar",70.316
+"Colsaerts, Nicolas",70.362
+"Pulkkanen, Tapio",70.367
+"Sordet, Clement",70.387
+"Chappell, Kevin",70.392
+"Girrbach, Joel",70.393
+"Aiken, Thomas",70.396
+"Paratore, Renato",70.4
+"Cabrera Bello, Rafa",70.444
+"Boneta, Albert",70.454
+"Bjerregaard, Lucas",70.478
+"Sterne, Richard",70.556
+"Tetak, Tadeáš",70.559
+"Johnston, Ryggs",70.579
+"Celli, Filippo",70.588
+"Vecchi Fossa, Jacopo",70.606
+"Levy, Alexander",70.607
+"Ahlawat, Veer",70.621
+"Van Velzen, Ryan",70.63
+"Germishuys, Deon",70.642
+"De Bruyn, Jannik",70.646
+"Besseling, Wil",70.649
+"Garcia-Heredia, Alfredo",70.715
+"Moscatel, Joel",70.724
+"Lombard, Zander",70.778
+"Scalise, Lorenzo",70.832
+"Baldwin, Matthew",70.835
+"Jin, Zihao",70.836
+"Ko, Jeong Weon",70.837
+"Whitnell, Dale",70.849
+"Shaun, Corey",70.859
+"Erickson, Dan",70.871
+"Lindberg, Mikael",70.871
+"Pineau, Pierre",70.908
+"Fisher, Ross",71.049
+"Karlberg, Rikard",71.071
+"Hutsby, Sam",71.076
+"Brun, Julien",71.119
+"Gale, Daniel",71.141
+"Frances, Alexander George",71.197
+"Akesson, Bjorn",71.269
+"Follet-Smith, Benjamin",71.27
+"List, Danny",71.273
+"Harding, Justin",71.293
+"Schwab, Matthias",71.329
+"Ortolani, Michele",71.35
+"Albertse, Louis",71.377
+"Zemmer, Aron",71.407
+"McGowan, Ross",71.424
+"Bekirian, Jean",71.526
+"Knappe, Alexander",71.533
+"Amat, Bastien",71.536
+"Michetti, Flavio",71.563
+"Coletta, Brett",71.657
+"Hirmer, Michael",71.817
+"Romano, Andrea",71.84
+"Schietekat, Neil",71.88
+"Memeo, Luca",71.906
+"Manica, Mafredi",72.041
+"Di Nitto, Enrico",72.065
+"Fdez-Castano, Gonzalo",72.104
+"Fallotico, Lucas",72.441
+"Cianchetti, Luca",72.889
+"Trainer, Martin",72.896
+"Barnes, Erik",74.174

--- a/scripts/project_per_round_strokes.py
+++ b/scripts/project_per_round_strokes.py
@@ -1,0 +1,54 @@
+import argparse
+import csv
+
+
+def load_tournament_info(path: str) -> dict:
+    """Load course par, field strength, and scoring prediction from CSV."""
+    info = {}
+    with open(path, encoding="utf-8-sig") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 3:
+                continue
+            key = row[1].strip().lower()
+            val = row[2].strip()
+            info[key] = val
+    return info
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Project per round strokes")
+    parser.add_argument("--strokes", required=True, help="DataGolf strokes gained predictions CSV")
+    parser.add_argument("--tournament", required=True, help="Tournament information CSV")
+    parser.add_argument("--output", required=True, help="Output CSV path")
+    args = parser.parse_args()
+
+    info = load_tournament_info(args.tournament)
+    par = float(info.get("course par", 72))
+    field = float(info.get("field strength", 0))
+    scoring = float(info.get("scoring prediction", 0))
+
+    rows = []
+    with open(args.strokes, encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row.get("player_name")
+            if not name:
+                continue
+            try:
+                sg = float(row["final_prediction"])
+            except (TypeError, ValueError):
+                continue
+            projected = round(par + field - sg + scoring, 3)
+            rows.append([name.strip("\""), projected])
+
+    with open(args.output, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["PLAYER NAME", "PROJECTED STROKES"])
+        for r in rows:
+            writer.writerow(r)
+    print(f"Wrote {len(rows)} rows to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `project_per_round_strokes.py` to calculate per-round scores using strokes gained predictions and tournament info
- generate sample projections for the 2025 Italian Open

## Testing
- `python3 scripts/project_per_round_strokes.py --strokes data/raw/'Italian Open DataGolf Strokes Gained Pred 20250624.csv' --tournament data/raw/'Tournament Information - Italian Open 20250624.csv' --output outputs/'Italian Open Projected Strokes 20250624.csv'`

------
https://chatgpt.com/codex/tasks/task_e_685cb60f449c832a9ce7c08cca194909