### PR TITLE
Add team roster score script

### DIFF
--- a/outputs/teamcrafters_roster_scores.csv
+++ b/outputs/teamcrafters_roster_scores.csv
@@ -1,0 +1,222 @@
+team_name,roster_score
+Air Force,67.515
+Akron,68.515
+Alabama,83.61
+Appalachian State,68.61
+Arizona,71.155
+Arizona State,74.365
+Arkansas,71.165
+Arkansas State,69.57
+Army,70.305
+Auburn,72.685
+Ball State,64.585
+Baylor,84.865
+Boise State,86.11
+Boston College,83.375
+Bowling Green,79.855
+Buffalo,82.44
+BYU,84.88
+California,81.115
+Central Michigan,79.45
+Charlotte,80.405
+Cincinnati,84.07
+Clemson,87.195
+Coastal Carolina,14.34
+Colorado,85.755
+Colorado State,25.25
+Delaware,77.525
+Duke,85.49
+East Carolina,81.245
+Eastern Michigan,79.05
+FIU,78.92
+Florida,85.56
+Florida Atlantic,78.25
+Florida State,72.825
+Fresno State,71.12
+Georgia,72.68
+Georgia Southern,70.3
+Georgia State,67.855
+Georgia Tech,73.465
+Hawaii,68.58
+Houston,71.65
+Illinois,74.195
+Indiana,73.005
+Iowa,84.215
+Iowa State,85.975
+Jacksonville State,78.385
+James Madison,81.745
+Kansas,82.32
+Kansas State,84.845
+Kennesaw State,78.625
+Kent State,72.935
+Kentucky,84.13
+Liberty,82.03
+Louisiana,80.105
+Louisiana–Monroe,79.685
+Louisiana Tech,78.785
+Louisville,84.835
+LSU,86.515
+Marshall,77.795
+Maryland,78.225
+Memphis,83.08
+Miami (FL),87.23
+Miami (OH),79.975
+Michigan,86.77
+Michigan State,80.98
+Middle Tennessee,80.755
+Minnesota,70.005
+Mississippi State,72.03
+Missouri,71.485
+Missouri State,64.755
+Navy,71.96
+NC State,70.84
+Nebraska,72.92
+Nevada,67.185
+New Mexico,66.26
+New Mexico State,66.455
+North Carolina,83.95
+Northern Illinois,78.015
+North Texas,81.605
+Northwestern,83.915
+Notre Dame,85.645
+Ohio,79.81
+Ohio State,85.14
+Oklahoma,85.55
+Oklahoma State,80.7
+Old Dominion,79.295
+Ole Miss,82.13
+Oregon,85.24
+Oregon State,81.785
+Penn State,86.855
+Pittsburgh,81.94
+Purdue,79.5
+Rice,78.71
+Rutgers,85.805
+Sam Houston,78.105
+San Diego State,81.43
+San Jose State,81.6
+SMU,84.915
+South Alabama,68.285
+South Carolina,71.83
+South Florida,69.32
+Southern Miss,71.87
+Stanford,70.21
+Syracuse,70.285
+TCU,71.54
+Temple,67.855
+Tennessee,72.445
+Texas,73.81
+Texas A&M,86.185
+Texas State,79.835
+Texas Tech,86.415
+Toledo,82.55
+Troy,81.03
+Tulane,82.28
+Tulsa,79.08
+UAB,78.645
+UCF,83.485
+UCLA,83.585
+UConn,82.295
+UNLV,77.14
+USC,83.32
+Utah,72.995
+Utah State,73.94
+UTEP,67.935
+UTSA,67.485
+Vanderbilt,72.21
+Virginia,73.42
+Virginia Tech,73.615
+Wake Forest,69.92
+Washington,69.635
+Washington State,71.825
+West Virginia,82.235
+Western Kentucky,80.48
+Western Michigan,78.485
+Wisconsin,83.2
+Wyoming,85.165
+Team 755,80.555
+Baylor,73.085
+Boise State,73.7
+Boston College,71.16
+Bowling Green,68.01
+Buffalo,70.35
+BYU,72.585
+California,69.995
+Central Michigan,67.555
+Charlotte,68.505
+Cincinnati,71.915
+Clemson,75.125
+Coastal Carolina,14.34
+Colorado,73.94
+Colorado State,25.25
+Delaware,66.58
+Duke,72.925
+East Carolina,69.2
+Eastern Michigan,67.66
+FIU,67.785
+Florida,73.445
+Florida Atlantic,67.44
+Iowa,72.02
+Iowa State,73.785
+Jacksonville State,67.295
+James Madison,70.19
+Kansas,70.055
+Kansas State,72.18
+Kennesaw State,67.82
+Kent State,62.235
+Kentucky,72.41
+Liberty,70.145
+Louisiana,68.535
+Louisiana–Monroe,68.065
+Louisiana Tech,68.105
+Louisville,72.71
+LSU,73.68
+Marshall,66.635
+Maryland,66.64
+Memphis,70.94
+Miami (FL),74.55
+Miami (OH),67.73
+Michigan,74.315
+Michigan State,69.74
+Middle Tennessee,69.22
+North Carolina,71.66
+Northern Illinois,65.985
+North Texas,69.955
+Northwestern,71.68
+Notre Dame,73.17
+Ohio,69.06
+Ohio State,72.345
+Oklahoma,72.87
+Oklahoma State,68.775
+Old Dominion,68.225
+Ole Miss,71.075
+Oregon,72.75
+Oregon State,70.14
+Penn State,74.96
+Pittsburgh,69.295
+Purdue,67.52
+Rice,67.075
+Rutgers,73.44
+Sam Houston,67.065
+San Diego State,69.06
+San Jose State,69.055
+SMU,72.63
+Texas A&M,73.89
+Texas State,68.235
+Texas Tech,74.085
+Toledo,70.83
+Troy,69.27
+Tulane,69.955
+Tulsa,68.31
+UAB,66.99
+UCF,70.725
+UCLA,70.96
+UConn,70.63
+UNLV,65.96
+USC,70.875
+West Virginia,70.575
+Western Kentucky,69.065
+Western Michigan,66.63
+Wisconsin,70.835
+Wyoming,73.19
+Team 755,69.06

--- a/scripts/compute_roster_scores.py
+++ b/scripts/compute_roster_scores.py
@@ -1,0 +1,146 @@
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+POSITION_GROUPS = {
+    "QB": ["QB"],
+    "LT": ["LT"],
+    "CB1": ["CB"],
+    "EDGE": ["RE", "LE"],
+    "LB1": ["MLB", "ROLB", "LOLB"],
+    "WR1": ["WR"],
+    "RT": ["RT"],
+    "DT1": ["DT"],
+    "CB2": ["CB"],
+    "LG": ["LG"],
+    "DE": ["RE", "LE"],
+    "S1": ["FS", "SS"],
+    "WR2": ["WR"],
+    "C": ["C"],
+    "LB2": ["MLB", "ROLB", "LOLB"],
+    "DT2": ["DT"],
+    "RB": ["HB"],
+    "RG": ["RG"],
+    "WR3": ["WR"],
+    "TE": ["TE"],
+    "CB3": ["CB"],
+    "S2": ["FS", "SS"],
+}
+
+
+
+def load_pos_values(path: Path) -> dict:
+    values = {}
+    with open(path, newline="") as f:
+        reader = csv.reader(f)
+        next(reader, None)
+        for row in reader:
+            if len(row) < 2:
+                continue
+            pos = row[0].strip()
+            if pos.lower() == "total" or not pos:
+                continue
+            val = row[1].strip().strip("%")
+            try:
+                values[pos] = float(val) / 100.0
+            except ValueError:
+                continue
+    return values
+
+
+def take_rating(pos_lists: dict, options: list) -> int:
+    for p in options:
+        lst = pos_lists.get(p)
+        if lst:
+            return lst.pop(0)
+    return 0
+
+
+def compute_team_score(team: dict, values: dict) -> float:
+    pos_lists = {}
+    for player in team.get("players", []):
+        pos = player.get("position")
+        rating = player.get("overall_rating")
+        if pos is None or rating is None:
+            continue
+        pos_lists.setdefault(pos, []).append(rating)
+    for lst in pos_lists.values():
+        lst.sort(reverse=True)
+
+    ratings = {}
+    # iterate in positional order defined above
+    temp_lists = {k: v[:] for k, v in pos_lists.items()}
+    for pos in [
+        "QB",
+        "LT",
+        "CB1",
+        "EDGE",
+        "LB1",
+        "WR1",
+        "RT",
+        "DT1",
+        "CB2",
+        "LG",
+        "DE",
+        "S1",
+        "WR2",
+        "C",
+        "LB2",
+        "DT2",
+        "RB",
+        "RG",
+        "WR3",
+        "TE",
+        "CB3",
+        "S2",
+    ]:
+        opts = POSITION_GROUPS.get(pos, [])
+        ratings[pos] = take_rating(temp_lists, opts)
+
+    score = 0.0
+    for pos, weight in values.items():
+        rating = ratings.get(pos, 0)
+        score += rating * weight
+    return score
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute roster scores from TeamCrafters JSON using positional value weights"
+    )
+    parser.add_argument("json_path", type=Path, help="TeamCrafters JSON file")
+    parser.add_argument(
+        "--values_csv",
+        default="College Football Positional Value.csv",
+        help="CSV with positional values",
+    )
+    parser.add_argument(
+        "--output",
+        default="outputs/team_roster_scores.csv",
+        help="Output CSV path",
+    )
+    args = parser.parse_args()
+
+    values = load_pos_values(Path(args.values_csv))
+    with open(args.json_path) as f:
+        data = json.load(f)
+
+    results = []
+    for team in data.get("teams", []):
+        score = compute_team_score(team, values)
+        results.append([team.get("name"), round(score, 3)])
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["team_name", "roster_score"])
+        writer.writerows(results)
+
+    print(f"Wrote {len(results)} teams to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to compute roster scores from TeamCrafters JSON
- generate roster scores for all teams

## Testing
- `python3 scripts/compute_roster_scores.py data/raw/teamcrafters_cfb26_perfect_final.json --output outputs/teamcrafters_roster_scores.csv`
- `python3 -m py_compile scripts/compute_roster_scores.py`


------
https://chatgpt.com/codex/tasks/task_e_687908b0661c832a9f58916f5307fde1