### PR TITLE
Add EV script for Italian Open

### DIFF
--- a/outputs/italian_open_positive_ev.csv
+++ b/outputs/italian_open_positive_ev.csv
@@ -1,0 +1,43 @@
+market,player,book,odds,ev
+top_5,"Forsstrom, Simon",bet365,+6000,0.2523
+top_5,"Girrbach, Joel",betway,+6600,0.2138
+top_5,"Iwata, Hiroshi",bet365,+6000,0.2027
+top_5,"McGowan, Ross",bet365,+27500,0.1844
+top_5,"Saddier, Adrien",bet365,+1400,0.1737
+top_10,"Scrivener, Jason",bet365,+1000,0.1715
+top_10,"Frances, Alexander George",bet365,+10000,0.1591
+top_20,"Girrbach, Joel",bovada,+1100,0.1572
+win,"Schaper, Jayden",fanduel,+3000,0.1571
+miss_cut,"Couvra, Martin",bet365,+225,0.1566
+win,"Lindell, Oliver",fanduel,+5500,0.1452
+win,"Aiken, Thomas",fanduel,+50000,0.1356
+top_10,"McGowan, Ross",bet365,+10000,0.1306
+win,"Saddier, Adrien",bet365,+6600,0.13
+top_5,"Scrivener, Jason",bet365,+2000,0.1188
+top_20,"Vecchi Fossa, Jacopo",bovada,+1600,0.1104
+top_10,"Saddier, Adrien",bet365,+650,0.1095
+top_5,"Clements, Todd",bet365,+2000,0.1018
+make_cut,"Girrbach, Joel",draftkings,+135,0.0981
+win,"Kobori, Kazuma",fanduel,+11000,0.0971
+top_5,"Frances, Alexander George",bet365,+27500,0.0953
+win,"Scrivener, Jason",bet365,+11000,0.0896
+top_10,"Amat, Bastien",bet365,+17500,0.0894
+make_cut,"Van Driel, Darius",draftkings,-125,0.0857
+top_10,"Molinari, Edoardo",bet365,+700,0.084
+top_20,"Saddier, Adrien",unibet,+300,0.084
+top_5,"Gumberg, Jordan",bet365,+6000,0.0825
+top_10,"Schaper, Jayden",unibet,+350,0.0791
+top_5,"Molinari, Edoardo",bet365,+1400,0.0784
+miss_cut,"Ferguson, Ewen",unibet,+275,0.0776
+top_5,"Schaper, Jayden",fanduel,+650,0.073
+make_cut,"Parry, John",draftkings,-200,0.0726
+win,"Ding, Wenyi",bet365,+5500,0.0724
+top_10,"Girrbach, Joel",bet365,+2500,0.0704
+top_10,"Lindell, Oliver",caesars,+550,0.0691
+top_5,"Lindell, Oliver",bet365,+1100,0.0686
+win,"Ramsay, Richie",betcris,+13245,0.0676
+win,"Purcell, Conor",betcris,+15066,0.0667
+top_5,"Kobori, Kazuma",bet365,+2000,0.0638
+make_cut,"Lindell, Oliver",draftkings,-175,0.0629
+make_cut,"Aiken, Thomas",draftkings,+140,0.0619
+make_cut,"Purcell, Conor",draftkings,-115,0.0602

--- a/scripts/compute_italian_open_ev.py
+++ b/scripts/compute_italian_open_ev.py
@@ -1,0 +1,116 @@
+import csv
+from pathlib import Path
+
+BOOKS = [
+    'bet365', 'fanduel', 'draftkings', 'betcris', 'caesars',
+    'betway', 'bovada', 'betonline', 'unibet', 'betmgm',
+    'betfair', 'pinnacle'
+]
+
+MARKET_FILES = {
+    'win': 'italian_open_win_american_ch.csv',
+    'top_5': 'italian_open_top5_american_ch.csv',
+    'top_10': 'italian_open_top10_american_ch.csv',
+    'top_20': 'italian_open_top20_american_ch.csv',
+    'make_cut': 'italian_open_cut_american_ch.csv',
+    'miss_cut': 'italian_open_mc_american_ch.csv',
+}
+
+PRED_FILE = 'my_model Italian Open 20250625.csv'
+
+def american_to_decimal(odds: str):
+    try:
+        o = int(odds)
+    except Exception:
+        return None
+    if o > 0:
+        return 1 + o / 100
+    return 1 + 100 / (-o)
+
+def american_to_prob(odds: str):
+    try:
+        o = int(odds)
+    except Exception:
+        return None
+    if o > 0:
+        return 100 / (o + 100)
+    return -o / (-o + 100)
+
+def load_predictions(path: Path):
+    preds = {}
+    with open(path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row['player_name'].strip().lower()
+            name = ' '.join(p.title() for p in name.split())
+            mc = american_to_prob(row['make_cut'])
+            t20 = american_to_prob(row['top_20'])
+            t10 = american_to_prob(row['top_10'])
+            t5 = american_to_prob(row['top_5'])
+            win = american_to_prob(row['win'])
+            preds[name] = {
+                'make_cut': mc,
+                'miss_cut': 1 - mc if mc is not None else None,
+                'top_20': t20,
+                'top_10': t10,
+                'top_5': t5,
+                'win': win,
+            }
+    return preds
+
+def best_ev_bets(preds: dict, data_root: str, threshold: float = 0.06):
+    bets = []
+    for market, file in MARKET_FILES.items():
+        path = Path(data_root) / file
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                name = row['player_name'].strip()
+                if ',' in name:
+                    last, first = [x.strip() for x in name.split(',', 1)]
+                    norm = f"{first.title()} {last.title()}"
+                else:
+                    norm = ' '.join(p.title() for p in name.split())
+                if norm not in preds:
+                    continue
+                prob = preds[norm].get(market)
+                if prob is None:
+                    continue
+                best = None
+                for book in BOOKS:
+                    odds = row.get(f"{book}_odds")
+                    if not odds or odds in ('', 'null'):
+                        continue
+                    dec = american_to_decimal(odds)
+                    if dec is None:
+                        continue
+                    ev = prob * dec - 1
+                    if ev >= threshold and (best is None or ev > best['ev']):
+                        best = {
+                            'market': market,
+                            'player': name,
+                            'book': book,
+                            'odds': odds,
+                            'ev': ev,
+                        }
+                if best:
+                    bets.append(best)
+    bets.sort(key=lambda x: x['ev'], reverse=True)
+    return bets
+
+def main():
+    preds = load_predictions(Path('data/raw') / PRED_FILE)
+    bets = best_ev_bets(preds, 'data/raw')
+    out = Path('outputs/italian_open_positive_ev.csv')
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['market', 'player', 'book', 'odds', 'ev'])
+        writer.writeheader()
+        for b in bets:
+            b2 = b.copy(); b2['ev'] = round(b2['ev'], 4)
+            writer.writerow(b2)
+    for b in bets:
+        print(f"{b['market']}, {b['player']}, {b['book']}, {b['odds']}, {b['ev']:.4f}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a script to compute positive EV bets for the Italian Open
- generate csv output listing bets with >6% EV

## Testing
- `python3 scripts/compute_italian_open_ev.py | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_685cc0389364832a97f3b203e331f4a7