### PR TITLE
Add LIV Dallas model projections

### DIFF
--- a/outputs/Adjusted LIV Dallas Strokes Gained 20250624.csv
+++ b/outputs/Adjusted LIV Dallas Strokes Gained 20250624.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,BASELINE STROKES,ADJUSTED STROKES,STROKES GAINED
+"Ancer, Abraham",70.909,70.977,0.053
+"Ballester, Jose Luis",72.005,72.005,-0.975
+"Bland, Richard",71.366,71.598,-0.568
+"Burmester, Dean",70.65,70.701,0.329
+"Campbell, Ben",71.863,71.953,-0.923
+"Casey, Paul",70.852,70.887,0.143
+"DeChambeau, Bryson",68.714,68.791,2.239
+"Garcia, Sergio",70.85,70.925,0.105
+"Gooch, Talor",70.701,70.732,0.298
+"Grace, Branden",71.533,71.621,-0.591
+"Hatton, Tyrrell",69.62,69.597,1.433
+"Herbert, Lucas",70.266,70.197,0.833
+"Horsfield, Sam",71.61,71.432,-0.402
+"Howell III, Charles",71.184,70.987,0.043
+"Jang, Yubin",72.314,72.314,-1.284
+"Johnson, Dustin",71.042,71.083,-0.053
+"Jones, Matt",72.173,72.433,-1.403
+"Kaymer, Martin",72.254,72.432,-1.402
+"Kim, Anthony",73.804,73.804,-2.774
+"Kjettrup, Frederik",73.396,73.396,-2.366
+"Koepka, Brooks",70.416,70.308,0.722
+"Kokrak, Jason",71.454,71.519,-0.489
+"Kozuma, Jinichiro",71.356,71.266,-0.236
+"Lahiri, Anirban",71.019,71.1,-0.07
+"Lee, Chieh-Po",72.377,72.377,-1.347
+"Lee, Danny",72.895,72.895,-1.865
+"Leishman, Marc",70.735,70.688,0.342
+"McDowell, Graeme",71.642,71.554,-0.524
+"McKibbin, Tom",70.743,70.693,0.337
+"Meronk, Adrian",71.695,72.076,-1.046
+"Mickelson, Phil",71.528,71.598,-0.568
+"Munoz, Sebastian",70.265,70.186,0.844
+"Na, Kevin",71.619,71.578,-0.548
+"Niemann, Joaquin",69.338,69.347,1.683
+"Ogletree, Andy",72.497,72.448,-1.418
+"Oosthuizen, Louis",70.947,70.929,0.101
+"Ortiz, Carlos",69.823,69.704,1.326
+"Pereira, Mito",72.69,72.739,-1.709
+"Pieters, Thomas",70.739,70.701,0.329
+"Poulter, Ian",72.239,72.371,-1.341
+"Puig, David",70.513,70.5,0.53
+"Rahm, Jon",68.773,68.711,2.319
+"Reed, Patrick",70.142,70.273,0.757
+"Schwartzel, Charl",70.945,70.882,0.148
+"Smith, Cameron",70.563,70.66,0.37
+"Steele, Brendan",71.253,71.144,-0.114
+"Stenson, Henrik",71.976,71.716,-0.686
+"Surratt, Caleb",71.538,71.585,-0.555
+"Tringale, Cameron",70.896,70.798,0.232
+"Uihlein, Peter",71.393,71.346,-0.316
+"Varner III, Harold",71.048,70.975,0.055
+"Watson, Bubba",70.883,70.913,0.117
+"Westwood, Lee",72.349,72.217,-1.187
+"Wolff, Matthew",71.756,71.797,-0.767

--- a/outputs/Adjusted Per Round Strokes LIV Dallas 20250624.csv
+++ b/outputs/Adjusted Per Round Strokes LIV Dallas 20250624.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,BASELINE STROKES,ADJUSTED STROKES
+"Ancer, Abraham",70.909,70.977
+"Ballester, Jose Luis",72.005,72.005
+"Bland, Richard",71.366,71.598
+"Burmester, Dean",70.65,70.701
+"Campbell, Ben",71.863,71.953
+"Casey, Paul",70.852,70.887
+"DeChambeau, Bryson",68.714,68.791
+"Garcia, Sergio",70.85,70.925
+"Gooch, Talor",70.701,70.732
+"Grace, Branden",71.533,71.621
+"Hatton, Tyrrell",69.62,69.597
+"Herbert, Lucas",70.266,70.197
+"Horsfield, Sam",71.61,71.432
+"Howell III, Charles",71.184,70.987
+"Jang, Yubin",72.314,72.314
+"Johnson, Dustin",71.042,71.083
+"Jones, Matt",72.173,72.433
+"Kaymer, Martin",72.254,72.432
+"Kim, Anthony",73.804,73.804
+"Kjettrup, Frederik",73.396,73.396
+"Koepka, Brooks",70.416,70.308
+"Kokrak, Jason",71.454,71.519
+"Kozuma, Jinichiro",71.356,71.266
+"Lahiri, Anirban",71.019,71.1
+"Lee, Chieh-Po",72.377,72.377
+"Lee, Danny",72.895,72.895
+"Leishman, Marc",70.735,70.688
+"McDowell, Graeme",71.642,71.554
+"McKibbin, Tom",70.743,70.693
+"Meronk, Adrian",71.695,72.076
+"Mickelson, Phil",71.528,71.598
+"Munoz, Sebastian",70.265,70.186
+"Na, Kevin",71.619,71.578
+"Niemann, Joaquin",69.338,69.347
+"Ogletree, Andy",72.497,72.448
+"Oosthuizen, Louis",70.947,70.929
+"Ortiz, Carlos",69.823,69.704
+"Pereira, Mito",72.69,72.739
+"Pieters, Thomas",70.739,70.701
+"Poulter, Ian",72.239,72.371
+"Puig, David",70.513,70.5
+"Rahm, Jon",68.773,68.711
+"Reed, Patrick",70.142,70.273
+"Schwartzel, Charl",70.945,70.882
+"Smith, Cameron",70.563,70.66
+"Steele, Brendan",71.253,71.144
+"Stenson, Henrik",71.976,71.716
+"Surratt, Caleb",71.538,71.585
+"Tringale, Cameron",70.896,70.798
+"Uihlein, Peter",71.393,71.346
+"Varner III, Harold",71.048,70.975
+"Watson, Bubba",70.883,70.913
+"Westwood, Lee",72.349,72.217
+"Wolff, Matthew",71.756,71.797

--- a/outputs/LIV Dallas DG Model 20250624.csv
+++ b/outputs/LIV Dallas DG Model 20250624.csv
@@ -1,0 +1,55 @@
+player_name,dg_id,dg_pred,my_pred
+bryson dechambeau,19841,2.317,2.239
+jon rahm,19195,2.258,2.319
+joaquin niemann,18079,1.693,1.683
+tyrrell hatton,14796,1.411,1.433
+carlos ortiz,14735,1.208,1.326
+patrick reed,14838,0.889,0.757
+sebastian munoz,20770,0.765,0.844
+lucas herbert,17064,0.765,0.833
+brooks koepka,16243,0.614,0.722
+david puig,28984,0.517,0.53
+cameron smith,15856,0.468,0.37
+dean burmester,14424,0.381,0.329
+talor gooch,18580,0.329,0.298
+marc leishman,7649,0.295,0.342
+thomas pieters,13944,0.291,0.329
+tom mckibbin,22322,0.287,0.337
+sergio garcia,5689,0.181,0.105
+paul casey,7108,0.178,0.143
+bubba watson,7334,0.147,0.117
+cameron tringale,14013,0.135,0.232
+abraham ancer,18238,0.121,0.053
+charl schwartzel,7398,0.086,0.148
+louis oosthuizen,7672,0.084,0.101
+anirban lahiri,12669,0.011,-0.07
+dustin johnson,12422,-0.012,-0.053
+harold varner iii,16602,-0.018,0.055
+charles howell iii,6892,-0.153,0.043
+brendan steele,11019,-0.223,-0.114
+jinichiro kozuma,14209,-0.325,-0.236
+richard bland,6516,-0.336,-0.568
+peter uihlein,11357,-0.363,-0.316
+jason kokrak,12337,-0.424,-0.489
+phil mickelson,1547,-0.497,-0.568
+branden grace,11952,-0.502,-0.591
+caleb surratt,30463,-0.507,-0.555
+sam horsfield,19866,-0.579,-0.402
+kevin na,7452,-0.589,-0.548
+graeme mcdowell,7548,-0.612,-0.524
+adrian meronk,14196,-0.665,-1.046
+matthew wolff,25919,-0.725,-0.767
+ben campbell,14373,-0.832,-0.923
+henrik stenson,5994,-0.946,-0.686
+jose luis ballester,28473,-0.975,-0.975
+matt jones,8605,-1.143,-1.403
+ian poulter,1435,-1.209,-1.341
+martin kaymer,8117,-1.223,-1.402
+yubin jang,28276,-1.284,-1.284
+lee westwood,4052,-1.319,-1.187
+chieh-po lee,16563,-1.347,-1.347
+andy ogletree,27597,-1.466,-1.418
+mito pereira,19455,-1.66,-1.709
+danny lee,11826,-1.865,-1.865
+frederik kjettrup,24660,-2.366,-2.366
+anthony kim,11641,-2.773,-2.774

--- a/outputs/Projected Per Round Strokes LIV Dallas 20250624.csv
+++ b/outputs/Projected Per Round Strokes LIV Dallas 20250624.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,PROJECTED STROKES
+"DeChambeau, Bryson",68.714
+"Rahm, Jon",68.773
+"Niemann, Joaquin",69.338
+"Hatton, Tyrrell",69.62
+"Ortiz, Carlos",69.823
+"Reed, Patrick",70.142
+"Munoz, Sebastian",70.265
+"Herbert, Lucas",70.266
+"Koepka, Brooks",70.416
+"Puig, David",70.513
+"Smith, Cameron",70.563
+"Burmester, Dean",70.65
+"Gooch, Talor",70.701
+"Leishman, Marc",70.735
+"Pieters, Thomas",70.739
+"McKibbin, Tom",70.743
+"Garcia, Sergio",70.85
+"Casey, Paul",70.852
+"Watson, Bubba",70.883
+"Tringale, Cameron",70.896
+"Ancer, Abraham",70.909
+"Schwartzel, Charl",70.945
+"Oosthuizen, Louis",70.947
+"Lahiri, Anirban",71.019
+"Johnson, Dustin",71.042
+"Varner III, Harold",71.048
+"Howell III, Charles",71.184
+"Steele, Brendan",71.253
+"Kozuma, Jinichiro",71.356
+"Bland, Richard",71.366
+"Uihlein, Peter",71.393
+"Kokrak, Jason",71.454
+"Mickelson, Phil",71.528
+"Grace, Branden",71.533
+"Surratt, Caleb",71.538
+"Horsfield, Sam",71.61
+"Na, Kevin",71.619
+"McDowell, Graeme",71.642
+"Meronk, Adrian",71.695
+"Wolff, Matthew",71.756
+"Campbell, Ben",71.863
+"Stenson, Henrik",71.976
+"Ballester, Jose Luis",72.005
+"Jones, Matt",72.173
+"Poulter, Ian",72.239
+"Kaymer, Martin",72.254
+"Jang, Yubin",72.314
+"Westwood, Lee",72.349
+"Lee, Chieh-Po",72.377
+"Ogletree, Andy",72.497
+"Pereira, Mito",72.69
+"Lee, Danny",72.895
+"Kjettrup, Frederik",73.396
+"Kim, Anthony",73.804

--- a/scripts/adjust_projections.py
+++ b/scripts/adjust_projections.py
@@ -66,6 +66,8 @@ def load_strokes(path, use_adjusted=True, course=None):
                 val = row["BASELINE STROKES"]
             elif "STROKES PREDICTION" in row:
                 val = row.get("STROKES PREDICTION")
+            elif "PROJECTED STROKES" in row:
+                val = row.get("PROJECTED STROKES")
             else:
                 val = row.get("STROKES")
 


### PR DESCRIPTION
## Summary
- compute strokes gained from adjusted per-round strokes for LIV Dallas
- fill the DataGolf model upload template with those projections

## Testing
- `python3 scripts/compute_strokes_gained.py outputs/Adjusted Per Round Strokes LIV Dallas 20250624.csv outputs/Adjusted LIV Dallas Strokes Gained 20250624.csv --avg-score 71.03`
- `python3 scripts/create_dg_model.py outputs/Adjusted LIV Dallas Strokes Gained 20250624.csv data/raw/LIV Dallas Model Upload Template 20250624.csv outputs/LIV Dallas DG Model 20250624.csv`


------
https://chatgpt.com/codex/tasks/task_e_685cb79b8954832abdb62b3d0ce392e0