### PR TITLE
Add per round strokes projection for LIV Chicago

### DIFF
--- a/outputs/Adjusted Per Round Strokes LIV Chicago.csv
+++ b/outputs/Adjusted Per Round Strokes LIV Chicago.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,PROJECTED STROKES,ADJUSTED STROKES,DELTA
+"Ancer, Abraham",70.597,70.608,0.011
+"Ballester, Jose Luis",71.954,71.903,-0.051
+"Bland, Richard",71.187,71.224,0.037
+"Burmester, Dean",70.957,70.973,0.016
+"Campbell, Ben",71.831,71.804,-0.027
+"Casey, Paul",70.666,70.653,-0.013
+"DeChambeau, Bryson",69.113,69.128,0.015
+"Garcia, Sergio",70.712,70.677,-0.035
+"Gooch, Talor",70.338,70.326,-0.012
+"Grace, Branden",71.125,71.183,0.058
+"Hatton, Tyrrell",69.608,69.637,0.029
+"Herbert, Lucas",70.766,70.778,0.012
+"Horsfield, Sam",71.434,71.524,0.09
+"Howell III, Charles",70.888,70.883,-0.005
+"Jang, Yubin",72.479,72.442,-0.037
+"Johnson, Dustin",71.182,71.15,-0.032
+"Jones, Matt",71.997,72.012,0.015
+"Kaymer, Martin",71.726,71.653,-0.073
+"Kim, Anthony",73.648,73.648,0.0
+"Kjettrup, Frederik",73.438,73.438,0.0
+"Koepka, Brooks",71.043,71.016,-0.027
+"Kokrak, Jason",71.278,71.227,-0.051
+"Kozuma, Jinichiro",71.323,71.383,0.06
+"Lahiri, Anirban",70.846,70.882,0.036
+"Lee, Chieh-Po",72.294,72.331,0.037
+"Lee, Danny",72.646,72.646,0.0
+"Leishman, Marc",70.995,70.951,-0.044
+"McDowell, Graeme",71.823,71.827,0.004
+"McKibbin, Tom",70.513,70.514,0.001
+"Meronk, Adrian",71.514,71.48,-0.034
+"Mickelson, Phil",71.727,71.688,-0.039
+"Munoz, Sebastian",70.174,70.243,0.069
+"Na, Kevin",71.82,71.863,0.043
+"Niemann, Joaquin",69.445,69.408,-0.037
+"Ogletree, Andy",72.118,72.05,-0.068
+"Oosthuizen, Louis",70.786,70.778,-0.008
+"Ortiz, Carlos",70.544,70.564,0.02
+"Pereira, Mito",72.877,72.877,0.0
+"Pieters, Thomas",70.859,70.905,0.046
+"Poulter, Ian",72.325,72.257,-0.068
+"Puig, David",70.527,70.48,-0.047
+"Rahm, Jon",69.021,69.014,-0.007
+"Reed, Patrick",70.189,70.173,-0.016
+"Schwartzel, Charl",70.993,70.998,0.005
+"Smith, Cameron",70.727,70.684,-0.043
+"Steele, Brendan",71.219,71.256,0.037
+"Stenson, Henrik",71.407,71.458,0.051
+"Surratt, Caleb",71.468,71.372,-0.096
+"Tringale, Cameron",70.703,70.737,0.034
+"Uihlein, Peter",71.814,71.718,-0.096
+"Varner III, Harold",70.864,70.868,0.004
+"Watson, Bubba",70.782,70.82,0.038
+"Westwood, Lee",71.851,71.857,0.006
+"Wolff, Matthew",72.044,72.059,0.015

--- a/outputs/LIV Chicago DG Model.csv
+++ b/outputs/LIV Chicago DG Model.csv
@@ -1,0 +1,55 @@
+player_name,dg_id,dg_pred,my_pred
+jon rahm,19195,1.989,2.212
+bryson dechambeau,19841,1.897,2.098
+joaquin niemann,18079,1.565,1.818
+tyrrell hatton,14796,1.402,1.589
+sebastian munoz,20770,0.836,0.983
+patrick reed,14838,0.821,1.053
+talor gooch,18580,0.672,0.9
+tom mckibbin,22322,0.497,0.712
+david puig,28984,0.483,0.746
+carlos ortiz,14735,0.466,0.662
+abraham ancer,18238,0.413,0.618
+paul casey,7108,0.344,0.573
+cameron tringale,14013,0.307,0.489
+sergio garcia,5689,0.298,0.549
+cameron smith,15856,0.283,0.542
+lucas herbert,17064,0.244,0.448
+bubba watson,7334,0.228,0.406
+louis oosthuizen,7672,0.224,0.448
+anirban lahiri,12669,0.164,0.344
+thomas pieters,13944,0.151,0.321
+harold varner iii,16602,0.146,0.358
+charles howell iii,6892,0.122,0.343
+dean burmester,14424,0.053,0.253
+charl schwartzel,7398,0.017,0.228
+marc leishman,7649,0.015,0.275
+brooks koepka,16243,-0.033,0.21
+branden grace,11952,-0.115,0.043
+dustin johnson,12422,-0.172,0.076
+richard bland,6516,-0.177,0.002
+brendan steele,11019,-0.209,-0.03
+jason kokrak,12337,-0.268,-0.001
+jinichiro kozuma,14209,-0.313,-0.157
+henrik stenson,5994,-0.397,-0.232
+sam horsfield,19866,-0.424,-0.298
+caleb surratt,30463,-0.458,-0.146
+adrian meronk,14196,-0.504,-0.254
+martin kaymer,8117,-0.716,-0.427
+phil mickelson,1547,-0.717,-0.462
+peter uihlein,11357,-0.804,-0.492
+kevin na,7452,-0.81,-0.637
+graeme mcdowell,7548,-0.813,-0.601
+ben campbell,14373,-0.821,-0.578
+lee westwood,4052,-0.841,-0.631
+jose luis ballester,28473,-0.944,-0.677
+matt jones,8605,-0.987,-0.786
+matthew wolff,25919,-1.034,-0.833
+andy ogletree,27597,-1.108,-0.824
+chieh-po lee,16563,-1.284,-1.105
+ian poulter,1435,-1.315,-1.031
+yubin jang,28276,-1.469,-1.216
+danny lee,11826,-1.636,-1.42
+mito pereira,19455,-1.867,-1.651
+frederik kjettrup,24660,-2.428,-2.212
+anthony kim,11641,-2.638,-2.422

--- a/outputs/Projected Per Round Strokes LIV Chicago.csv
+++ b/outputs/Projected Per Round Strokes LIV Chicago.csv
@@ -1,0 +1,55 @@
+PLAYER NAME,PROJECTED STROKES
+"Rahm, Jon",69.021
+"DeChambeau, Bryson",69.113
+"Niemann, Joaquin",69.445
+"Hatton, Tyrrell",69.608
+"Munoz, Sebastian",70.174
+"Reed, Patrick",70.189
+"Gooch, Talor",70.338
+"McKibbin, Tom",70.513
+"Puig, David",70.527
+"Ortiz, Carlos",70.544
+"Ancer, Abraham",70.597
+"Casey, Paul",70.666
+"Tringale, Cameron",70.703
+"Garcia, Sergio",70.712
+"Smith, Cameron",70.727
+"Herbert, Lucas",70.766
+"Watson, Bubba",70.782
+"Oosthuizen, Louis",70.786
+"Lahiri, Anirban",70.846
+"Pieters, Thomas",70.859
+"Varner III, Harold",70.864
+"Howell III, Charles",70.888
+"Burmester, Dean",70.957
+"Schwartzel, Charl",70.993
+"Leishman, Marc",70.995
+"Koepka, Brooks",71.043
+"Grace, Branden",71.125
+"Johnson, Dustin",71.182
+"Bland, Richard",71.187
+"Steele, Brendan",71.219
+"Kokrak, Jason",71.278
+"Kozuma, Jinichiro",71.323
+"Stenson, Henrik",71.407
+"Horsfield, Sam",71.434
+"Surratt, Caleb",71.468
+"Meronk, Adrian",71.514
+"Kaymer, Martin",71.726
+"Mickelson, Phil",71.727
+"Uihlein, Peter",71.814
+"Na, Kevin",71.82
+"McDowell, Graeme",71.823
+"Campbell, Ben",71.831
+"Westwood, Lee",71.851
+"Ballester, Jose Luis",71.954
+"Jones, Matt",71.997
+"Wolff, Matthew",72.044
+"Ogletree, Andy",72.118
+"Lee, Chieh-Po",72.294
+"Poulter, Ian",72.325
+"Jang, Yubin",72.479
+"Lee, Danny",72.646
+"Pereira, Mito",72.877
+"Kjettrup, Frederik",73.438
+"Kim, Anthony",73.648


### PR DESCRIPTION
## Summary
- generate per-round stroke projections for the LIV Chicago tournament using DataGolf decomposition data and tournament info.
- adjust per-round strokes using BetOnline, BetCris, and Pinnacle matchup odds for Round 1 and tournament to align projections with sharp sportsbooks.
- populate the LIV model upload template with my per-round stroke predictions.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689544485ebc832a94809ecaa902101d