### PR TITLE
Add EV analysis for LIV Dallas

### DIFF
--- a/outputs/liv_dallas_positive_ev.csv
+++ b/outputs/liv_dallas_positive_ev.csv
@@ -1,0 +1,18 @@
+market,player,book,odds,ev
+top_5,"Stenson, Henrik",bet365,+5500,0.9002
+win,"Kozuma, Jinichiro",bovada,+20000,0.5209
+top_10,"Stenson, Henrik",bet365,+1500,0.5009
+win,"Stenson, Henrik",bet365,+40000,0.457
+top_5,"Kozuma, Jinichiro",bet365,+2200,0.4277
+win,"Howell III, Charles",betcris,+10088,0.2955
+top_20,"Stenson, Henrik",betway,+400,0.292
+win,"Herbert, Lucas",bovada,+3500,0.2618
+top_5,"Na, Kevin",bet365,+2800,0.2511
+top_10,"Kozuma, Jinichiro",bet365,+725,0.2332
+top_5,"Steele, Brendan",betway,+1600,0.2186
+top_5,"Howell III, Charles",bet365,+1300,0.2121
+win,"Steele, Brendan",bovada,+12500,0.1844
+top_10,"Steele, Brendan",betway,+550,0.0924
+top_10,"Na, Kevin",bet365,+875,0.0821
+win,"Varner III, Harold",betcris,+8082,0.0718
+top_5,"Horsfield, Sam",bet365,+2000,0.0709

--- a/scripts/compute_liv_dallas_ev.py
+++ b/scripts/compute_liv_dallas_ev.py
@@ -1,0 +1,103 @@
+import csv
+from pathlib import Path
+
+BOOKS = [
+    'bet365','fanduel','draftkings','betcris','caesars','betway','bovada','betonline','unibet','betmgm','betfair','pinnacle'
+]
+
+MARKET_FILES = {
+    'win': 'liv_dallas_win_american_ch.csv',
+    'top_5': 'liv_dallas_top5_american_ch.csv',
+    'top_10': 'liv_dallas_top10_american_ch.csv',
+    'top_20': 'liv_dallas_top20_american_ch.csv'
+}
+
+PRED_FILE = 'My_Model LIV Dallas 20250625.csv'
+
+def american_to_decimal(odds: str):
+    try:
+        o = int(float(odds))
+    except Exception:
+        return None
+    if o > 0:
+        return 1 + o / 100
+    return 1 + 100 / (-o)
+
+def american_to_prob(odds: str):
+    try:
+        o = float(odds)
+    except Exception:
+        return None
+    if o == float('inf'):
+        return 0.0
+    if o > 0:
+        return 100 / (o + 100)
+    return -o / (-o + 100)
+
+def load_predictions(path: Path):
+    preds = {}
+    with open(path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row['player_name'].strip().lower()
+            name = ' '.join(p.title() for p in name.split())
+            preds[name] = {}
+            for market in ['win','top_5','top_10','top_20']:
+                val = row.get(market)
+                if val in (None, '', 'null'):
+                    prob = None
+                else:
+                    prob = american_to_prob(val)
+                preds[name][market] = prob
+    return preds
+
+def best_ev_bets(preds: dict, data_root: str, threshold: float = 0.06):
+    bets = []
+    for market, file in MARKET_FILES.items():
+        path = Path(data_root) / file
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                name = row['player_name'].strip()
+                if ',' in name:
+                    last, first = [x.strip() for x in name.split(',',1)]
+                    norm = f"{first.title()} {last.title()}"
+                else:
+                    norm = ' '.join(p.title() for p in name.split())
+                if norm not in preds:
+                    continue
+                prob = preds[norm].get(market)
+                if prob is None:
+                    continue
+                best = None
+                for book in BOOKS:
+                    odds = row.get(f"{book}_odds")
+                    if not odds or odds in ('', 'null'):
+                        continue
+                    dec = american_to_decimal(odds)
+                    if dec is None:
+                        continue
+                    ev = prob * dec - 1
+                    if ev >= threshold and (best is None or ev > best['ev']):
+                        best = {'market': market, 'player': name, 'book': book, 'odds': odds, 'ev': ev}
+                if best:
+                    bets.append(best)
+    bets.sort(key=lambda x: x['ev'], reverse=True)
+    return bets
+
+def main():
+    preds = load_predictions(Path('data/raw')/PRED_FILE)
+    bets = best_ev_bets(preds, 'data/raw')
+    out = Path('outputs/liv_dallas_positive_ev.csv')
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['market','player','book','odds','ev'])
+        writer.writeheader()
+        for b in bets:
+            b2 = b.copy(); b2['ev'] = round(b2['ev'],4)
+            writer.writerow(b2)
+    for b in bets:
+        print(f"{b['market']}, {b['player']}, {b['book']}, {b['odds']}, {b['ev']:.4f}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `compute_liv_dallas_ev.py` for EV comparison of model and bookmaker odds
- generate `liv_dallas_positive_ev.csv` with the top value bets

## Testing
- `python3 scripts/compute_liv_dallas_ev.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685cbc70bfd8832aadcf71d73b0ffabb