### PR TITLE
Update LIV Andalucia DK model projections

### DIFF
--- a/outputs/Adjusted Per Round Strokes LIV Andalucia.csv
+++ b/outputs/Adjusted Per Round Strokes LIV Andalucia.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,BASELINE STROKES,ADJUSTED STROKES
+"Ancer, Abraham",71.759,71.68
+"Ballester, Jose Luis",73.595,73.595
+"Bland, Richard",72.13,72.141
+"Burmester, Dean",71.945,71.843
+"Campbell, Ben",72.569,72.481
+"Casey, Paul",71.611,71.611
+"DeChambeau, Bryson",70.213,70.298
+"Garcia, Sergio",71.654,71.581
+"Gooch, Talor",71.823,71.838
+"Grace, Branden",72.553,72.447
+"Hatton, Tyrrell",70.79,70.785
+"Herbert, Lucas",71.878,71.884
+"Horsfield, Sam",72.678,72.276
+"Howell III, Charles",72.22,72.252
+"Jang, Yubin",73.685,73.245
+"Johnson, Dustin",72.199,72.202
+"Jones, Matt",73.481,73.571
+"Kaymer, Martin",72.596,72.512
+"Kim, Anthony",74.702,74.702
+"Kjettrup, Frederik",74.548,74.988
+"Koepka, Brooks",71.873,71.889
+"Kokrak, Jason",72.78,73.028
+"Kozuma, Jinichiro",72.235,72.149
+"Lahiri, Anirban",71.841,71.888
+"Lee, Chieh-Po",73.404,73.625
+"Lee, Danny",73.835,73.376
+"Leishman, Marc",72.026,72.189
+"Masaveu, Luis",73.807,73.807
+"McDowell, Graeme",72.662,72.488
+"McKibbin, Tom",71.834,71.705
+"Meronk, Adrian",72.888,73.05
+"Mickelson, Phil",72.915,73.042
+"Munoz, Sebastian",71.184,71.225
+"Na, Kevin",72.71,72.758
+"Niemann, Joaquin",70.807,70.773
+"Ogletree, Andy",73.563,73.473
+"Oosthuizen, Louis",71.58,71.469
+"Ortiz, Carlos",71.319,71.429
+"Pereira, Mito",74.069,74.528
+"Pieters, Thomas",72.073,72.068
+"Poulter, Ian",73.407,73.809
+"Puig, David",71.428,71.381
+"Rahm, Jon",70.138,70.092
+"Reed, Patrick",71.055,70.955
+"Schwartzel, Charl",71.973,71.935
+"Smith, Cameron",71.757,71.937
+"Steele, Brendan",72.538,72.284
+"Stenson, Henrik",72.718,72.609
+"Surratt, Caleb",73.049,73.234
+"Tringale, Cameron",71.81,71.823
+"Uihlein, Peter",72.999,73.006
+"Varner III, Harold",72.11,72.132
+"Watson, Bubba",72.38,72.323
+"Westwood, Lee",73.165,73.339

--- a/outputs/Adjusted Strokes Gained LIV Andalucia.csv
+++ b/outputs/Adjusted Strokes Gained LIV Andalucia.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,BASELINE STROKES,ADJUSTED STROKES,STROKES GAINED
+"Ancer, Abraham",71.759,71.68,0.53
+"Ballester, Jose Luis",73.595,73.595,-1.385
+"Bland, Richard",72.13,72.141,0.069
+"Burmester, Dean",71.945,71.843,0.367
+"Campbell, Ben",72.569,72.481,-0.271
+"Casey, Paul",71.611,71.611,0.599
+"DeChambeau, Bryson",70.213,70.298,1.912
+"Garcia, Sergio",71.654,71.581,0.629
+"Gooch, Talor",71.823,71.838,0.372
+"Grace, Branden",72.553,72.447,-0.237
+"Hatton, Tyrrell",70.79,70.785,1.425
+"Herbert, Lucas",71.878,71.884,0.326
+"Horsfield, Sam",72.678,72.276,-0.066
+"Howell III, Charles",72.22,72.252,-0.042
+"Jang, Yubin",73.685,73.245,-1.035
+"Johnson, Dustin",72.199,72.202,0.008
+"Jones, Matt",73.481,73.571,-1.361
+"Kaymer, Martin",72.596,72.512,-0.302
+"Kim, Anthony",74.702,74.702,-2.492
+"Kjettrup, Frederik",74.548,74.988,-2.778
+"Koepka, Brooks",71.873,71.889,0.321
+"Kokrak, Jason",72.78,73.028,-0.818
+"Kozuma, Jinichiro",72.235,72.149,0.061
+"Lahiri, Anirban",71.841,71.888,0.322
+"Lee, Chieh-Po",73.404,73.625,-1.415
+"Lee, Danny",73.835,73.376,-1.166
+"Leishman, Marc",72.026,72.189,0.021
+"Masaveu, Luis",73.807,73.807,-1.597
+"McDowell, Graeme",72.662,72.488,-0.278
+"McKibbin, Tom",71.834,71.705,0.505
+"Meronk, Adrian",72.888,73.05,-0.84
+"Mickelson, Phil",72.915,73.042,-0.832
+"Munoz, Sebastian",71.184,71.225,0.985
+"Na, Kevin",72.71,72.758,-0.548
+"Niemann, Joaquin",70.807,70.773,1.437
+"Ogletree, Andy",73.563,73.473,-1.263
+"Oosthuizen, Louis",71.58,71.469,0.741
+"Ortiz, Carlos",71.319,71.429,0.781
+"Pereira, Mito",74.069,74.528,-2.318
+"Pieters, Thomas",72.073,72.068,0.142
+"Poulter, Ian",73.407,73.809,-1.599
+"Puig, David",71.428,71.381,0.829
+"Rahm, Jon",70.138,70.092,2.118
+"Reed, Patrick",71.055,70.955,1.255
+"Schwartzel, Charl",71.973,71.935,0.275
+"Smith, Cameron",71.757,71.937,0.273
+"Steele, Brendan",72.538,72.284,-0.074
+"Stenson, Henrik",72.718,72.609,-0.399
+"Surratt, Caleb",73.049,73.234,-1.024
+"Tringale, Cameron",71.81,71.823,0.387
+"Uihlein, Peter",72.999,73.006,-0.796
+"Varner III, Harold",72.11,72.132,0.078
+"Watson, Bubba",72.38,72.323,-0.113
+"Westwood, Lee",73.165,73.339,-1.129

--- a/outputs/LIV Andalucia DG Model.csv
+++ b/outputs/LIV Andalucia DG Model.csv
@@ -1,0 +1,55 @@
+player_name,dg_id,dg_pred,my_pred
+jon rahm,19195,2.072,2.118
+bryson dechambeau,19841,1.997,1.912
+tyrrell hatton,14796,1.42,1.425
+joaquin niemann,18079,1.403,1.437
+patrick reed,14838,1.155,1.255
+sebastian munoz,20770,1.026,0.985
+carlos ortiz,14735,0.891,0.781
+david puig,28984,0.782,0.829
+louis oosthuizen,7672,0.63,0.741
+paul casey,7108,0.599,0.599
+sergio garcia,5689,0.556,0.629
+cameron smith,15856,0.453,0.273
+abraham ancer,18238,0.451,0.53
+cameron tringale,14013,0.4,0.387
+talor gooch,18580,0.387,0.372
+tom mckibbin,22322,0.376,0.505
+anirban lahiri,12669,0.369,0.322
+brooks koepka,16243,0.337,0.321
+lucas herbert,17064,0.332,0.326
+dean burmester,14424,0.265,0.367
+charl schwartzel,7398,0.237,0.275
+marc leishman,7649,0.184,0.021
+thomas pieters,13944,0.137,0.142
+harold varner iii,16602,0.1,0.078
+richard bland,6516,0.08,0.069
+dustin johnson,12422,0.011,0.008
+charles howell iii,6892,-0.01,-0.042
+jinichiro kozuma,14209,-0.025,0.061
+bubba watson,7334,-0.17,-0.113
+brendan steele,11019,-0.328,-0.074
+branden grace,11952,-0.343,-0.237
+ben campbell,14373,-0.359,-0.271
+martin kaymer,8117,-0.386,-0.302
+graeme mcdowell,7548,-0.452,-0.278
+sam horsfield,19866,-0.468,-0.066
+kevin na,7452,-0.5,-0.548
+henrik stenson,5994,-0.508,-0.399
+jason kokrak,12337,-0.57,-0.818
+adrian meronk,14196,-0.678,-0.84
+phil mickelson,1547,-0.705,-0.832
+peter uihlein,11357,-0.789,-0.796
+caleb surratt,30463,-0.839,-1.024
+lee westwood,4052,-0.955,-1.129
+chieh-po lee,16563,-1.194,-1.415
+ian poulter,1435,-1.197,-1.599
+matt jones,8605,-1.271,-1.361
+andy ogletree,27597,-1.353,-1.263
+jose luis ballester,28473,-1.385,-1.385
+yubin jang,28276,-1.475,-1.035
+luis masaveu,30428,-1.597,-1.597
+danny lee,11826,-1.625,-1.166
+mito pereira,19455,-1.859,-2.318
+frederik kjettrup,24660,-2.338,-2.778
+anthony kim,11641,-2.492,-2.492

--- a/outputs/Projected Per Round Strokes LIV Andalucia.csv
+++ b/outputs/Projected Per Round Strokes LIV Andalucia.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,PROJECTED STROKES
+"Rahm, Jon",70.138
+"DeChambeau, Bryson",70.213
+"Hatton, Tyrrell",70.79
+"Niemann, Joaquin",70.807
+"Reed, Patrick",71.055
+"Munoz, Sebastian",71.184
+"Ortiz, Carlos",71.319
+"Puig, David",71.428
+"Oosthuizen, Louis",71.58
+"Casey, Paul",71.611
+"Garcia, Sergio",71.654
+"Smith, Cameron",71.757
+"Ancer, Abraham",71.759
+"Tringale, Cameron",71.81
+"Gooch, Talor",71.823
+"McKibbin, Tom",71.834
+"Lahiri, Anirban",71.841
+"Koepka, Brooks",71.873
+"Herbert, Lucas",71.878
+"Burmester, Dean",71.945
+"Schwartzel, Charl",71.973
+"Leishman, Marc",72.026
+"Pieters, Thomas",72.073
+"Varner III, Harold",72.11
+"Bland, Richard",72.13
+"Johnson, Dustin",72.199
+"Howell III, Charles",72.22
+"Kozuma, Jinichiro",72.235
+"Watson, Bubba",72.38
+"Steele, Brendan",72.538
+"Grace, Branden",72.553
+"Campbell, Ben",72.569
+"Kaymer, Martin",72.596
+"McDowell, Graeme",72.662
+"Horsfield, Sam",72.678
+"Na, Kevin",72.71
+"Stenson, Henrik",72.718
+"Kokrak, Jason",72.78
+"Meronk, Adrian",72.888
+"Mickelson, Phil",72.915
+"Uihlein, Peter",72.999
+"Surratt, Caleb",73.049
+"Westwood, Lee",73.165
+"Lee, Chieh-Po",73.404
+"Poulter, Ian",73.407
+"Jones, Matt",73.481
+"Ogletree, Andy",73.563
+"Ballester, Jose Luis",73.595
+"Jang, Yubin",73.685
+"Masaveu, Luis",73.807
+"Lee, Danny",73.835
+"Pereira, Mito",74.069
+"Kjettrup, Frederik",74.548
+"Kim, Anthony",74.702


### PR DESCRIPTION
## Summary
- compute strokes gained from adjusted strokes for LIV Andalucia
- fill LIV Andalucia upload template with those strokes gained values

## Testing
- `python3 scripts/compute_strokes_gained.py outputs/'Adjusted Per Round Strokes LIV Andalucia.csv' outputs/'Adjusted Strokes Gained LIV Andalucia.csv' --tournament-info 'data/raw/Tournament Information - LIV Andalucia.csv'`
- `python3 scripts/create_dg_model.py outputs/'Adjusted Strokes Gained LIV Andalucia.csv' 'data/raw/liv Andalucia_upload_template.csv' outputs/'LIV Andalucia DG Model.csv'`
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ed273907c832a9059d5f026c8ae4e