### PR TITLE
Convert LIV UK strokes to DataGolf model

### DIFF
--- a/outputs/Adjusted Per Round Strokes LIV UK.csv
+++ b/outputs/Adjusted Per Round Strokes LIV UK.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,PROJECTED STROKES,ADJUSTED STROKES,DELTA
+"Ancer, Abraham",70.109,70.062,-0.047
+"Ballester, Jose Luis",71.279,71.279,0.0
+"Bland, Richard",70.607,70.499,-0.108
+"Burmester, Dean",70.01,70.055,0.045
+"Campbell, Ben",71.327,71.181,-0.146
+"Casey, Paul",70.038,69.948,-0.09
+"DeChambeau, Bryson",67.961,68.008,0.047
+"Garcia, Sergio",70.139,70.12,-0.019
+"Gooch, Talor",69.92,69.88,-0.04
+"Grace, Branden",70.676,70.822,0.146
+"Hatton, Tyrrell",68.711,68.681,-0.03
+"Herbert, Lucas",69.814,69.9,0.086
+"Horsfield, Sam",70.61,70.664,0.054
+"Howell III, Charles",70.274,70.396,0.122
+"Jang, Yubin",71.803,71.803,0.0
+"Johnson, Dustin",69.941,69.949,0.008
+"Jones, Matt",71.223,71.224,0.001
+"Kaymer, Martin",71.306,71.36,0.054
+"Kim, Anthony",72.921,72.921,0.0
+"Kjettrup, Frederik",72.735,72.735,0.0
+"Koepka, Brooks",70.121,70.106,-0.015
+"Kokrak, Jason",70.526,70.46,-0.066
+"Kozuma, Jinichiro",70.326,70.324,-0.002
+"Lahiri, Anirban",70.289,70.194,-0.095
+"Lee, Chieh-Po",71.65,71.697,0.047
+"Lee, Danny",72.123,71.989,-0.134
+"Leishman, Marc",70.303,70.297,-0.006
+"McDowell, Graeme",71.25,71.135,-0.115
+"McKibbin, Tom",69.755,69.804,0.049
+"Meronk, Adrian",70.701,70.714,0.013
+"Mickelson, Phil",70.969,70.956,-0.013
+"Munoz, Sebastian",69.628,69.652,0.024
+"Na, Kevin",71.31,71.444,0.134
+"Niemann, Joaquin",68.707,68.714,0.007
+"Ogletree, Andy",71.607,71.553,-0.054
+"Oosthuizen, Louis",70.286,70.221,-0.065
+"Ortiz, Carlos",69.698,69.73,0.032
+"Pereira, Mito",72.104,72.104,0.0
+"Pieters, Thomas",70.123,70.125,0.002
+"Poulter, Ian",71.857,71.81,-0.047
+"Puig, David",69.546,69.555,0.009
+"Rahm, Jon",68.038,68.013,-0.025
+"Reed, Patrick",69.519,69.598,0.079
+"Schwartzel, Charl",70.358,70.309,-0.049
+"Smith, Cameron",69.877,69.903,0.026
+"Steele, Brendan",70.648,70.687,0.039
+"Stenson, Henrik",71.014,71.013,-0.001
+"Surratt, Caleb",70.838,70.953,0.115
+"Tringale, Cameron",70.011,69.98,-0.031
+"Uihlein, Peter",70.581,70.542,-0.039
+"Varner III, Harold",70.013,70.171,0.158
+"Watson, Bubba",70.381,70.43,0.049
+"Westwood, Lee",71.154,70.987,-0.167
+"Wolff, Matthew",71.023,71.023,0.0

--- a/outputs/Adjusted Strokes Gained LIV UK.csv
+++ b/outputs/Adjusted Strokes Gained LIV UK.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,BASELINE STROKES,ADJUSTED STROKES,STROKES GAINED
+"Ancer, Abraham",70.109,70.062,0.268
+"Ballester, Jose Luis",71.279,71.279,-0.949
+"Bland, Richard",70.607,70.499,-0.169
+"Burmester, Dean",70.01,70.055,0.275
+"Campbell, Ben",71.327,71.181,-0.851
+"Casey, Paul",70.038,69.948,0.382
+"DeChambeau, Bryson",67.961,68.008,2.322
+"Garcia, Sergio",70.139,70.12,0.21
+"Gooch, Talor",69.92,69.88,0.45
+"Grace, Branden",70.676,70.822,-0.492
+"Hatton, Tyrrell",68.711,68.681,1.649
+"Herbert, Lucas",69.814,69.9,0.43
+"Horsfield, Sam",70.61,70.664,-0.334
+"Howell III, Charles",70.274,70.396,-0.066
+"Jang, Yubin",71.803,71.803,-1.473
+"Johnson, Dustin",69.941,69.949,0.381
+"Jones, Matt",71.223,71.224,-0.894
+"Kaymer, Martin",71.306,71.36,-1.03
+"Kim, Anthony",72.921,72.921,-2.591
+"Kjettrup, Frederik",72.735,72.735,-2.405
+"Koepka, Brooks",70.121,70.106,0.224
+"Kokrak, Jason",70.526,70.46,-0.13
+"Kozuma, Jinichiro",70.326,70.324,0.006
+"Lahiri, Anirban",70.289,70.194,0.136
+"Lee, Chieh-Po",71.65,71.697,-1.367
+"Lee, Danny",72.123,71.989,-1.659
+"Leishman, Marc",70.303,70.297,0.033
+"McDowell, Graeme",71.25,71.135,-0.805
+"McKibbin, Tom",69.755,69.804,0.526
+"Meronk, Adrian",70.701,70.714,-0.384
+"Mickelson, Phil",70.969,70.956,-0.626
+"Munoz, Sebastian",69.628,69.652,0.678
+"Na, Kevin",71.31,71.444,-1.114
+"Niemann, Joaquin",68.707,68.714,1.616
+"Ogletree, Andy",71.607,71.553,-1.223
+"Oosthuizen, Louis",70.286,70.221,0.109
+"Ortiz, Carlos",69.698,69.73,0.6
+"Pereira, Mito",72.104,72.104,-1.774
+"Pieters, Thomas",70.123,70.125,0.205
+"Poulter, Ian",71.857,71.81,-1.48
+"Puig, David",69.546,69.555,0.775
+"Rahm, Jon",68.038,68.013,2.317
+"Reed, Patrick",69.519,69.598,0.732
+"Schwartzel, Charl",70.358,70.309,0.021
+"Smith, Cameron",69.877,69.903,0.427
+"Steele, Brendan",70.648,70.687,-0.357
+"Stenson, Henrik",71.014,71.013,-0.683
+"Surratt, Caleb",70.838,70.953,-0.623
+"Tringale, Cameron",70.011,69.98,0.35
+"Uihlein, Peter",70.581,70.542,-0.212
+"Varner III, Harold",70.013,70.171,0.159
+"Watson, Bubba",70.381,70.43,-0.1
+"Westwood, Lee",71.154,70.987,-0.657
+"Wolff, Matthew",71.023,71.023,-0.693

--- a/outputs/LIV UK DG Model.csv
+++ b/outputs/LIV UK DG Model.csv
@@ -1,0 +1,55 @@
+player_name,dg_id,dg_pred,my_pred
+bryson dechambeau,19841,2.369,2.322
+jon rahm,19195,2.292,2.317
+joaquin niemann,18079,1.624,1.616
+tyrrell hatton,14796,1.619,1.649
+patrick reed,14838,0.812,0.732
+david puig,28984,0.784,0.775
+sebastian munoz,20770,0.702,0.678
+carlos ortiz,14735,0.633,0.6
+tom mckibbin,22322,0.576,0.526
+lucas herbert,17064,0.517,0.43
+cameron smith,15856,0.453,0.427
+talor gooch,18580,0.41,0.45
+dustin johnson,12422,0.389,0.381
+dean burmester,14424,0.32,0.275
+cameron tringale,14013,0.319,0.35
+harold varner iii,16602,0.317,0.159
+paul casey,7108,0.292,0.382
+abraham ancer,18238,0.221,0.268
+brooks koepka,16243,0.209,0.224
+thomas pieters,13944,0.207,0.205
+sergio garcia,5689,0.191,0.21
+charles howell iii,6892,0.057,-0.066
+louis oosthuizen,7672,0.044,0.109
+anirban lahiri,12669,0.041,0.136
+marc leishman,7649,0.027,0.033
+jinichiro kozuma,14209,0.004,0.006
+charl schwartzel,7398,-0.028,0.021
+bubba watson,7334,-0.051,-0.1
+jason kokrak,12337,-0.196,-0.13
+peter uihlein,11357,-0.25,-0.212
+richard bland,6516,-0.276,-0.169
+sam horsfield,19866,-0.279,-0.334
+brendan steele,11019,-0.318,-0.357
+branden grace,11952,-0.345,-0.492
+adrian meronk,14196,-0.371,-0.384
+caleb surratt,30463,-0.508,-0.623
+phil mickelson,1547,-0.639,-0.626
+henrik stenson,5994,-0.683,-0.683
+matthew wolff,25919,-0.692,-0.693
+lee westwood,4052,-0.824,-0.657
+matt jones,8605,-0.893,-0.894
+graeme mcdowell,7548,-0.92,-0.805
+jose luis ballester,28473,-0.949,-0.949
+martin kaymer,8117,-0.976,-1.03
+kevin na,7452,-0.98,-1.114
+ben campbell,14373,-0.996,-0.851
+andy ogletree,27597,-1.277,-1.223
+chieh-po lee,16563,-1.32,-1.367
+yubin jang,28276,-1.473,-1.473
+ian poulter,1435,-1.527,-1.48
+mito pereira,19455,-1.774,-1.774
+danny lee,11826,-1.793,-1.659
+frederik kjettrup,24660,-2.405,-2.405
+anthony kim,11641,-2.591,-2.591

--- a/outputs/Projected Per Round Strokes LIV UK.csv
+++ b/outputs/Projected Per Round Strokes LIV UK.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,PROJECTED STROKES
+"DeChambeau, Bryson",67.961
+"Rahm, Jon",68.038
+"Niemann, Joaquin",68.707
+"Hatton, Tyrrell",68.711
+"Reed, Patrick",69.519
+"Puig, David",69.546
+"Munoz, Sebastian",69.628
+"Ortiz, Carlos",69.698
+"McKibbin, Tom",69.755
+"Herbert, Lucas",69.814
+"Smith, Cameron",69.877
+"Gooch, Talor",69.92
+"Johnson, Dustin",69.941
+"Burmester, Dean",70.01
+"Tringale, Cameron",70.011
+"Varner III, Harold",70.013
+"Casey, Paul",70.038
+"Ancer, Abraham",70.109
+"Koepka, Brooks",70.121
+"Pieters, Thomas",70.123
+"Garcia, Sergio",70.139
+"Howell III, Charles",70.274
+"Oosthuizen, Louis",70.286
+"Lahiri, Anirban",70.289
+"Leishman, Marc",70.303
+"Kozuma, Jinichiro",70.326
+"Schwartzel, Charl",70.358
+"Watson, Bubba",70.381
+"Kokrak, Jason",70.526
+"Uihlein, Peter",70.581
+"Bland, Richard",70.607
+"Horsfield, Sam",70.61
+"Steele, Brendan",70.648
+"Grace, Branden",70.676
+"Meronk, Adrian",70.701
+"Surratt, Caleb",70.838
+"Mickelson, Phil",70.969
+"Stenson, Henrik",71.014
+"Wolff, Matthew",71.023
+"Westwood, Lee",71.154
+"Jones, Matt",71.223
+"McDowell, Graeme",71.25
+"Ballester, Jose Luis",71.279
+"Kaymer, Martin",71.306
+"Na, Kevin",71.31
+"Campbell, Ben",71.327
+"Ogletree, Andy",71.607
+"Lee, Chieh-Po",71.65
+"Jang, Yubin",71.803
+"Poulter, Ian",71.857
+"Pereira, Mito",72.104
+"Lee, Danny",72.123
+"Kjettrup, Frederik",72.735
+"Kim, Anthony",72.921

--- a/outputs/per_round_strokes_liv_uk.csv
+++ b/outputs/per_round_strokes_liv_uk.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,PROJECTED STROKES
+"DeChambeau, Bryson",67.961
+"Rahm, Jon",68.038
+"Niemann, Joaquin",68.707
+"Hatton, Tyrrell",68.711
+"Reed, Patrick",69.519
+"Puig, David",69.546
+"Munoz, Sebastian",69.628
+"Ortiz, Carlos",69.698
+"McKibbin, Tom",69.755
+"Herbert, Lucas",69.814
+"Smith, Cameron",69.877
+"Gooch, Talor",69.92
+"Johnson, Dustin",69.941
+"Burmester, Dean",70.01
+"Tringale, Cameron",70.011
+"Varner III, Harold",70.013
+"Casey, Paul",70.038
+"Ancer, Abraham",70.109
+"Koepka, Brooks",70.121
+"Pieters, Thomas",70.123
+"Garcia, Sergio",70.139
+"Howell III, Charles",70.274
+"Oosthuizen, Louis",70.286
+"Lahiri, Anirban",70.289
+"Leishman, Marc",70.303
+"Kozuma, Jinichiro",70.326
+"Schwartzel, Charl",70.358
+"Watson, Bubba",70.381
+"Kokrak, Jason",70.526
+"Uihlein, Peter",70.581
+"Bland, Richard",70.607
+"Horsfield, Sam",70.61
+"Steele, Brendan",70.648
+"Grace, Branden",70.676
+"Meronk, Adrian",70.701
+"Surratt, Caleb",70.838
+"Mickelson, Phil",70.969
+"Stenson, Henrik",71.014
+"Wolff, Matthew",71.023
+"Westwood, Lee",71.154
+"Jones, Matt",71.223
+"McDowell, Graeme",71.25
+"Ballester, Jose Luis",71.279
+"Kaymer, Martin",71.306
+"Na, Kevin",71.31
+"Campbell, Ben",71.327
+"Ogletree, Andy",71.607
+"Lee, Chieh-Po",71.65
+"Jang, Yubin",71.803
+"Poulter, Ian",71.857
+"Pereira, Mito",72.104
+"Lee, Danny",72.123
+"Kjettrup, Frederik",72.735
+"Kim, Anthony",72.921

--- a/scripts/adjust_per_round_strokes.py
+++ b/scripts/adjust_per_round_strokes.py
@@ -76,14 +76,24 @@ def main():
     parser = argparse.ArgumentParser(description="Adjust per-round strokes using market matchups")
     parser.add_argument("--strokes", required=True, help="CSV with per-round stroke projections")
     parser.add_argument("--r1", required=True, help="Round 1 matchup odds CSV")
-    parser.add_argument("--t72", required=True, help="72-hole matchup odds CSV")
+    parser.add_argument(
+        "--t72",
+        required=True,
+        help="Multi-round matchup odds CSV (e.g. 72-hole for PGA, 54-hole for LIV)",
+    )
+    parser.add_argument(
+        "--holes",
+        type=int,
+        default=72,
+        help="Number of holes for the tournament matchups (default 72)",
+    )
     parser.add_argument("--output", required=True, help="Output CSV path")
     args = parser.parse_args()
 
     strokes = load_per_round_strokes(args.strokes)
     pairs = []
     pairs.extend(parse_matchups_per_round(args.r1, strokes, holes=18))
-    pairs.extend(parse_matchups_per_round(args.t72, strokes, holes=72))
+    pairs.extend(parse_matchups_per_round(args.t72, strokes, holes=args.holes))
 
     adjusted = adjust_strokes(strokes, pairs)
 


### PR DESCRIPTION
## Summary
- compute market-adjusted strokes gained for the 54-hole LIV UK event
- generate updated DataGolf model values using the template

## Testing
- `python3 scripts/compute_strokes_gained.py outputs/Adjusted\ Per\ Round\ Strokes\ LIV\ UK.csv outputs/Adjusted\ Strokes\ Gained\ LIV\ UK.csv --tournament-info "data/raw/Tournament Information - LIV UK.csv"`
- `python3 scripts/create_dg_model.py outputs/Adjusted\ Strokes\ Gained\ LIV\ UK.csv "data/raw/liv_model_upload_template LIV UK.csv" outputs/LIV\ UK\ DG\ Model.csv`

------
https://chatgpt.com/codex/tasks/task_e_688106f194d4832ab3d4453cba00e168